### PR TITLE
Fixed issue for OS X 10.15 Catalina (may close #25)

### DIFF
--- a/alt-tab-macos/logic/WindowManager.swift
+++ b/alt-tab-macos/logic/WindowManager.swift
@@ -59,7 +59,15 @@ func cgWindows() -> [NSDictionary] {
     let windows = CGWindowListCopyWindowInfo([.excludeDesktopElements, .optionOnScreenOnly], kCGNullWindowID) as! [NSDictionary]
     return windows.filter {
         let isWindowNotMenubarOrOthers = $0[kCGWindowLayer] as? Int == 0
-        let hasTitle = !(($0[kCGWindowName] as? String ?? "").isEmpty)
+        
+        
+        var hasTitle = false
+        if #available(macOS 10.15, *) {
+            hasTitle = !(($0[kCGWindowOwnerName] as? String ?? "").isEmpty)
+        } else {
+            hasTitle = !(($0[kCGWindowName] as? String ?? "").isEmpty)
+        }
+        
         return isWindowNotMenubarOrOthers && hasTitle
     }
 }


### PR DESCRIPTION
Problem was that for Catalina, the app needed the Screen Recording permissions to get `windowName` so added a check at the beginning.

Not much of a Swift guy, so feel free to refactor my mess.

Cool idea that I've been waiting for a long time for my Mac, so wanted to contribute :)