### PR TITLE
feat: added NICE DCV to the don't show list

### DIFF
--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -49,7 +49,7 @@ class Preferences {
         "startAtLogin": "true",
         "menubarIcon": MenubarIconPreference.outlined.rawValue,
         "dontShowBlacklist": ["com.McAfee.McAfeeSafariHost"].joined(separator: "\n"),
-        "disableShortcutsBlacklist": ["com.realvnc.vncviewer", "com.microsoft.rdc.macos", "com.teamviewer.TeamViewer", "org.virtualbox.app.VirtualBoxVM", "com.parallels.", "com.citrix.XenAppViewer"].joined(separator: "\n"),
+        "disableShortcutsBlacklist": ["com.realvnc.vncviewer", "com.microsoft.rdc.macos", "com.teamviewer.TeamViewer", "org.virtualbox.app.VirtualBoxVM", "com.parallels.", "com.citrix.XenAppViewer", "com.nicesoftware.dcvviewer"].joined(separator: "\n"),
         "disableShortcutsBlacklistOnlyFullscreen": "true",
         "updatePolicy": UpdatePolicyPreference.autoCheck.rawValue,
         "crashPolicy": CrashPolicyPreference.ask.rawValue,


### PR DESCRIPTION
This adds [NICE DCV](https://docs.aws.amazon.com/dcv/index.html) to the list of applications for which alt-tab-macos is disabled by default if full-screen (i.e. the `disableShortcutsBlacklist`); NICE DCV is a remote display protocol on the same vein of VNC, RDP and other applications already in the list.