### PR TITLE
fix: app crashes when no windows are open

### DIFF
--- a/alt-tab-macos/logic/TrackedWindows.swift
+++ b/alt-tab-macos/logic/TrackedWindows.swift
@@ -25,11 +25,13 @@ class TrackedWindows {
     }
 
     private class func isSingleSpace() {
-        let firstSpaceIndex = list[0].spaceIndex
-        for window in list {
-            if window.spaceIndex != nil && window.spaceIndex != firstSpaceIndex {
-                Spaces.singleSpace = false
-                return
+        if list.count > 0 {
+            let firstSpaceIndex = list[0].spaceIndex
+            for window in list {
+                if window.spaceIndex != nil && window.spaceIndex != firstSpaceIndex {
+                    Spaces.singleSpace = false
+                    return
+                }
             }
         }
         Spaces.singleSpace = true


### PR DESCRIPTION
The application still crashed when there were no windows to be shown.

Related to #95 and #96 