### PR TITLE
fix: kVK_RightOption issue

### DIFF
--- a/alt-tab-macos/logic/Keyboard.swift
+++ b/alt-tab-macos/logic/Keyboard.swift
@@ -38,7 +38,10 @@ func keyboardHandler(_ cgEvent: CGEvent, _ delegate: Application) -> Unmanaged<C
             let isRightArrow = event.keyCode == kVK_RightArrow
             let isLeftArrow = event.keyCode == kVK_LeftArrow
             let isEscape = event.keyCode == kVK_Escape
-            if event.modifierFlags.contains(Preferences.metaModifierFlag!) {
+            if isMeta {
+                delegate.toggleMetaKey()
+            }
+            if delegate.isMetaKeyPressed {
                 if keyDown {
                     if isTab && event.modifierFlags.contains(.shift) {
                         delegate.showUiOrSelectPrevious()

--- a/alt-tab-macos/logic/Preferences.swift
+++ b/alt-tab-macos/logic/Preferences.swift
@@ -33,7 +33,6 @@ class Preferences {
     static var highlightBorderColor: NSColor?
     static var highlightBackgroundColor: NSColor?
     static var metaKeyCodes: [UInt16]?
-    static var metaModifierFlag: NSEvent.ModifierFlags?
     static var windowDisplayDelay: DispatchTimeInterval?
     static var windowCornerRadius: CGFloat?
     static var font: NSFont?
@@ -41,10 +40,10 @@ class Preferences {
         MacroPreference(" macOS", (0, 5, 20, .clear, NSColor(red: 0, green: 0, blue: 0, alpha: 0.3))),
         MacroPreference("❖ Windows 10", (2, 0, 0, .white, .clear))
     ])
-    static var metaKeyMacro = MacroPreferenceHelper<([Int], NSEvent.ModifierFlags)>([
-        MacroPreference("⌥ option", ([kVK_Option, kVK_RightOption], .option)),
-        MacroPreference("⌃ control", ([kVK_Control, kVK_RightControl], .control)),
-        MacroPreference("⌘ command", ([kVK_Command, kVK_RightCommand], .command))
+    static var metaKeyMacro = MacroPreferenceHelper<([Int])>([
+        MacroPreference("⌥ option", ([kVK_Option, kVK_RightOption])),
+        MacroPreference("⌃ control", ([kVK_Control, kVK_RightControl])),
+        MacroPreference("⌘ command", ([kVK_Command, kVK_RightCommand]))
     ])
 
     private static let defaultsFile = fileFromPreferencesFolder("alt-tab-macos-defaults.json")
@@ -78,8 +77,7 @@ class Preferences {
             tabKeyCode = try UInt16(value).orThrow()
         case "metaKey":
             let p = try metaKeyMacro.labelToMacro[value].orThrow()
-            metaKeyCodes = p.preferences.0.map { UInt16($0) }
-            metaModifierFlag = p.preferences.1
+            metaKeyCodes = p.preferences.map { UInt16($0) }
         case "theme":
             let p = try themeMacro.labelToMacro[value].orThrow()
             cellBorderWidth = p.preferences.0

--- a/alt-tab-macos/ui/Application.swift
+++ b/alt-tab-macos/ui/Application.swift
@@ -13,6 +13,7 @@ class Application: NSApplication, NSApplicationDelegate, NSWindowDelegate {
     var workItems: [DispatchWorkItem] = []
     var isFirstSummon: Bool = true
     var appIsBeingUsed: Bool = false
+    var isMetaKeyPressed: Bool = false
 
     override init() {
         super.init()
@@ -33,6 +34,11 @@ class Application: NSApplication, NSApplicationDelegate, NSWindowDelegate {
         preferencesPanel = PreferencesPanel()
         Keyboard.listenToGlobalEvents(self)
         Screen.listenToChanges()
+    }
+
+    func toggleMetaKey() {
+        debugPrint("toggleMetaKey")
+        isMetaKeyPressed = !isMetaKeyPressed
     }
 
     func showUiOrSelectNext() {


### PR DESCRIPTION
by implementing the trigger without usage of modifierFlags.

We observed both, that triggering the application with kVK_RightOption is not possible (native alt tab comes up instead on my system) on some? keyboards. Ive looked into it yesterday when trying out all possible combinations. Ive looked into it since kVK_RightOption is actually located physically left on my pc keyboard (Logitech K740).

This is what happens if we trigger the main feature with kVK_RightCommand (54) + kVK_Tab (48) on a pc keyboard (Logitech K740):

```
"pressed" 54
"isMeta"
"metaModifierFlag"
"-------"
"pressed" 48
"metaModifierFlag"
"keyDown"
"isTab"
"showUiOrSelectNext"
"showUiOrCycleSelection"
"pressed" 48
"metaModifierFlag"
"-------"
"pressed" 54
"isMeta"
"else isMeta and not keyDown"
"focusTarget"
"hideUi"
"-------"
```

This is what happens if we trigger the main feature with kVK_RightOption (61) + kVK_Tab (48) the same keyboard: 

```
"pressed" 61
"isMeta"
"metaModifierFlag"
"-------"
"pressed" 48
"no metaModifierFlag" <<<<<<<<<<<<<<
"-------"
"pressed" 48
"no metaModifierFlag" <<<<<<<<<<<<<<
"-------"
"pressed" 55
"metaModifierFlag"
"keyDown"
"-------"
"pressed" 55
"metaModifierFlag"
"-------"
"pressed" 61
"isMeta"
"else isMeta and not keyDown"
"focusTarget"
"-------"
"pressed" 0
"no metaModifierFlag"
"-------"
```

Tab (48) gets pressed without the proper NSEvent.ModifierFlags `.option` being present. The Tab event will contain `.command` flag instead 💩 

What happens is fascinating, I wonder if macOS adds all the additional keycodes or if it the hardware (keyboard) itself does that (command key 55 and keycode 0 get added). The 0 keycode gets also added on a macBook keyboard if I switch the cmd and option keys via the macOS native "Modifier Keys..." menu. But it does not add the command keycode when pressing option. 

Iam using the "Modifier Keys" menu for my PC keyboard so that the physical windows key is option and ALT is command to mimic the macOS keyboard layout.

Ive tried to come up with different solutions and ended up with not honouring the NSEvent.ModifierFlags at all.

Before commit: `if event.modifierFlags.contains(Preferences.metaModifierFlag!) {`
After commit: `if delegate.isMetaKeyPressed {`

The application watches and stores (Bool toggle), if the metaKey (whatever the user has choosen) is being pressed. The NSEvent.ModifierFlags are removed from the Preferences.

Do you want to support this combination? Do you see any issues with that implementation? What do you think?

I know, this ignores the given flags (but cgEvent.type == .flagsChanged is still required) to solve one currently known problematic meta key combination so I fully understand if you reject this change.

Tested on MacBook Pro 2015 keyboard and PC keyboard (Logitech K740).