### PR TITLE
feat: allow cursor follow focus behavior

### DIFF
--- a/resources/l10n/Localizable.strings
+++ b/resources/l10n/Localizable.strings
@@ -38,6 +38,12 @@
 "Also select windows using:" = "Also select windows using:";
 
 /* No comment provided by engineer. */
+"Miscellaneous:" = "Miscellaneous:";
+
+/* No comment provided by engineer. */
+"Cursor follows focus" = "Cursor follows focus"
+
+/* No comment provided by engineer. */
 "AltTab crashed last time you used it. Sending a crash report will help get the issue fixed" = "AltTab crashed last time you used it. Sending a crash report will help get the issue fixed";
 
 /* No comment provided by engineer. */

--- a/resources/l10n/en.lproj/Localizable.strings
+++ b/resources/l10n/en.lproj/Localizable.strings
@@ -41,6 +41,12 @@
 /*No comment provided by engineer.*/
 "Also select windows using:" = "Also select windows using:";
 
+/* No comment provided by engineer. */
+"Miscellaneous:" = "Miscellaneous:";
+
+/* No comment provided by engineer. */
+"Cursor follows focus" = "Cursor follows focus"
+
 /*No comment provided by engineer.*/
 "AltTab crashed last time you used it. Sending a crash report will help get the issue fixed" = "AltTab crashed last time you used it. Sending a crash report will help get the issue fixed";
 

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -24,6 +24,7 @@ class Preferences {
         "hideShowAppShortcut": "H",
         "arrowKeysEnabled": "true",
         "mouseHoverEnabled": "true",
+        "cursorFollowFocusEnabled": "false",
         "showMinimizedWindows": ShowHowPreference.show.rawValue,
         "showMinimizedWindows2": ShowHowPreference.show.rawValue,
         "showHiddenWindows": ShowHowPreference.show.rawValue,
@@ -90,6 +91,7 @@ class Preferences {
     static var hideShowAppShortcut: String { defaults.string("hideShowAppShortcut") }
     static var arrowKeysEnabled: Bool { defaults.bool("arrowKeysEnabled") }
     static var mouseHoverEnabled: Bool { defaults.bool("mouseHoverEnabled") }
+    static var cursorFollowFocusEnabled: Bool { defaults.bool("cursorFollowFocusEnabled") }
     static var showTabsAsWindows: Bool { defaults.bool("showTabsAsWindows") }
     static var hideColoredCircles: Bool { defaults.bool("hideColoredCircles") }
     static var windowDisplayDelay: DispatchTimeInterval { DispatchTimeInterval.milliseconds(defaults.int("windowDisplayDelay")) }

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -189,10 +189,26 @@ class App: AppCenterApplication, NSApplicationDelegate {
         KeyRepeatTimer.toggleRepeatingKeyPreviousWindow()
     }
 
-    func focusSelectedWindow(_ window: Window?) {
+    func focusSelectedWindow(_ selectedWindow: Window?) {
         hideUi()
         guard !CGWindow.isMissionControlActive() else { return }
-        window?.focus()
+        guard let window = selectedWindow else { return }
+
+        window.focus()
+        if Preferences.cursorFollowFocusEnabled {
+            moveCursorToSelectedWindow(window)
+        }
+    }
+
+    func moveCursorToSelectedWindow(_ window: Window) {
+        guard let position = window.position, let size = window.size else { return }
+
+        let point = CGPoint(
+            x: position.x + size.width / 2,
+            y: position.y + size.height / 2
+        )
+
+        CGWarpMouseCursorPosition(point)
     }
 
     func reopenUi() {

--- a/src/ui/preferences-window/tabs/ControlsTab.swift
+++ b/src/ui/preferences-window/tabs/ControlsTab.swift
@@ -32,8 +32,11 @@ class ControlsTab {
         let hideShowAppShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Hide/Show app", comment: ""), "hideShowAppShortcut", Preferences.hideShowAppShortcut, labelPosition: .right)
         let enableArrows = LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Arrow keys", comment: ""), "arrowKeysEnabled", extraAction: ControlsTab.arrowKeysEnabledCallback, labelPosition: .right)
         let enableMouse = LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Mouse hover", comment: ""), "mouseHoverEnabled", labelPosition: .right)
-        let checkboxesExplanations = LabelAndControl.makeLabel(NSLocalizedString("Also select windows using:", comment: ""))
-        let checkboxes = StackView([StackView(enableArrows), StackView(enableMouse)], .vertical)
+        let enableCursorFollowFocus = LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Cursor follows focus", comment: ""), "cursorFollowFocusEnabled", labelPosition: .right)
+        let selectWindowcheckboxesExplanations = LabelAndControl.makeLabel(NSLocalizedString("Also select windows using:", comment: ""))
+        let selectWindowCheckboxes = StackView([StackView(enableArrows), StackView(enableMouse)], .vertical)
+        let miscCheckboxesExplanations = LabelAndControl.makeLabel(NSLocalizedString("Miscellaneous:", comment: ""))
+        let miscCheckboxes = StackView([StackView(enableCursorFollowFocus)], .vertical)
         let shortcuts = StackView([focusWindowShortcut, previousWindowShortcut, cancelShortcut, closeWindowShortcut, minDeminWindowShortcut, quitAppShortcut, hideShowAppShortcut].map { (view: [NSView]) in StackView(view) }, .vertical)
         let orPress = LabelAndControl.makeLabel(NSLocalizedString("While open, press:", comment: ""), shouldFit: false)
         let (holdShortcut, nextWindowShortcut, tab1View) = toShowSection("")
@@ -48,7 +51,8 @@ class ControlsTab {
         let grid = GridView([
             [tabView],
             [orPress, shortcuts],
-            [checkboxesExplanations, checkboxes],
+            [selectWindowcheckboxesExplanations, selectWindowCheckboxes],
+            [miscCheckboxesExplanations, miscCheckboxes]
         ])
         grid.column(at: 0).xPlacement = .trailing
         grid.mergeCells(inHorizontalRange: NSRange(location: 0, length: 2), verticalRange: NSRange(location: 0, length: 1))


### PR DESCRIPTION
Addresses https://github.com/lwouis/alt-tab-macos/issues/1087

Adds user preference that makes the cursor follow the focus after _alt-tabbing_. In order to not confuse the users, this option is disabled by default.

Main motivation was integration with other shortcuts (like `⌃ + ←` or `⌃ + → ` in _mission control_) which work in context of the display on which the cursor is (regardless of focus). 

The solution also works across multiple displays, but I didn't know how to screen capture that :sweat_smile: 

![image](https://user-images.githubusercontent.com/22738928/151670339-1d96083f-e3d8-4795-a937-3130784b3d2b.png)
![Screen Recording 2022-01-29 at 18 10 39](https://user-images.githubusercontent.com/22738928/151670571-4d60934e-e16d-4d03-a2db-23469a583cc4.gif)
