### PR TITLE
fix: fast shortcut press would fail to switch windows

### DIFF
--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -20,9 +20,7 @@ class Windows {
     }
 
     static func cycleFocusedWindowIndex(_ step: Int) {
-        DispatchQueue.main.async { () -> () in
-            updateFocusedWindowIndex(windowIndexAfterCycling(step))
-        }
+        updateFocusedWindowIndex(windowIndexAfterCycling(step))
     }
 
     static func windowIndexAfterCycling(_ step: Int) -> Int {


### PR DESCRIPTION
With many windows open, and a blazing fast shortcut press, AltTab would fail to switch as it would queue the focus task before the cycling task