### PR TITLE
WIP: Add quick-actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ From macOS 10.12 to 10.15
 
 * You hover and click with the `🖱️ mouse`.
 * You cycle with `⇦ left arrow` and `⇨ right arrow`.
+* You can close a window with `w` or quit the whole application with `q`
 * You can cancel with `⎋ escape`.
 
 ## Configuration

--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		05F4FB3C23BA5A890001427A /* Observer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F4FB3B23BA5A890001427A /* Observer.swift */; };
 		4807A6C623A9CD190052A53E /* SkyLight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4807A6C523A9CD190052A53E /* SkyLight.framework */; };
 		D04BA02DD4152997C32CF50B /* StatusItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA0AF7C5DCF367FBB663C /* StatusItem.swift */; };
 		D04BA0496ACF1427B6E9D369 /* CGWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA78E3B4E73B40DB77174 /* CGWindow.swift */; };
@@ -35,6 +36,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		05F4FB3B23BA5A890001427A /* Observer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Observer.swift; sourceTree = "<group>"; };
 		4807A6C523A9CD190052A53E /* SkyLight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SkyLight.framework; path = ../../../../System/Library/PrivateFrameworks/SkyLight.framework; sourceTree = "<group>"; };
 		D04BA02F476DE30C4647886C /* PreferencesPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PreferencesPanel.swift; sourceTree = "<group>"; };
 		D04BA0AF7C5DCF367FBB663C /* StatusItem.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StatusItem.swift; sourceTree = "<group>"; };
@@ -225,6 +227,7 @@
 				D04BA2D2AD6B1CCA3F3A4DD7 /* SystemPermissions.swift */,
 				D04BA5EB5ED248C8C22CC672 /* Spaces.swift */,
 				D04BAE80772D25834E440975 /* TrackedWindow.swift */,
+				05F4FB3B23BA5A890001427A /* Observer.swift */,
 			);
 			path = logic;
 			sourceTree = "<group>";
@@ -348,6 +351,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D04BA960DDD1D32A3019C835 /* CollectionViewCenterFlowLayout.swift in Sources */,
+				05F4FB3C23BA5A890001427A /* Observer.swift in Sources */,
 				D04BAEF78503D7A2CEFB9E9E /* main.swift in Sources */,
 				D04BA20D4A240843293B3B52 /* Cell.swift in Sources */,
 				D04BA57A871B7269BEBAFF84 /* Keyboard.swift in Sources */,

--- a/alt-tab-macos/api-wrappers/AXUIElement.swift
+++ b/alt-tab-macos/api-wrappers/AXUIElement.swift
@@ -7,7 +7,9 @@ import Foundation
 enum AXAttributeKey: String {
     case windows = "AXWindows"
     case minimized = "AXMinimized"
+    case fullScreen = "AXFullScreen"
     case focusedWindow = "AXFocusedWindow"
+    case closeButton = "AXCloseButton"
     case subrole = "AXSubrole"
 }
 
@@ -53,6 +55,10 @@ extension AXUIElement {
         return attribute(.minimized, Bool.self) == true
     }
 
+    func isFullScreen() -> Bool {
+        return attribute(.fullScreen, Bool.self) == true
+    }
+
     func focus(_ id: CGWindowID) {
         var elementConnection = UInt32(0)
         CGSGetWindowOwner(cgsMainConnectionId, id, &elementConnection)
@@ -85,5 +91,15 @@ extension AXUIElement {
 
         SLPSPostEventRecordTo(&psn_, &(UnsafeMutablePointer(mutating: UnsafePointer<UInt8>(bytes1)).pointee))
         SLPSPostEventRecordTo(&psn_, &(UnsafeMutablePointer(mutating: UnsafePointer<UInt8>(bytes2)).pointee))
+    }
+
+    func close() {
+        if isFullScreen() {
+            AXUIElementSetAttributeValue(self, AXAttributeKey.fullScreen.rawValue as CFString, 0 as CFTypeRef)
+            return
+        }
+        if let closeButtonRef = attribute(.closeButton, AXUIElement.self) {
+            AXUIElementPerformAction(closeButtonRef, kAXPressAction as CFString)
+        }
     }
 }

