### PR TITLE
fix: Ghost popup windows in Android Studio (see #1056)

### DIFF
--- a/src/logic/Application.swift
+++ b/src/logic/Application.swift
@@ -30,7 +30,8 @@ class Application: NSObject {
         if app.bundleIdentifier == "edu.stanford.protege" ||
                app.bundleIdentifier?.range(of: "^com\\.install4j\\..+?$", options: .regularExpression) != nil ||
                app.bundleIdentifier?.range(of: "^com\\.live2d\\.cubism\\..+?$", options: .regularExpression) != nil ||
-               app.bundleIdentifier?.range(of: "^com\\.jetbrains\\..+?$", options: .regularExpression) != nil {
+               app.bundleIdentifier?.range(of: "^com\\.jetbrains\\..+?$", options: .regularExpression) != nil ||
+               app.bundleIdentifier?.range(of: "^com\\.google\\.android\\.studio.*?$", options: .regularExpression) != nil {
             return n.filter { $0 != kAXFocusedUIElementChangedNotification }
         }
         return n


### PR DESCRIPTION
Closes https://github.com/lwouis/alt-tab-macos/issues/1056

- [x] The commits messages [follow the convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary), so your PR can be merged.


The regex needed to match not only  `com.google.android.studio` but also `com.google.android.studio-EAP`, hence the `.*` part at the end.