### PR TITLE
Quick fix for #543 (removes quit button from prefs dialog)

### DIFF
--- a/src/ui/preferences-window/PreferencesWindow.swift
+++ b/src/ui/preferences-window/PreferencesWindow.swift
@@ -13,10 +13,12 @@ class PreferencesWindow: NSWindow, NSToolbarDelegate {
         isReleasedWhenClosed = false
         hidesOnDeactivate = false
         styleMask.insert([.miniaturizable, .closable])
-        addQuitButton()
+        // Disabled, see issue #543
+        // addQuitButton()
     }
 
     private func addQuitButton() {
+        // TODO: Something breaks here! See issue #543
         let quitButton = NSButton(title: NSLocalizedString("Quit", comment: ""), target: nil, action: #selector(NSApplication.terminate(_:)))
         quitButton.translatesAutoresizingMaskIntoConstraints = false
         let accessoryViewController = NSTitlebarAccessoryViewController()


### PR DESCRIPTION
This is really just band-aid; something in laying out that button breaks things, but it's not strictly required.

Refs #543
Refs #544 