--- a/alt-tab-macos/logic/Keyboard.swift
+++ b/alt-tab-macos/logic/Keyboard.swift
@@ -47,6 +47,8 @@ func keyboardHandler(proxy: CGEventTapProxy, type: CGEventType, event_: CGEvent,
             let isMetaDown = event.modifierFlags.contains(Preferences.metaModifierFlag!)
             let isRightArrow = event.keyCode == kVK_RightArrow
             let isLeftArrow = event.keyCode == kVK_LeftArrow
+            let isQ = event.keyCode == kVK_ANSI_Q
+            let isW = event.keyCode == kVK_ANSI_W
             let isEscape = event.keyCode == kVK_Escape
             if isMetaDown && type == .keyDown {
                 if isTab && event.modifierFlags.contains(.shift) {
@@ -57,6 +59,10 @@ func keyboardHandler(proxy: CGEventTapProxy, type: CGEventType, event_: CGEvent,
                     return dispatchWork(application, true, { application.cycleSelection(1) })
                 } else if isLeftArrow && application.appIsBeingUsed {
                     return dispatchWork(application, true, { application.cycleSelection(-1) })
+                } else if isQ && application.appIsBeingUsed {
+                    return dispatchWork(application, true, { application.quitTargetApp() })
+                } else if isW && application.appIsBeingUsed {
+                    return dispatchWork(application, true, { application.closeTarget() })
                 } else if type == .keyDown && isEscape {
                     return dispatchWork(application, false, { application.hideUi() })
                 }

--- a/alt-tab-macos/logic/Observer.swift
+++ b/alt-tab-macos/logic/Observer.swift
@@ -1,0 +1,84 @@
+import Cocoa
+import Foundation
+
+enum AXNotification: String {
+    case destroyed = "AXUIElementDestroyed"
+    case rezized = "AXWindowResized"
+}
+
+enum ObserverMode {
+    case refreshUiOnClose
+    case refreshUiOnQuit
+}
+
+class Observer: NSObject {
+    var axObserver: AXObserver?
+    var activeKvoObservers = [(NSRunningApplication, String?)]()
+
+    func createObserver(_ window: TrackedWindow, _ delegate: Application, _ mode: ObserverMode) {
+        let application = UnsafeMutableRawPointer(Unmanaged.passUnretained(delegate).toOpaque())
+
+        func refreshUiOnCloseCallback(observer: AXObserver, element: AXUIElement, notificationName: CFString, delegate_: UnsafeMutableRawPointer?) -> Void {
+            debugPrint("refreshUiOnCloseCallback")
+            let application = Unmanaged<Application>.fromOpaque(delegate_!).takeUnretainedValue()
+
+            if notificationName == AXNotification.rezized.rawValue as CFString {
+                element.close()
+                AXObserverRemoveNotification(observer, element, notificationName)
+            }
+            if notificationName == AXNotification.destroyed.rawValue as CFString {
+                if application.appIsBeingUsed {
+                    // give the system a ms to clean up
+                    DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + .milliseconds(1), execute: {
+                        application.isOutdated = true
+                        application.showUiOrCycleSelection(TrackedWindows.focusedWindowIndex)
+                    })
+                }
+                AXObserverRemoveNotification(observer, element, notificationName)
+            }
+        }
+
+        if mode == .refreshUiOnClose {
+            if AXObserverCreate(window.ownerPid, refreshUiOnCloseCallback, &axObserver) == .success {
+                if (window.axWindow?.isFullScreen())! {
+                    if AXObserverAddNotification(axObserver!, window.axWindow!, AXNotification.rezized.rawValue as CFString, application) != .success {
+                        AXObserverRemoveNotification(axObserver!, window.axWindow!, AXNotification.rezized.rawValue as CFString)
+                    }
+                }
+                if AXObserverAddNotification(axObserver!, window.axWindow!, AXNotification.destroyed.rawValue as CFString, application) != .success {
+                    AXObserverRemoveNotification(axObserver!, window.axWindow!, AXNotification.destroyed.rawValue as CFString)
+                }
+            }
+            CFRunLoopAddSource(CFRunLoopGetCurrent(), AXObserverGetRunLoopSource(axObserver!), .defaultMode)
+        } else if mode == .refreshUiOnQuit {
+            window.app?.addObserver(self, forKeyPath: #keyPath(NSRunningApplication.isTerminated), options: .new, context: application)
+            activeKvoObservers.append((window.app!, #keyPath(NSRunningApplication.isTerminated)))
+        }
+    }
+
+    override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
+        debugPrint("observeValue")
+        if keyPath == #keyPath(NSRunningApplication.isTerminated) {
+            let application = Unmanaged<Application>.fromOpaque(context!).takeUnretainedValue()
+            if application.appIsBeingUsed {
+                DispatchQueue.main.async(execute: {
+                    application.isOutdated = true
+                    application.showUiOrCycleSelection(TrackedWindows.focusedWindowIndex)
+                })
+            }
+            (object as! NSRunningApplication).removeObserver(self, forKeyPath: keyPath!)
+            activeKvoObservers = activeKvoObservers.filter { $0 != (object as! NSRunningApplication, keyPath!) }
+        }
+    }
+
+    func clearObservers() {
+        debugPrint("clearObservers")
+        if activeKvoObservers.count > 0 {
+            let activeKvoObservers_ = activeKvoObservers
+            for observer in activeKvoObservers_ {
+                observer.0.removeObserver(self, forKeyPath: observer.1!)
+                activeKvoObservers = activeKvoObservers.filter { $0 != observer }
+            }
+        }
+    }
+}

--- a/alt-tab-macos/logic/TrackedWindow.swift
+++ b/alt-tab-macos/logic/TrackedWindow.swift
@@ -9,7 +9,18 @@ class TrackedWindow {
     var thumbnail: NSImage?
     var icon: NSImage?
     var app: NSRunningApplication?
-    var axWindow: AXUIElement?
+    private var _axWindow: AXUIElement? = nil
+    var axWindow: AXUIElement? {
+        set {
+            _axWindow = newValue
+        }
+        get {
+            if _axWindow == nil {
+                _axWindow = id.AXUIElementOfOtherSpaceWindow(ownerPid)
+            }
+            return _axWindow
+        }
+    }
     var isMinimized: Bool
     var spaceId: CGSSpaceID?
     var spaceIndex: SpaceIndex?
@@ -28,7 +39,7 @@ class TrackedWindow {
         if let cgImage = cgId.screenshot() {
             self.thumbnail = NSImage(cgImage: cgImage, size: NSSize(width: cgImage.width, height: cgImage.height))
         }
-        self.axWindow = axWindow
+        self._axWindow = axWindow
         self.isMinimized = isMinimized
         self.spaceId = spaceId
         // System Preferences windows appear on all spaces, so we make them the current space
@@ -37,9 +48,16 @@ class TrackedWindow {
     }
 
     func focus() {
-        if axWindow == nil {
-            axWindow = id.AXUIElementOfOtherSpaceWindow(ownerPid)
-        }
         axWindow?.focus(id)
+    }
+
+    func close() {
+        axWindow?.close()
+    }
+
+    func quitApp() {
+        if app != nil {
+            app?.terminate()
+        }
     }
 }


### PR DESCRIPTION
This PR adds quick-actions to quickly manipulate the selected window/application.

~Current limitation aside from the progress below is, that windows in fullscreen can't be closed.
Ideas on how to achieve this are more than welcome~ Works now :)
~Also im not entirely happy with the delays in `./ui/Application.swift` _(LOC 110 & 119)_. Input regarding this is also appreciated.~ 

@lwouis: Could you take a look at it, if this is going in the direction you intended? :)

Progress:
- [x] Close windows (`w`)
- [x] Quit application (`q`)
- [ ] Snap window left (`arrow left`)
- [ ] Snap window right (`arrow right`)
- [ ] Enter full screen (`f`)
- [ ] Minimize Window (`m`)

Closes #9 