### PR TITLE
docs: update homebrew instructions for newer versions

### DIFF
--- a/docs/Introduction.md
+++ b/docs/Introduction.md
@@ -27,7 +27,8 @@ permalink: /
 
 Alternatively, you can use [homebrew](https://brew.sh/):
 
-* Homebrew 2.5 or above: `brew install alt-tab`
+* Homebrew 2.7 or above: `brew install --cask alt-tab`
+* Homebrew 2.6 or below and 2.5 or above: `brew install alt-tab`
 * Homebrew 2.4 or below: `brew cask install alt-tab`
 
 ## Compatibility


### PR DESCRIPTION
Since `brew cask install` has been disabled, you must use `brew install --cask`.

reference: https://github.com/ansible-collections/community.general/issues/1524

---

Best regards,
s4na

