### PR TITLE
docs: fix brew install command

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -12,7 +12,7 @@ permalink: /
 
 [**Download the latest release**]({{ site.github.latest_release.assets[0].browser_download_url }})
 
-Alternatively, you can use [homebrew](https://brew.sh/): `brew cask install alt-tab`
+Alternatively, you can use [homebrew](https://brew.sh/): `brew install --cask alt-tab`
 
 ## Compatibility
 


### PR DESCRIPTION
See https://stackoverflow.com/questions/30413621/homebrew-cask-option-not-recognized
