### PR TITLE
fix issue #1249 #1079 #1392

### DIFF
--- a/src/logic/Application.swift
+++ b/src/logic/Application.swift
@@ -72,7 +72,7 @@ class Application: NSObject {
     }
 
     func addAndObserveWindows() {
-        if runningApplication.isFinishedLaunching && runningApplication.activationPolicy != .prohibited && axUiElement == nil {
+        if runningApplication.activationPolicy != .prohibited && axUiElement == nil {
             axUiElement = AXUIElementCreateApplication(pid)
             AXObserverCreate(pid, axObserverCallback, &axObserver)
             debugPrint("Adding app", pid ?? "nil", runningApplication.bundleIdentifier ?? "nil")


### PR DESCRIPTION
I am able to reproduce the issue by reinstall JetBrains AppCode. The first time I open AppCode after reinstall it, AltTab never show AppCode window. I debug the code on my Mac, I find that AltTab can get the event of app launched but never get the event of finishedLaunching. So I just remove the code runningApplication.isFinishedLaunching. After that, AltTab work well and the issue is fixed.

The following picture is the debug log when I reproduce this issue:
![image](https://user-images.githubusercontent.com/3339872/158782000-bccd0a36-1c3e-412c-8439-5508a4b62f30.png)


Thank you for opening a PR! Please make sure that:

* The title and description of the PR convey what the change is about, by mentioning the ticket it addresses for instance.
* The commits messages [follow the convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary), so your PR can be merged.
