### PR TITLE
docs: Correct Homebrew cask command

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -12,7 +12,7 @@ permalink: /
 
 [**Download the latest release**]({{ site.github.latest_release.assets[0].browser_download_url }})
 
-Alternatively, you can use [homebrew](https://brew.sh/): `brew cask install alt-tab`
+Alternatively, you can use [homebrew](https://brew.sh/): `brew install --cask alt-tab`
 
 ## Compatibility
 


### PR DESCRIPTION
`brew cask` is not a command anymore
https://stackoverflow.com/questions/30413621/homebrew-cask-option-not-recognized

Thank you for opening a PR! Please make sure that:

* The title and description of the PR convey what the change is about, by mentioning the ticket it addresses for instance.
* The commits messages [follow the convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary), so your PR can be merged.
