### PR TITLE
Show window controls on hover, even when option is disabled

### DIFF
--- a/src/ui/main-window/ThumbnailView.swift
+++ b/src/ui/main-window/ThumbnailView.swift
@@ -68,7 +68,7 @@ class ThumbnailView: NSStackView {
         if let shouldShowWindowControls = shouldShowWindowControls_ {
             self.shouldShowWindowControls = shouldShowWindowControls
         }
-        let shouldShow = shouldShowWindowControls && isHighlighted && !Preferences.hideColoredCircles && !window_!.isWindowlessApp && !Preferences.hideThumbnails
+        let shouldShow = shouldShowWindowControls && !Preferences.hideColoredCircles && !window_!.isWindowlessApp && !Preferences.hideThumbnails
         if isShowingWindowControls != shouldShow {
             isShowingWindowControls = shouldShow
             [closeIcon, minimizeIcon, maximizeIcon].forEach { $0.isHidden = !shouldShow }
@@ -210,7 +210,7 @@ class ThumbnailView: NSStackView {
 
     func mouseMoved() {
         showOrHideWindowControls(true)
-        if !isHighlighted {
+        if Preferences.mouseHoverEnabled && !isHighlighted {
             mouseMovedCallback()
         }
         hoverWindowControls()

--- a/src/ui/main-window/ThumbnailsView.swift
+++ b/src/ui/main-window/ThumbnailsView.swift
@@ -211,7 +211,7 @@ class ScrollView: NSScrollView {
 
     override func mouseMoved(with event: NSEvent) {
         // disable mouse hover during scrolling as it creates jank during elastic bounces at the start/end of the scrollview
-        if !Preferences.mouseHoverEnabled || isCurrentlyScrolling { return }
+        if isCurrentlyScrolling { return }
         if let hit = hitTest(App.app.thumbnailsPanel.mouseLocationOutsideOfEventStream) {
             var target: NSView? = hit
             while !(target is ThumbnailView) && target != nil {


### PR DESCRIPTION
Awesome project!

This PR makes the window controls always appear on hover - regardless of the "Mouse hover" option.
I think this makes the most sense, as you are still able to click-to-focus windows when the option is disabled anyway.