### PR TITLE
fix: app was responding to drag-drop mouse moves even with setting disabled

### DIFF
--- a/src/ui/main-window/ThumbnailView.swift
+++ b/src/ui/main-window/ThumbnailView.swift
@@ -213,7 +213,9 @@ class ThumbnailView: NSStackView {
     }
 
     override func draggingUpdated(_ sender: NSDraggingInfo) -> NSDragOperation {
-        mouseMovedCallback()
+        if Preferences.mouseHoverEnabled && !isHighlighted {
+            mouseMovedCallback()
+        }
         return .link
     }
 


### PR DESCRIPTION
App continued to respond to mouse moves during drag-drop even if "respond to mouse" setting was disabled.