### PR TITLE
fix: workaround for not responding on Ventura

### DIFF
--- a/src/logic/Applications.swift
+++ b/src/logic/Applications.swift
@@ -44,7 +44,9 @@ class Applications {
     static func addRunningApplications(_ runningApps: [NSRunningApplication]) {
         runningApps.forEach {
             if isActualApplication($0) {
-                Applications.list.append(Application($0))
+                var isCurrent = $0.processIdentifier == NSRunningApplication.current.processIdentifier
+
+                Applications.list.append(Application($0, isCurrent: isCurrent))
             }
         }
     }

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -242,12 +242,12 @@ class Preferences {
     @available(OSX, deprecated: 10.11)
     private static func migrateLoginItem() {
         do {
-            let loginItems = LSSharedFileListCreate(nil, kLSSharedFileListSessionLoginItems.takeRetainedValue(), nil).takeRetainedValue()
-            let loginItemsSnapshot = LSSharedFileListCopySnapshot(loginItems, nil).takeRetainedValue() as! [LSSharedFileListItem]
+            let loginItems = LSSharedFileListCreate(nil, kLSSharedFileListSessionLoginItems.takeRetainedValue(), nil)!.takeRetainedValue()
+            let loginItemsSnapshot = LSSharedFileListCopySnapshot(loginItems, nil)!.takeRetainedValue() as! [LSSharedFileListItem]
             let itemName = Bundle.main.bundleURL.lastPathComponent as CFString
             let itemUrl = URL(fileURLWithPath: Bundle.main.bundlePath) as CFURL
             loginItemsSnapshot.forEach {
-                if (LSSharedFileListItemCopyDisplayName($0)?.takeRetainedValue() == itemName) ||
+                if (LSSharedFileListItemCopyDisplayName($0).takeRetainedValue() == itemName) ||
                        (LSSharedFileListItemCopyResolvedURL($0, 0, nil)?.takeRetainedValue() == itemUrl) {
                     LSSharedFileListItemRemove(loginItems, $0)
                 }


### PR DESCRIPTION
Thanks to the discussion in https://github.com/lwouis/alt-tab-macos/issues/1852 and @Write's finding of self-observing being the issue, I narrowed it down further to some issue with `retryAxCallUntilTimeout()`. Something isn't happy about being put into a background queue and then back into the main queue when it's the AltTab application.

The "fix" here is to check if the current application is AltTab and subscribe to events directly instead of through `retryAxCallUntilTimeout()`.

A better long-term fix is probably to look into all the async stuff and see if it can be simplified, but this at least gets the app functional on Ventura again.
