### PR TITLE
Menu changes

### DIFF
--- a/alt-tab-macos/ui/Application.swift
+++ b/alt-tab-macos/ui/Application.swift
@@ -64,6 +64,11 @@ class Application: NSApplication, NSApplicationDelegate, NSWindowDelegate {
         Screen.showPanel(preferencesPanel!, Screen.preferred(), .appleCentered)
     }
 
+    @objc
+    func showUi() {
+        showUiOrCycleSelection(0)
+    }
+
     func cycleSelection(_ step: Int) {
         TrackedWindows.focusedWindowIndex = TrackedWindows.moveFocusedWindowIndex(step)
         self.thumbnailsPanel!.highlightCellAt(step)

--- a/alt-tab-macos/ui/StatusItem.swift
+++ b/alt-tab-macos/ui/StatusItem.swift
@@ -10,6 +10,11 @@ class StatusItem {
                 action: #selector(application.showPreferencesPanel),
                 keyEquivalent: ",")
         item.menu!.addItem(
+                withTitle: "Show…",
+                action: #selector(application.showUi),
+                keyEquivalent: "s"
+        )
+        item.menu!.addItem(
             withTitle: "Quit \(Application.name) #VERSION#",
                 action: #selector(NSApplication.terminate(_:)),
                 keyEquivalent: "q")

--- a/alt-tab-macos/ui/StatusItem.swift
+++ b/alt-tab-macos/ui/StatusItem.swift
@@ -6,15 +6,11 @@ class StatusItem {
         item.button!.title = Application.name
         item.menu = NSMenu()
         item.menu!.addItem(
-                withTitle: "Version #VERSION#",
-                action: nil,
-                keyEquivalent: "")
-        item.menu!.addItem(
                 withTitle: "Preferences…",
                 action: #selector(application.showPreferencesPanel),
                 keyEquivalent: ",")
         item.menu!.addItem(
-                withTitle: "Quit \(ProcessInfo.processInfo.processName)",
+            withTitle: "Quit \(Application.name) #VERSION#",
                 action: #selector(NSApplication.terminate(_:)),
                 keyEquivalent: "q")
         return item


### PR DESCRIPTION
* Removes the unnecessary "Version #VERSION#" menu item
* Adds a new item (previously an alternate item) to open the selector window even when keyboard access fails for some reason

Spun out from #99 as requested.