### PR TITLE
Soften privilege warnings

### DIFF
--- a/alt-tab-macos/logic/Keyboard.swift
+++ b/alt-tab-macos/logic/Keyboard.swift
@@ -23,9 +23,15 @@ func listenToGlobalKeyboardEvents(_ delegate: Application) {
                 eventsOfInterest: eventMask,
                 callback: keyboardHandler,
                 userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(delegate).toOpaque()))
+        if eventTap == nil {
+            debugPrint("Could not enable keyboard hook; is accessibility enabled?")
+            delegate.keyboardWasHooked(false)
+            return
+        }
         let runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
         CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
         CGEvent.tapEnable(tap: eventTap!, enable: true)
+        delegate.keyboardWasHooked(true)
         CFRunLoopRun()
     }
 }

--- a/alt-tab-macos/logic/SystemPermissions.swift
+++ b/alt-tab-macos/logic/SystemPermissions.swift
@@ -4,25 +4,14 @@ import Cocoa
 // macOS has some privacy restrictions. The user needs to grant certain permissions, app by app, in System Preferences > Security & Privacy > Privacy
 class SystemPermissions {
     // macOS 10.9+
-    static func ensureAccessibilityCheckboxIsChecked() {
-        if !AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary) {
-            debugPrint("Before using this app, you need to give permission in System Preferences > Security & Privacy > Privacy > Accessibility.",
-                    "Please authorize and re-launch.",
-                    "See https://help.rescuetime.com/article/59-how-do-i-enable-accessibility-permissions-on-mac-osx",
-                    separator: "\n")
-            NSApp.terminate(self)
-        }
+    static func checkAccessibility() -> Bool {
+        return AXIsProcessTrustedWithOptions(["AXTrustedCheckOptionPrompt": true] as CFDictionary)
     }
 
     // macOS 10.15+
-    static func ensureScreenRecordingCheckboxIsChecked() {
+    static func checkScreenshot() -> Bool {
+        // TODO: This may false-positive if the first window we encounter happens to be owned by the app itself
         let firstWindow = CGWindow.windows(.optionOnScreenOnly)[0]
-        if let cgId = firstWindow.value(.number, CGWindowID.self), cgId.screenshot() == nil {
-            debugPrint("Before using this app, you need to give permission in System Preferences > Security & Privacy > Privacy > Screen Recording.",
-                    "Please authorize and re-launch.",
-                    "See https://dropshare.zendesk.com/hc/en-us/articles/360033453434-Enabling-Screen-Recording-Permission-on-macOS-Catalina-10-15-",
-                    separator: "\n")
-            NSApp.terminate(self)
-        }
+        return firstWindow.value(.number, CGWindowID.self)!.screenshot() != nil
     }
 }

--- a/alt-tab-macos/ui/Application.swift
+++ b/alt-tab-macos/ui/Application.swift
@@ -11,6 +11,7 @@ class Application: NSApplication, NSApplicationDelegate, NSWindowDelegate {
     var uiWorkShouldBeDone = true
     var isFirstSummon = true
     var appIsBeingUsed = false
+    var keyboardSuccessfullyHooked = false
 
     override init() {
         super.init()
@@ -62,6 +63,10 @@ class Application: NSApplication, NSApplicationDelegate, NSWindowDelegate {
             preferencesPanel = PreferencesPanel()
         }
         Screen.showPanel(preferencesPanel!, Screen.preferred(), .appleCentered)
+    }
+
+    func keyboardWasHooked(_ success: Bool) {
+        keyboardSuccessfullyHooked = success
     }
 
     func cycleSelection(_ step: Int) {

--- a/alt-tab-macos/ui/Application.swift
+++ b/alt-tab-macos/ui/Application.swift
@@ -23,8 +23,6 @@ class Application: NSApplication, NSApplicationDelegate, NSWindowDelegate {
     }
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-        SystemPermissions.ensureScreenRecordingCheckboxIsChecked()
-        SystemPermissions.ensureAccessibilityCheckboxIsChecked()
         Preferences.loadFromDiskAndUpdateValues()
         statusItem = StatusItem.make(self)
         initPreferencesDependentComponents()

--- a/alt-tab-macos/ui/PreferencesPanel.swift
+++ b/alt-tab-macos/ui/PreferencesPanel.swift
@@ -2,6 +2,19 @@ import Cocoa
 import Foundation
 
 class PreferencesPanel: NSPanel, NSWindowDelegate {
+    let ACCESSIBILITY_WARNING_TEXT = """
+Before using this app, you need to give permission in System Preferences > Security & Privacy > Privacy > Accessibility.
+Please authorize and re-launch.
+
+See https://help.rescuetime.com/article/59-how-do-i-enable-accessibility-permissions-on-mac-osx
+"""
+    let SCREENSHOT_WARNING_TEXT = """
+Before using this app, you need to give permission in System Preferences > Security & Privacy > Privacy > Screen Recording.
+Please authorize and re-launch.
+
+See https://dropshare.zendesk.com/hc/en-us/articles/360033453434-Enabling-Screen-Recording-Permission-on-macOS-Catalina-10-15-
+"""
+
     let panelWidth = CGFloat(496)
     let panelHeight = CGFloat(256) // auto expands to content height (but does not auto shrink)
     let panelPadding = CGFloat(40)
@@ -71,6 +84,8 @@ class PreferencesPanel: NSPanel, NSWindowDelegate {
         }
 
         return [
+            (SystemPermissions.checkAccessibility() ? nil : makeWarningLabel(ACCESSIBILITY_WARNING_TEXT)),
+            (SystemPermissions.checkScreenshot() ? nil : makeWarningLabel(SCREENSHOT_WARNING_TEXT)),
             makeLabelWithDropdown("Alt key", rawName: "metaKey", values: Preferences.metaKeyMacro.labels),
             makeLabelWithInput("Tab key", rawName: "tabKeyCode", width: 33, suffixText: "KeyCodes Reference", suffixUrl: "https://eastmanreference.com/complete-list-of-applescript-key-codes", validator: tabKeyCodeValidator),
             makeHorizontalSeparator(),
@@ -82,7 +97,7 @@ class PreferencesPanel: NSPanel, NSWindowDelegate {
             makeHorizontalSeparator(),
             makeLabelWithSlider("Window apparition delay", rawName: "windowDisplayDelay", minValue: 0, maxValue: 2000, numberOfTickMarks: 0, unitText: "ms"),
             makeLabelWithDropdown("Show on", rawName: "showOnScreen", values: Preferences.showOnScreenMacro.labels)
-        ]
+            ].compactMap { $0 }
     }
 
     private func makeHorizontalSeparator() -> NSView {
@@ -90,6 +105,14 @@ class PreferencesPanel: NSPanel, NSWindowDelegate {
         view.boxType = .separator
 
         return view
+    }
+
+    private func makeWarningLabel(_ labelText: String) -> NSTextField {
+        let label = NSTextField(wrappingLabelWithString: labelText)
+        label.alignment = .center
+        label.widthAnchor.constraint(equalToConstant: panelWidth - panelPadding).isActive = true
+        label.textColor = NSColor.red
+        return label
     }
 
     private func makeLabelWithInput(_ labelText: String, rawName: String, width: CGFloat? = nil, suffixText: String? = nil, suffixUrl: String? = nil, validator: ((String)->Bool)? = nil) -> NSStackView {


### PR DESCRIPTION
* When keyboard hooking fails, don't crash in `CFMachPortCreateRunLoopSource`
* When not a11y/screenshot privileged, show a warning in the preferences instead of crashing at startup