### PR TITLE
Fix alternative install command template

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -12,7 +12,7 @@ permalink: /
 
 [**Download the latest release**]({{ site.github.latest_release.assets[0].browser_download_url }})
 
-Alternatively, you can use [homebrew](https://brew.sh/): `brew cask install alt-tab`
+Alternatively, you can use [homebrew](https://brew.sh/): `brew install alt-tab`
 
 ## Compatibility
 


### PR DESCRIPTION
'cask' command option no more recognized by homebrew as it's now part of Homebrew Core

