### PR TITLE
Add option to hide the space number label

### DIFF
--- a/alt-tab-macos/logic/Preferences.swift
+++ b/alt-tab-macos/logic/Preferences.swift
@@ -12,7 +12,8 @@ class Preferences {
         "metaKey": metaKeyMacro.macros[0].label,
         "windowDisplayDelay": "0",
         "theme": themeMacro.macros[0].label,
-        "showOnScreen": showOnScreenMacro.macros[0].label
+        "showOnScreen": showOnScreenMacro.macros[0].label,
+        "hideSpaceNumberLabels": String(false)
     ]
     static var rawValues = [String: String]()
     static var minimumWindowSize = CGFloat(200)
@@ -39,6 +40,7 @@ class Preferences {
     static var windowCornerRadius: CGFloat?
     static var font: NSFont?
     static var showOnScreen: ShowOnScreenPreference?
+    static var hideSpaceNumberLabels = false
     static var themeMacro = MacroPreferenceHelper<(CGFloat, CGFloat, CGFloat, NSColor, NSColor)>([
         MacroPreference(" macOS", (0, 5, 20, .clear, NSColor(red: 0, green: 0, blue: 0, alpha: 0.3))),
         MacroPreference("❖ Windows 10", (2, 0, 0, .white, .clear))
@@ -110,6 +112,8 @@ class Preferences {
         case "showOnScreen":
             let p = try showOnScreenMacro.labelToMacro[value].orThrow()
             showOnScreen = p.preferences
+        case "hideSpaceNumberLabels":
+            hideSpaceNumberLabels = try Bool(value).orThrow()
         default:
             throw NSError.make(domain: "Preferences", message: "Tried to update an unknown preference: '\(valueName)' = '\(value)'")
         }

--- a/alt-tab-macos/ui/Cell.swift
+++ b/alt-tab-macos/ui/Cell.swift
@@ -53,7 +53,7 @@ class Cell: NSCollectionViewItem {
         let fontIconWidth = Spaces.singleSpace && !openWindow!.isMinimized ? 0 : Preferences.fontIconSize + Preferences.interItemPadding
         label.textContainer!.size.width = thumbnail.frame.width - Preferences.iconSize! - Preferences.interItemPadding - fontIconWidth
         minimizedIcon.isHidden = !openWindow!.isMinimized
-        spaceIcon.isHidden = openWindow!.isMinimized || Spaces.singleSpace
+        spaceIcon.isHidden = openWindow!.isMinimized || Spaces.singleSpace || Preferences.hideSpaceNumberLabels
         if !spaceIcon.isHidden {
             spaceIcon.setNumber(UInt32(element.spaceIndex!))
         }

--- a/alt-tab-macos/ui/PreferencesPanel.swift
+++ b/alt-tab-macos/ui/PreferencesPanel.swift
@@ -79,6 +79,7 @@ class PreferencesPanel: NSPanel, NSWindowDelegate {
             makeLabelWithSlider("Max thumbnails per row", rawName: "maxThumbnailsPerRow", minValue: 3, maxValue: 16, numberOfTickMarks: 0),
             makeLabelWithSlider("Apps icon size", rawName: "iconSize", minValue: 12, maxValue: 64, numberOfTickMarks: 0, unitText: "px"),
             makeLabelWithSlider("Window font size", rawName: "fontHeight", minValue: 12, maxValue: 64, numberOfTickMarks: 0, unitText: "px"),
+            makeLabelWithCheckbox("Hide space number labels", rawName: "hideSpaceNumberLabels"),
             makeHorizontalSeparator(),
             makeLabelWithSlider("Window apparition delay", rawName: "windowDisplayDelay", minValue: 0, maxValue: 2000, numberOfTickMarks: 0, unitText: "ms"),
             makeLabelWithDropdown("Show on", rawName: "showOnScreen", values: Preferences.showOnScreenMacro.labels)
@@ -104,6 +105,12 @@ class PreferencesPanel: NSPanel, NSWindowDelegate {
         return makeLabelWithProvidedControl(labelText, rawName: rawName, control: input, suffixText: suffixText, suffixUrl: suffixUrl)
     }
 
+    private func makeLabelWithCheckbox(_ labelText: String, rawName: String) -> NSStackView {
+        let checkbox = NSButton.init(checkboxWithTitle: "", target: nil, action: nil)
+        setControlValue(checkbox, Preferences.rawValues[rawName]!)
+        return makeLabelWithProvidedControl(labelText, rawName: rawName, control: checkbox)
+    }
+
     private func makeLabelWithDropdown(_ labelText: String, rawName: String, values: [String], suffixText: String? = nil) -> NSStackView {
         let popUp = NSPopUpButton()
         popUp.addItems(withTitles: values)
@@ -127,8 +134,8 @@ class PreferencesPanel: NSPanel, NSWindowDelegate {
         return makeLabelWithProvidedControl(labelText, rawName: rawName, control: slider, suffixText: suffixText, suffixWidth: 60)
     }
 
-    private func makeLabelWithProvidedControl(_ labelText: String, rawName: String, control: NSControl, suffixText: String? = nil, suffixWidth: CGFloat? = nil, suffixUrl: String? = nil) -> NSStackView {
-        let label = NSTextField(wrappingLabelWithString: labelText + ": ")
+    private func makeLabelWithProvidedControl(_ labelText: String?, rawName: String, control: NSControl, suffixText: String? = nil, suffixWidth: CGFloat? = nil, suffixUrl: String? = nil) -> NSStackView {
+        let label = NSTextField(wrappingLabelWithString: (labelText != nil ? labelText! + ": " : ""))
         label.alignment = .right
         label.widthAnchor.constraint(equalToConstant: labelWidth).isActive = true
         label.identifier = NSUserInterfaceItemIdentifier(rawName + ControlIdentifierDiscriminator.LABEL.rawValue)
@@ -232,7 +239,9 @@ class PreferencesPanel: NSPanel, NSWindowDelegate {
     }
 
     private func getControlValue(_ control: NSControl) -> String {
-        if control is NSPopUpButton {
+        if control is NSButton {
+            return String((control as! NSButton).state == NSButton.StateValue.on)
+        } else if control is NSPopUpButton {
             return (control as! NSPopUpButton).titleOfSelectedItem!
         } else if control is NSSlider {
             return String(format: "%.0f", control.doubleValue) // we are only interested in decimals of the provided double
@@ -242,7 +251,9 @@ class PreferencesPanel: NSPanel, NSWindowDelegate {
     }
 
     private func setControlValue(_ control: NSControl, _ value: String) {
-        if control is NSPopUpButton {
+        if control is NSButton {
+            (control as! NSButton).state = Bool(value) ?? false ? NSButton.StateValue.on : NSButton.StateValue.off
+        } else if control is NSPopUpButton {
             (control as! NSPopUpButton).selectItem(withTitle: value)
         } else if control is NSTextField{
             control.stringValue = value


### PR DESCRIPTION
I have two displays (so ATM counts them as two Spaces), but I don't really need to see the space number in this case.