### PR TITLE
perf: improves performance of ThumbnailPanel significantly

### DIFF
--- a/alt-tab-macos/ui/Application.swift
+++ b/alt-tab-macos/ui/Application.swift
@@ -98,6 +98,7 @@ class Application: NSApplication, NSApplicationDelegate, NSWindowDelegate {
     }
 
     func showUiOrCycleSelection(_ step: Int) {
+        NSLog("Application.showUiOrCycleSelection")
         appIsBeingUsed = true
         if isFirstSummon {
             isFirstSummon = false

--- a/alt-tab-macos/ui/Cell.swift
+++ b/alt-tab-macos/ui/Cell.swift
@@ -75,6 +75,8 @@ class Cell: NSCollectionViewItem {
     private func makeVStackView(_ hStackView: NSStackView) -> NSStackView {
         let vStackView = NSStackView()
         vStackView.wantsLayer = true
+        vStackView.canDrawSubviewsIntoLayer = true
+        vStackView.layer!.drawsAsynchronously = true
         vStackView.layer!.backgroundColor = .clear
         vStackView.layer!.cornerRadius = Preferences.cellCornerRadius!
         vStackView.layer!.borderWidth = Preferences.cellBorderWidth!

--- a/alt-tab-macos/ui/ThumbnailsPanel.swift
+++ b/alt-tab-macos/ui/ThumbnailsPanel.swift
@@ -103,4 +103,10 @@ class ThumbnailsPanel: NSPanel, NSCollectionViewDataSource, NSCollectionViewDele
         backgroundView!.setFrameSize(frame.size)
         collectionView_!.setFrameOrigin(NSPoint(x: Preferences.windowPadding, y: Preferences.windowPadding))
     }
+
+    // just for timestamp logging in combination with Application.showUiOrCycleSelection
+    override func orderOut(_ sender: Any?) {
+        NSLog("ThumbnailsPanel.orderOut")
+        super.orderOut(sender)
+    }
 }


### PR DESCRIPTION
One performance issue we had is related how layers are handled. This commit allows subviews of Cell to be drawn into its layer and the layer be drawn asynchronously. In my test use-case with 16 windows with 3440x1417 sizing this brought the required time from key event reaction to ThumbnailPanel orderOut from 650ms down to 250ms. There is eventually more performance to gain by explicit control of .layerContentsRedrawPolicy. This commit also adds two NSLog statements for easy timing observations in the Run console.

Related to #45 (closes?)