### PR TITLE
Make sure kAXFocusedUIElementChangedNotification is only allowed when the trigger PID isn't alt-tab's

### DIFF
--- a/src/logic/events/AccessibilityEvents.swift
+++ b/src/logic/events/AccessibilityEvents.swift
@@ -11,8 +11,7 @@ fileprivate func handleEvent(_ type: String, _ element: AXUIElement) throws {
     debugPrint("Accessibility event", type, type != kAXFocusedUIElementChangedNotification ? (try element.title() ?? "nil") : "nil")
     // events are handled concurrently, thus we check that the app is still running
     if let pid = try element.pid(),
-       try ((pid != ProcessInfo.processInfo.processIdentifier && element.subrole() != kAXUnknownSubrole)
-               || (type != kAXFocusedUIElementChangedNotification)) {
+       try (pid != ProcessInfo.processInfo.processIdentifier || (element.subrole() != kAXUnknownSubrole && type != kAXFocusedUIElementChangedNotification)) {
         switch type {
             case kAXApplicationActivatedNotification: try applicationActivated(element, pid)
             case kAXApplicationHiddenNotification,

--- a/src/logic/events/AccessibilityEvents.swift
+++ b/src/logic/events/AccessibilityEvents.swift
@@ -11,7 +11,8 @@ fileprivate func handleEvent(_ type: String, _ element: AXUIElement) throws {
     debugPrint("Accessibility event", type, type != kAXFocusedUIElementChangedNotification ? (try element.title() ?? "nil") : "nil")
     // events are handled concurrently, thus we check that the app is still running
     if let pid = try element.pid(),
-       try (!(pid == ProcessInfo.processInfo.processIdentifier && element.subrole() == kAXUnknownSubrole)) {
+       try ((pid != ProcessInfo.processInfo.processIdentifier && element.subrole() != kAXUnknownSubrole)
+               || (type != kAXFocusedUIElementChangedNotification)) {
         switch type {
             case kAXApplicationActivatedNotification: try applicationActivated(element, pid)
             case kAXApplicationHiddenNotification,


### PR DESCRIPTION
This seems to fix https://github.com/lwouis/alt-tab-macos/issues/563.

I noticed that `voiceOverFocusedWindow()` was being called twice whenever the focused window would change, and traced it back to `kAXFocusedUIElementChangedNotification` being triggered and acted upon when the focused window changed. 

I modified the conditional when handling accessibility events to disallow `kAXFocusedUIElementChangedNotification` from running unless the triggering PID isn't alt-tab's. I've done some testing and it seems to fix the freezing issue without any other side effects.