### PR TITLE
Allow switching to Parallels windows

### DIFF
--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -157,25 +157,17 @@ class Window {
             // but quickly switches back to another window in that space
             // You can reproduce this buggy behaviour by clicking on the dock icon, proving it's an OS bug
             BackgroundWork.accessibilityCommandsQueue.asyncWithCap { [weak self] in
-                do {
-                    guard let self = self else { return }
-                    var elementConnection = UInt32(0)
-                    CGSGetWindowOwner(cgsMainConnectionId, self.cgWindowId, &elementConnection)
-                    var psn = ProcessSerialNumber()
-                    CGSGetConnectionPSN(elementConnection, &psn)
+                guard let self = self else { return }
+                var elementConnection = UInt32(0)
+                CGSGetWindowOwner(cgsMainConnectionId, self.cgWindowId, &elementConnection)
 
-                    if psn.lowLongOfPSN == 0 && psn.highLongOfPSN == 0 {
-                        let wid = try self.axUiElement.pid()!
-                        GetProcessForPID(wid, &psn)
-                    }
+                var psn = ProcessSerialNumber()
+                GetProcessForPID(self.application.pid, &psn)
 
-                    _SLPSSetFrontProcessWithOptions(&psn, self.cgWindowId, .userGenerated)
+                _SLPSSetFrontProcessWithOptions(&psn, self.cgWindowId, .userGenerated)
 
-                    self.makeKeyWindow(psn)
-                    self.axUiElement.focusWindow()
-                } catch {
-                    debugPrint("Error!")
-                }
+                self.makeKeyWindow(psn)
+                self.axUiElement.focusWindow()
             }
         }
     }

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -157,14 +157,25 @@ class Window {
             // but quickly switches back to another window in that space
             // You can reproduce this buggy behaviour by clicking on the dock icon, proving it's an OS bug
             BackgroundWork.accessibilityCommandsQueue.asyncWithCap { [weak self] in
-                guard let self = self else { return }
-                var elementConnection = UInt32(0)
-                CGSGetWindowOwner(cgsMainConnectionId, self.cgWindowId, &elementConnection)
-                var psn = ProcessSerialNumber()
-                CGSGetConnectionPSN(elementConnection, &psn)
-                _SLPSSetFrontProcessWithOptions(&psn, self.cgWindowId, .userGenerated)
-                self.makeKeyWindow(psn)
-                self.axUiElement.focusWindow()
+                do {
+                    guard let self = self else { return }
+                    var elementConnection = UInt32(0)
+                    CGSGetWindowOwner(cgsMainConnectionId, self.cgWindowId, &elementConnection)
+                    var psn = ProcessSerialNumber()
+                    CGSGetConnectionPSN(elementConnection, &psn)
+
+                    if psn.lowLongOfPSN == 0 && psn.highLongOfPSN == 0 {
+                        let wid = try self.axUiElement.pid()!
+                        GetProcessForPID(wid, &psn)
+                    }
+
+                    _SLPSSetFrontProcessWithOptions(&psn, self.cgWindowId, .userGenerated)
+
+                    self.makeKeyWindow(psn)
+                    self.axUiElement.focusWindow()
+                } catch {
+                    debugPrint("Error!")
+                }
             }
         }
     }


### PR DESCRIPTION
This should fix https://github.com/lwouis/alt-tab-macos/issues/1213.

I'm noticing a weird issue where switching between two Parallels windows when they're adjacent in the focus order only works if you very quickly press and release the switcher shortcut. Otherwise, the focus doesn't change. I'm guessing from the code comments that that's an OS bug.