### PR TITLE
Improve the Chinese translation of "Miscellaneous"

### DIFF
--- a/resources/l10n/zh-CN.lproj/Localizable.strings
+++ b/resources/l10n/zh-CN.lproj/Localizable.strings
@@ -192,7 +192,7 @@
 "Minimized windows:" = "最小化窗口：";
 
 /*No comment provided by engineer.*/
-"Miscellaneous:" = "混杂的：";
+"Miscellaneous:" = "杂项：";
 
 /*No comment provided by engineer.*/
 "Mouse hover" = "鼠标悬停";


### PR DESCRIPTION
The previous translation of "Miscellaneous" to Chinese takes the meaning when the word is used as an adj. The new translation takes the meaning when the word is used as a none. "杂项", when back-translated to English, is "Miscellaneous items", which can be derived as "Miscellaneous settings" based on the context. It is a more suitable translation in my opinion.

BTW: Loving this app! THANKS a lot to every contributor.