### PR TITLE
Removed isMetaDown check on Escape keydown (closes #119)

### DIFF
--- a/alt-tab-macos/logic/Keyboard.swift
+++ b/alt-tab-macos/logic/Keyboard.swift
@@ -48,7 +48,10 @@ func keyboardHandler(proxy: CGEventTapProxy, type: CGEventType, event_: CGEvent,
             let isRightArrow = event.keyCode == kVK_RightArrow
             let isLeftArrow = event.keyCode == kVK_LeftArrow
             let isEscape = event.keyCode == kVK_Escape
-            if isMetaDown && type == .keyDown {
+            
+            if type == .keyDown && isEscape {
+                return dispatchWork(application, false, { application.hideUi() })
+            } else if isMetaDown && type == .keyDown {
                 if isTab && event.modifierFlags.contains(.shift) {
                     return dispatchWork(application, true, { application.showUiOrCycleSelection(-1) })
                 } else if isTab {
@@ -57,8 +60,6 @@ func keyboardHandler(proxy: CGEventTapProxy, type: CGEventType, event_: CGEvent,
                     return dispatchWork(application, true, { application.cycleSelection(1) })
                 } else if isLeftArrow && application.appIsBeingUsed {
                     return dispatchWork(application, true, { application.cycleSelection(-1) })
-                } else if type == .keyDown && isEscape {
-                    return dispatchWork(application, false, { application.hideUi() })
                 }
             } else if isMetaChanged && !isMetaDown {
                 return dispatchWork(application, false, { application.focusTarget() })


### PR DESCRIPTION
This is due to TouchBar's escape key down event does not have modifier flags from the keyboard

Since I chose (^ Control) as Alt key in the preference, I expect all keyboard events to have 
`Event modifier: NSEventModifierFlags(rawValue: 262401)`
when the (^ Control) key is pressed down

However, while keeping (^ Control) down, an keydown event from Esc key on the touch bar does not have the expected modifier flags, instead:
`Event modifier: NSEventModifierFlags(rawValue: 256)`
And since the modifier flags are wrong, hideUI() is not called

I could not find a way to distinguish whether the Esc key down event is coming from touch bar or actual keyboard, so I skipped the isMetaDown check for this case.