### PR TITLE
feat: multiple meta keys

### DIFF
--- a/alt-tab-macos/logic/Keyboard.swift
+++ b/alt-tab-macos/logic/Keyboard.swift
@@ -1,17 +1,5 @@
 import Cocoa
-
-// Apple doesn't provide an enum for this, strangely
-enum KeyCode: UInt16 {
-    case tab = 48
-    case escape = 53
-    case command = 55
-    case capsLock = 57
-    case option = 58
-    case control = 59
-    case function = 63
-    case leftArrow = 123
-    case rightArrow = 124
-}
+import Carbon.HIToolbox
 
 class Keyboard {
     static func listenToGlobalEvents(_ delegate: Application) {
@@ -43,12 +31,11 @@ func keyboardHandler(_ cgEvent: CGEvent, _ delegate: Application) -> Unmanaged<C
     if cgEvent.type == .keyDown || cgEvent.type == .keyUp || cgEvent.type == .flagsChanged {
         if let event = NSEvent(cgEvent: cgEvent) {
             let keyDown = event.type == .keyDown
-            let keycode = KeyCode(rawValue: event.keyCode)
             let isTab = event.keyCode == Preferences.tabKeyCode
-            let isMeta = keycode == Preferences.metaKeyCode
-            let isRightArrow = keycode == KeyCode.rightArrow
-            let isLeftArrow = keycode == KeyCode.leftArrow
-            let isEscape = keycode == KeyCode.escape
+            let isMeta = event.keyCode == Preferences.metaKeyCode
+            let isRightArrow = event.keyCode == kVK_RightArrow
+            let isLeftArrow = event.keyCode == kVK_LeftArrow
+            let isEscape = event.keyCode == kVK_Escape
             if event.modifierFlags.contains(Preferences.metaModifierFlag!) {
                 if keyDown {
                     if isTab && event.modifierFlags.contains(.shift) {

--- a/alt-tab-macos/logic/Keyboard.swift
+++ b/alt-tab-macos/logic/Keyboard.swift
@@ -32,7 +32,7 @@ func keyboardHandler(_ cgEvent: CGEvent, _ delegate: Application) -> Unmanaged<C
         if let event = NSEvent(cgEvent: cgEvent) {
             let keyDown = event.type == .keyDown
             let isTab = event.keyCode == Preferences.tabKeyCode
-            let isMeta = event.keyCode == Preferences.metaKeyCode
+            let isMeta = Preferences.metaKeyCodes.contains(event.keyCode)
             let isRightArrow = event.keyCode == kVK_RightArrow
             let isLeftArrow = event.keyCode == kVK_LeftArrow
             let isEscape = event.keyCode == kVK_Escape

--- a/alt-tab-macos/logic/Preferences.swift
+++ b/alt-tab-macos/logic/Preferences.swift
@@ -32,7 +32,7 @@ class Preferences {
     static var tabKeyCode: UInt16?
     static var highlightBorderColor: NSColor?
     static var highlightBackgroundColor: NSColor?
-    static var metaKeyCode: UInt16?
+    static var metaKeyCodes: [UInt16] = []
     static var metaModifierFlag: NSEvent.ModifierFlags?
     static var windowDisplayDelay: DispatchTimeInterval?
     static var windowCornerRadius: CGFloat?
@@ -41,12 +41,12 @@ class Preferences {
         MacroPreference(" macOS", (0, 5, 20, .clear, NSColor(red: 0, green: 0, blue: 0, alpha: 0.3))),
         MacroPreference("❖ Windows 10", (2, 0, 0, .white, .clear))
     ])
-    static var metaKeyMacro = MacroPreferenceHelper<(Int, NSEvent.ModifierFlags)>([
-        MacroPreference("⌥ option", (kVK_Option, .option)),
-        MacroPreference("⌃ control", (kVK_Control, .control)),
-        MacroPreference("⌘ command", (kVK_Command, .command)),
-        MacroPreference("⇪ caps lock", (kVK_CapsLock, .capsLock)),
-        MacroPreference("fn", (kVK_Function, .function))
+    static var metaKeyMacro = MacroPreferenceHelper<([Int], NSEvent.ModifierFlags)>([
+        MacroPreference("⌥ option", ([kVK_Option, kVK_RightOption], .option)),
+        MacroPreference("⌃ control", ([kVK_Control, kVK_RightControl], .control)),
+        MacroPreference("⌘ command", ([kVK_Command, kVK_RightCommand], .command)),
+        MacroPreference("⇪ caps lock", ([kVK_CapsLock], .capsLock)),
+        MacroPreference("fn", ([kVK_Function], .function))
     ])
 
     private static let defaultsFile = fileFromPreferencesFolder("alt-tab-macos-defaults.json")
@@ -80,7 +80,7 @@ class Preferences {
             tabKeyCode = try UInt16(value).orThrow()
         case "metaKey":
             let p = try metaKeyMacro.labelToMacro[value].orThrow()
-            metaKeyCode = UInt16(p.preferences.0)
+            metaKeyCodes = p.preferences.0.map { UInt16($0) }
             metaModifierFlag = p.preferences.1
         case "theme":
             let p = try themeMacro.labelToMacro[value].orThrow()

--- a/alt-tab-macos/logic/Preferences.swift
+++ b/alt-tab-macos/logic/Preferences.swift
@@ -101,11 +101,11 @@ class Preferences {
     }
 
     private static func preferencesVersion(_ url: URL) throws -> Int {
-        try Int(loadFromDisk(url)["version"] ?? "0").orThrow()
+        return try Int(loadFromDisk(url)["version"] ?? "0").orThrow()
     }
 
     private static func loadFromDisk(_ url: URL) throws -> [String: String] {
-        try JSONDecoder().decode([String: String].self, from: Data(contentsOf: url))
+        return try JSONDecoder().decode([String: String].self, from: Data(contentsOf: url))
     }
 
     private static func handleNoFileOrOldFile(_ userFile: URL) throws {
@@ -134,7 +134,7 @@ class Preferences {
     }
 
     private static func fileFromPreferencesFolder(_ fileName: String) -> URL {
-        FileManager.default
+        return FileManager.default
                 .urls(for: .libraryDirectory, in: .userDomainMask)
                 .first!
                 .appendingPathComponent("Preferences", isDirectory: true)

--- a/alt-tab-macos/logic/Preferences.swift
+++ b/alt-tab-macos/logic/Preferences.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Cocoa
+import Carbon.HIToolbox
 
 class Preferences {
     static var defaults: [String: String] = [
@@ -8,7 +9,7 @@ class Preferences {
         "maxThumbnailsPerRow": "4",
         "iconSize": "32",
         "fontHeight": "15",
-        "tabKeyCode": String(KeyCode.tab.rawValue),
+        "tabKeyCode": String(kVK_Tab),
         "metaKey": metaKeyMacro.macros[0].label,
         "windowDisplayDelay": "0",
         "theme": themeMacro.macros[0].label
@@ -31,7 +32,7 @@ class Preferences {
     static var tabKeyCode: UInt16?
     static var highlightBorderColor: NSColor?
     static var highlightBackgroundColor: NSColor?
-    static var metaKeyCode: KeyCode?
+    static var metaKeyCode: UInt16?
     static var metaModifierFlag: NSEvent.ModifierFlags?
     static var windowDisplayDelay: DispatchTimeInterval?
     static var windowCornerRadius: CGFloat?
@@ -40,12 +41,12 @@ class Preferences {
         MacroPreference(" macOS", (0, 5, 20, .clear, NSColor(red: 0, green: 0, blue: 0, alpha: 0.3))),
         MacroPreference("❖ Windows 10", (2, 0, 0, .white, .clear))
     ])
-    static var metaKeyMacro = MacroPreferenceHelper<(KeyCode, NSEvent.ModifierFlags)>([
-        MacroPreference("⌥ option", (.option, .option)),
-        MacroPreference("⌃ control", (.control, .control)),
-        MacroPreference("⌘ command", (.command, .command)),
-        MacroPreference("⇪ caps lock", (.capsLock, .capsLock)),
-        MacroPreference("fn", (.function, .function))
+    static var metaKeyMacro = MacroPreferenceHelper<(Int, NSEvent.ModifierFlags)>([
+        MacroPreference("⌥ option", (kVK_Option, .option)),
+        MacroPreference("⌃ control", (kVK_Control, .control)),
+        MacroPreference("⌘ command", (kVK_Command, .command)),
+        MacroPreference("⇪ caps lock", (kVK_CapsLock, .capsLock)),
+        MacroPreference("fn", (kVK_Function, .function))
     ])
 
     private static let defaultsFile = fileFromPreferencesFolder("alt-tab-macos-defaults.json")
@@ -79,7 +80,7 @@ class Preferences {
             tabKeyCode = try UInt16(value).orThrow()
         case "metaKey":
             let p = try metaKeyMacro.labelToMacro[value].orThrow()
-            metaKeyCode = p.preferences.0
+            metaKeyCode = UInt16(p.preferences.0)
             metaModifierFlag = p.preferences.1
         case "theme":
             let p = try themeMacro.labelToMacro[value].orThrow()

--- a/alt-tab-macos/logic/WindowManager.swift
+++ b/alt-tab-macos/logic/WindowManager.swift
@@ -17,7 +17,7 @@ class OpenWindow {
     }
 
     func computeIcon() -> NSImage? {
-        NSRunningApplication(processIdentifier: ownerPid!)?.icon
+        return NSRunningApplication(processIdentifier: ownerPid!)?.icon
     }
 
     func computeThumbnail() -> NSImage {

--- a/alt-tab-macos/ui/Application.swift
+++ b/alt-tab-macos/ui/Application.swift
@@ -91,7 +91,7 @@ class Application: NSApplication, NSApplicationDelegate, NSWindowDelegate {
     }
 
     func cellWithStep(_ step: Int) -> Int {
-        selectedOpenWindow + step < 0 ? openWindows.count - 1 : (selectedOpenWindow + step) % openWindows.count
+        return selectedOpenWindow + step < 0 ? openWindows.count - 1 : (selectedOpenWindow + step) % openWindows.count
     }
 
     func cycleSelection(_ step: Int) {
@@ -130,6 +130,6 @@ class Application: NSApplication, NSApplicationDelegate, NSWindowDelegate {
     }
 
     func currentlySelectedWindow() -> OpenWindow? {
-        openWindows.count > selectedOpenWindow ? openWindows[selectedOpenWindow] : nil
+        return openWindows.count > selectedOpenWindow ? openWindows[selectedOpenWindow] : nil
     }
 }

--- a/alt-tab-macos/ui/PreferencesPanel.swift
+++ b/alt-tab-macos/ui/PreferencesPanel.swift
@@ -28,7 +28,7 @@ class PreferencesPanel: NSPanel, NSTextViewDelegate {
         return [
             makeLabelWithDropdown(\PreferencesPanel.theme, "Main window theme", "theme", Preferences.themeMacro.labels),
             makeLabelWithDropdown(\PreferencesPanel.metaKey, "Meta key to activate the app", "metaKey", Preferences.metaKeyMacro.labels),
-            makeLabelWithInput(\PreferencesPanel.tabKeyCode, "Tab key (NSEvent.keyCode)", "tabKeyCode"),
+            makeLabelWithInput(\PreferencesPanel.tabKeyCode, "Tab key (HIToolbox.Events)", "tabKeyCode"),
             makeLabelWithInput(\PreferencesPanel.maxScreenUsage, "Max window size (screen %)", "maxScreenUsage"),
             makeLabelWithInput(\PreferencesPanel.maxThumbnailsPerRow, "Max thumbnails per row", "maxThumbnailsPerRow"),
             makeLabelWithInput(\PreferencesPanel.iconSize, "Apps icon size (px)", "iconSize"),

--- a/alt-tab-macos/ui/PreferencesPanel.swift
+++ b/alt-tab-macos/ui/PreferencesPanel.swift
@@ -25,7 +25,7 @@ class PreferencesPanel: NSPanel, NSTextViewDelegate {
     }
 
     private func makeLabelsAndInputs() -> [[NSView]] {
-        [
+        return [
             makeLabelWithDropdown(\PreferencesPanel.theme, "Main window theme", "theme", Preferences.themeMacro.labels),
             makeLabelWithDropdown(\PreferencesPanel.metaKey, "Meta key to activate the app", "metaKey", Preferences.metaKeyMacro.labels),
             makeLabelWithInput(\PreferencesPanel.tabKeyCode, "Tab key (NSEvent.keyCode)", "tabKeyCode"),

--- a/alt-tab-macos/ui/ThumbnailsPanel.swift
+++ b/alt-tab-macos/ui/ThumbnailsPanel.swift
@@ -58,7 +58,7 @@ class ThumbnailsPanel: NSPanel, NSCollectionViewDataSource, NSCollectionViewDele
 
     func collectionView(_ collectionView: NSCollectionView, numberOfItemsInSection section: Int) -> Int {
 //        debugPrint("collectionView: count items", openWindows.count)
-        application!.openWindows.count
+        return application!.openWindows.count
     }
 
     func collectionView(_ collectionView: NSCollectionView, itemForRepresentedObjectAt indexPath: IndexPath) -> NSCollectionViewItem {


### PR DESCRIPTION
Hi Louis!

Ive made an little change and am interested in your opinion and if you accept the pull request or improve upon.

`metaKeyCodes` is now an array and is provided with both keycodes for `option`, `control` and `command`. 

This fixes two issues:
- UI stayed open when the user did open it with the secondary `metaKey` keyCode (the UI got toggled by the `modifierFlags` check) and the user had to click the proper `metaKeyCode` to close it again
- PC keyboards (all of them? i observed this on a Logitech K740) send the secondary keyCode for the command and option keys so the application did not work for this setup

```
MacBook Pro 2015 modifier keycodes
left / right
 
Command: 55 / 54
Option: 58 / 61
Control: 59
Function: 63
```

```
PC Keyboard (Logitech K740) on macOS
left / right

Command: 54 / 55
Option: 61
Control: 59 / 62
Function: no keycode event
```

Ive tested the application on macOS High Sierra (mentioned pc keyboard) and macOS Catalina (MacBook Pro keyboard).

The pc keyboard I use has an issue with the option metakey event handling but this not related to this commit.

Cheers