### PR TITLE
Reorganize how window validity exceptions are checked and add ColorSlurp exception

### DIFF
--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -162,6 +162,7 @@
 		D04BAFB973C3D28718FAEB87 /* Windows.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BACD976030676FD0761D5 /* Windows.swift */; };
 		D04BAFBC862BA5FE0294EA7A /* AXUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA6F823BC0EDA9AA4B80A /* AXUIElement.swift */; };
 		D04BAFF30A98CF287F85DA1E /* BlacklistsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA27695D9A5824720BD7B /* BlacklistsTab.swift */; };
+		E0E22679AC8016061DC7523F /* WindowCheck.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E2272B0496A7706A22CA8E /* WindowCheck.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -421,6 +422,7 @@
 		D04BAF77F9D94C397EB646AE /* 1-row.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "1-row.jpg"; sourceTree = "<group>"; };
 		D04BAFA20F13FB588F6CCB81 /* bug_report.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = bug_report.md; sourceTree = "<group>"; };
 		D04BAFDA9E2623E21CBD6CEF /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = InfoPlist.strings; sourceTree = "<group>"; };
+		E0E2272B0496A7706A22CA8E /* WindowCheck.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowCheck.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -709,6 +711,7 @@
 				D04BA7E3EA104941FE76DA70 /* AppCenterCrashes.swift */,
 				BF0C864F182B6155A66D241D /* KeyRepeatTimer.swift */,
 				BF0C8BA452332236D972C60E /* ATShortcut.swift */,
+				E0E224EAAF8C1DCBEFBA41B0 /* windowcheck */,
 			);
 			path = logic;
 			sourceTree = "<group>";
@@ -1282,6 +1285,14 @@
 			path = docs;
 			sourceTree = "<group>";
 		};
+		E0E224EAAF8C1DCBEFBA41B0 /* windowcheck */ = {
+			isa = PBXGroup;
+			children = (
+				E0E2272B0496A7706A22CA8E /* WindowCheck.swift */,
+			);
+			path = windowcheck;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -1627,6 +1638,7 @@
 				BF0C8C7E96DB48120462DA00 /* TrafficLightButton.swift in Sources */,
 				BF0C898511686611E4D7D81E /* Button.swift in Sources */,
 				BF0C8E16F38203AEC71E062B /* TableView.swift in Sources */,
+				E0E22679AC8016061DC7523F /* WindowCheck.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/api-wrappers/AXUIElement.swift
+++ b/src/api-wrappers/AXUIElement.swift
@@ -7,6 +7,7 @@ import ApplicationServices.HIServices.AXAttributeConstants
 import ApplicationServices.HIServices.AXActionConstants
 
 // if the window server is busy, it may not reply to AX calls. We retry right before the call times-out and returns a bogus value
+
 func retryAxCallUntilTimeout(_ group: DispatchGroup? = nil, _ timeoutInSeconds: Double = Double(AXUIElement.globalTimeoutInSeconds), _ fn: @escaping () throws -> Void, _ startTime: DispatchTime = DispatchTime.now()) {
     group?.enter()
     BackgroundWork.axCallsQueue.async {
@@ -34,7 +35,10 @@ extension AXUIElement {
     // See https://humanbenchmark.com/tests/reactiontime
     static let retryDelayInMilliseconds = 250
 
+    static let minWindowSize = 100.0
+
     // default timeout for AX calls is 6s. We increase it in order to avoid retrying every 6s, thus saving resources
+
     static func setGlobalTimeout() {
         // we add 5s to make sure to not do an extra retry
         AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide(), globalTimeoutInSeconds + 5)
@@ -43,9 +47,9 @@ extension AXUIElement {
     func axCallWhichCanThrow<T>(_ result: AXError, _ successValue: inout T) throws -> T? {
         switch result {
             case .success: return successValue
-            // .cannotComplete can happen if the app is unresponsive; we throw in that case to retry until the call succeeds
+                // .cannotComplete can happen if the app is unresponsive; we throw in that case to retry until the call succeeds
             case .cannotComplete: throw AxError.runtimeError
-            // for other errors it's pointless to retry
+                // for other errors it's pointless to retry
             default: return nil
         }
     }
@@ -81,99 +85,16 @@ extension AXUIElement {
         // Activity Monitor main window subrole is "AXDialog" for a brief moment at launch; it then becomes "AXStandardWindow"
 
         // Some non-windows have cgWindowId == 0 (e.g. windows of apps starting at login with the checkbox "Hidden" checked)
+
+        let opts = WindowCheckOptions(runningApp: runningApp, title: title, subrole: subrole, wid: wid, level: level, role: role, size: size)
+
         return wid != 0 &&
-            size != nil && size!.width > 100 && size!.height > 100 &&
-            (books(runningApp) || keynote(runningApp) || iina(runningApp) || (
-                // CGWindowLevel == .normalWindow helps filter out iStats Pro and other top-level pop-overs, and floating windows
+                size != nil && size!.width > minWindowSize && size!.height > minWindowSize &&
                 level == CGWindow.normalLevel &&
-                    jetbrainApp(runningApp, title, subrole) &&
-                    ([kAXStandardWindowSubrole, kAXDialogSubrole].contains(subrole) ||
-                        openBoard(runningApp) ||
-                        adobeAudition(runningApp, subrole) ||
-                        steam(runningApp, title, role) ||
-                        worldOfWarcraft(runningApp, role) ||
-                        battleNetBootstrapper(runningApp, role) ||
-                        firefoxFullscreenVideo(runningApp, role) ||
-                        vlcFullscreenVideo(runningApp, role) ||
-                        androidEmulator(runningApp, title) ||
-                        sanGuoShaAirWD(runningApp) ||
-                        dvdFab(runningApp) ||
-                        drBetotte(runningApp))))
-    }
-
-    private static func jetbrainApp(_ runningApp: NSRunningApplication, _ title: String?, _ subrole: String?) -> Bool {
-        // jetbrain apps sometimes generate non-windows that pass all checks in isActualWindow
-        // they have no title, so we can filter them out based on that
-        return runningApp.bundleIdentifier?.range(of: "^com\\.(jetbrains\\.|google\\.android\\.studio).*?$", options: .regularExpression) == nil ||
-            (subrole == kAXStandardWindowSubrole || title != nil && title != "")
-    }
-
-    private static func iina(_ runningApp: NSRunningApplication) -> Bool {
-        // IINA.app can have videos float (level == 2 instead of 0)
-        // there is also complex animations during which we may or may not consider the window not a window
-        return runningApp.bundleIdentifier == "com.colliderli.iina"
-    }
-
-    private static func keynote(_ runningApp: NSRunningApplication) -> Bool {
-        // apple Keynote has a fake fullscreen window when in presentation mode
-        // it covers the screen with a AXUnknown window instead of using standard fullscreen mode
-        return runningApp.bundleIdentifier == "com.apple.iWork.Keynote"
-    }
-
-    private static func openBoard(_ runningApp: NSRunningApplication) -> Bool {
-        // OpenBoard is a ported app which doesn't use standard macOS windows
-        return runningApp.bundleIdentifier == "org.oe-f.OpenBoard"
-    }
-
-    private static func adobeAudition(_ runningApp: NSRunningApplication, _ subrole: String?) -> Bool {
-        return runningApp.bundleIdentifier == "com.adobe.Audition" && subrole == kAXFloatingWindowSubrole
-    }
-
-    private static func books(_ runningApp: NSRunningApplication) -> Bool {
-        // Books.app has animations on window creation. This means windows are originally created with subrole == AXUnknown or isOnNormalLevel == false
-        return runningApp.bundleIdentifier == "com.apple.iBooksX"
-    }
-
-    private static func worldOfWarcraft(_ runningApp: NSRunningApplication, _ role: String?) -> Bool {
-        return runningApp.bundleIdentifier == "com.blizzard.worldofwarcraft" && role == kAXWindowRole
-    }
-
-    private static func battleNetBootstrapper(_ runningApp: NSRunningApplication, _ role: String?) -> Bool {
-        // Battlenet bootstrapper windows have subrole == AXUnknown
-        return runningApp.bundleIdentifier == "net.battle.bootstrapper" && role == kAXWindowRole
-    }
-
-    private static func drBetotte(_ runningApp: NSRunningApplication) -> Bool {
-        return runningApp.bundleIdentifier == "com.ssworks.drbetotte"
-    }
-
-    private static func dvdFab(_ runningApp: NSRunningApplication) -> Bool {
-        return runningApp.bundleIdentifier == "com.goland.dvdfab.macos"
-    }
-
-    private static func sanGuoShaAirWD(_ runningApp: NSRunningApplication) -> Bool {
-        return runningApp.bundleIdentifier == "SanGuoShaAirWD"
-    }
-
-    private static func steam(_ runningApp: NSRunningApplication, _ title: String?, _ role: String?) -> Bool {
-        // All Steam windows have subrole == AXUnknown
-        // some dropdown menus are not desirable; they have title == "", or sometimes role == nil when switching between menus quickly
-        return runningApp.bundleIdentifier == "com.valvesoftware.steam" && title != "" && role != nil
-    }
-
-    private static func firefoxFullscreenVideo(_ runningApp: NSRunningApplication, _ role: String?) -> Bool {
-        // Firefox fullscreen video have subrole == AXUnknown if fullscreen'ed when the base window is not fullscreen
-        return (runningApp.bundleIdentifier?.hasPrefix("org.mozilla.firefox") ?? false) && role == kAXWindowRole
-    }
-
-    private static func vlcFullscreenVideo(_ runningApp: NSRunningApplication, _ role: String?) -> Bool {
-        // VLC fullscreen video have subrole == AXUnknown if fullscreen'ed
-        return (runningApp.bundleIdentifier?.hasPrefix("org.videolan.vlc") ?? false) && role == kAXWindowRole
-    }
-
-    private static func androidEmulator(_ runningApp: NSRunningApplication, _ title: String?) -> Bool {
-        // android emulator small vertical menu is a "window" with empty title; we exclude it
-        return title != "" && Applications.isAndroidEmulator(runningApp)
+                ([kAXStandardWindowSubrole, kAXDialogSubrole].contains(subrole) ||
+                        windowChecks.contains(where: { element in
+                            element.check(opts)
+                        }))
     }
 
     func position() throws -> CGPoint? {

--- a/src/logic/Applications.swift
+++ b/src/logic/Applications.swift
@@ -44,7 +44,9 @@ class Applications {
     static func addRunningApplications(_ runningApps: [NSRunningApplication]) {
         runningApps.forEach {
             if isActualApplication($0) {
-                Applications.list.append(Application($0))
+                var isCurrent = $0.processIdentifier == NSRunningApplication.current.processIdentifier
+
+                Applications.list.append(Application($0, isCurrent: isCurrent))
             }
         }
     }

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -242,12 +242,12 @@ class Preferences {
     @available(OSX, deprecated: 10.11)
     private static func migrateLoginItem() {
         do {
-            let loginItems = LSSharedFileListCreate(nil, kLSSharedFileListSessionLoginItems.takeRetainedValue(), nil).takeRetainedValue()
-            let loginItemsSnapshot = LSSharedFileListCopySnapshot(loginItems, nil).takeRetainedValue() as! [LSSharedFileListItem]
+            let loginItems = LSSharedFileListCreate(nil, kLSSharedFileListSessionLoginItems.takeRetainedValue(), nil)!.takeRetainedValue()
+            let loginItemsSnapshot = LSSharedFileListCopySnapshot(loginItems, nil)!.takeRetainedValue() as! [LSSharedFileListItem]
             let itemName = Bundle.main.bundleURL.lastPathComponent as CFString
             let itemUrl = URL(fileURLWithPath: Bundle.main.bundlePath) as CFURL
             loginItemsSnapshot.forEach {
-                if (LSSharedFileListItemCopyDisplayName($0)?.takeRetainedValue() == itemName) ||
+                if (LSSharedFileListItemCopyDisplayName($0).takeRetainedValue() == itemName) ||
                        (LSSharedFileListItemCopyResolvedURL($0, 0, nil)?.takeRetainedValue() == itemUrl) {
                     LSSharedFileListItemRemove(loginItems, $0)
                 }

--- a/src/logic/windowcheck/WindowCheck.swift
+++ b/src/logic/windowcheck/WindowCheck.swift
@@ -22,7 +22,8 @@ let windowChecks: [WindowCheck] = [
     SteamWindowCheck(),
     FirefoxFullscreenVideoWindowCheck(),
     VLCFullscreenVideoWindowCheck(),
-    AndroidEmulatorWindowCheck()
+    AndroidEmulatorWindowCheck(),
+    ColorSlurpWindowCheck()
 ]
 
 struct WindowCheckOptions {
@@ -185,5 +186,12 @@ class AndroidEmulatorWindowCheck : WindowCheck {
     override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
         // android emulator small vertical menu is a "window" with empty title; we exclude it
         return opts.title != "" && Applications.isAndroidEmulator(opts.runningApp)
+    }
+}
+
+class ColorSlurpWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        // ColorSlurp presents its dialog as a kAXSystemDialogSubrole, so we need a special check
+        return opts.runningApp.bundleIdentifier == "com.IdeaPunch.ColorSlurp"
     }
 }

--- a/src/logic/windowcheck/WindowCheck.swift
+++ b/src/logic/windowcheck/WindowCheck.swift
@@ -1,0 +1,189 @@
+//
+// Created by Zachary Wander on 8/14/22.
+// Copyright (c) 2022 lwouis. All rights reserved.
+//
+
+/**
+ The collection of all window checkers.
+ If a new check is created, its instance should be added here.
+ */
+let windowChecks: [WindowCheck] = [
+    JetBrainsWindowCheck(),
+    IINAWindowCheck(),
+    KeyNoteWindowCheck(),
+    OpenBoardWindowCheck(),
+    AdobeAuditionWindowCheck(),
+    BooksWindowCheck(),
+    WorldOfWarcraftWindowCheck(),
+    BattleNetBootstrapperWindowCheck(),
+    DrBetotteWindowCheck(),
+    DVDFabWindowCheck(),
+    SanGuoShaAirWDWindowCheck(),
+    SteamWindowCheck(),
+    FirefoxFullscreenVideoWindowCheck(),
+    VLCFullscreenVideoWindowCheck(),
+    AndroidEmulatorWindowCheck()
+]
+
+struct WindowCheckOptions {
+    var runningApp: NSRunningApplication
+    var title: String?
+    var subrole: String?
+    var wid: CGWindowID
+    var level: CGWindowLevel
+    var role: String?
+    var size: CGSize?
+}
+
+/**
+ The base class for performing a window exception check.
+ Subclasses should override [isValidWindow] and perform checks based
+ on the passed [WindowCheckOptions], returning true if the window should
+ show in the switcher.
+ */
+class WindowCheck {
+    func check(_ opts: WindowCheckOptions) -> Bool {
+        return isValidWindow(opts) && isValidSize(opts.size) && isValidLevel(opts.level)
+    }
+
+    /**
+     This allows for overriding the default requirements of windows being at least 100x100
+     to show in the switcher.
+     - Parameter size: the size of the window being checked.
+     - Returns: true if the window's size is correct.
+     */
+    func isValidSize(_ size: CGSize?) -> Bool {
+        return size != nil && size!.width > AXUIElement.minWindowSize && size!.height > AXUIElement.minWindowSize
+    }
+
+    /**
+     Most windows should only show in the switcher if they have a normal level.
+     Some apps (Books, KeyNote, IINA) should show up no matter their level.
+     - Parameter level: the current window level.
+     - Returns: true if the window's level is correct.
+     */
+    func isValidLevel(_ level: CGWindowLevel) -> Bool {
+        return level == CGWindow.normalLevel
+    }
+
+    func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        fatalError("Must override!")
+    }
+}
+
+class JetBrainsWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        // jetbrain apps sometimes generate non-windows that pass all checks in isActualWindow
+        // they have no title, so we can filter them out based on that
+        return opts.runningApp.bundleIdentifier?.range(of: "^com\\.(jetbrains\\.|google\\.android\\.studio).*?$", options: .regularExpression) != nil &&
+                (opts.subrole == kAXStandardWindowSubrole || opts.title != nil && opts.title != "")
+    }
+}
+
+class IINAWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        // IINA.app can have videos float (level == 2 instead of 0)
+        // there is also complex animations during which we may or may not consider the window not a window
+        return opts.runningApp.bundleIdentifier == "com.colliderli.iina"
+    }
+
+    override func isValidLevel(_ level: CGWindowLevel) -> Bool {
+        return true
+    }
+}
+
+class KeyNoteWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        // apple Keynote has a fake fullscreen window when in presentation mode
+        // it covers the screen with a AXUnknown window instead of using standard fullscreen mode
+        return opts.runningApp.bundleIdentifier == "com.apple.iWork.Keynote"
+    }
+
+    override func isValidLevel(_ level: CGWindowLevel) -> Bool {
+        return true
+    }
+}
+
+class OpenBoardWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        // OpenBoard is a ported app which doesn't use standard macOS windows
+        return opts.runningApp.bundleIdentifier == "org.oe-f.OpenBoard"
+    }
+}
+
+class AdobeAuditionWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        return opts.runningApp.bundleIdentifier == "com.adobe.Audition" && opts.subrole == kAXFloatingWindowSubrole
+    }
+}
+
+class BooksWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        // Books.app has animations on window creation. This means windows are originally created with subrole == AXUnknown or isOnNormalLevel == false
+        return opts.runningApp.bundleIdentifier == "com.apple.iBooksX"
+    }
+
+    override func isValidLevel(_ level: CGWindowLevel) -> Bool {
+        return true
+    }
+}
+
+class WorldOfWarcraftWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        return opts.runningApp.bundleIdentifier == "com.blizzard.worldofwarcraft" && opts.role == kAXWindowRole
+    }
+}
+
+class BattleNetBootstrapperWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        // Battlenet bootstrapper windows have subrole == AXUnknown
+        return opts.runningApp.bundleIdentifier == "net.battle.bootstrapper" && opts.role == kAXWindowRole
+    }
+}
+
+class DrBetotteWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        return opts.runningApp.bundleIdentifier == "com.ssworks.drbetotte"
+    }
+}
+
+class DVDFabWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        return opts.runningApp.bundleIdentifier == "com.goland.dvdfab.macos"
+    }
+}
+
+class SanGuoShaAirWDWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        return opts.runningApp.bundleIdentifier == "SanGuoShaAirWD"
+    }
+}
+
+class SteamWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        // All Steam windows have subrole == AXUnknown
+        // some dropdown menus are not desirable; they have title == "", or sometimes role == nil when switching between menus quickly
+        return opts.runningApp.bundleIdentifier == "com.valvesoftware.steam" && opts.title != "" && opts.role != nil
+    }
+}
+
+class FirefoxFullscreenVideoWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        // Firefox fullscreen video have subrole == AXUnknown if fullscreen'ed when the base window is not fullscreen
+        return (opts.runningApp.bundleIdentifier?.hasPrefix("org.mozilla.firefox") ?? false) && opts.role == kAXWindowRole
+    }
+}
+
+class VLCFullscreenVideoWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        // VLC fullscreen video have subrole == AXUnknown if fullscreen'ed
+        return (opts.runningApp.bundleIdentifier?.hasPrefix("org.videolan.vlc") ?? false) && opts.role == kAXWindowRole
+    }
+}
+
+class AndroidEmulatorWindowCheck : WindowCheck {
+    override func isValidWindow(_ opts: WindowCheckOptions) -> Bool {
+        // android emulator small vertical menu is a "window" with empty title; we exclude it
+        return opts.title != "" && Applications.isAndroidEmulator(opts.runningApp)
+    }
+}


### PR DESCRIPTION
This PR has 2 changes:

- I noticed that checking for exceptions for when to show windows is getting a little complex and hard to read. This PR extracts checks into separate WindowCheck sub-classes and iterates over those instances, instead of creating and ORing a new function in for every exception. I also added a provision for excepting smaller-than-100x100 windows in the future.
- ColorSlurp's picked-color dialog is meant to behave as a full window, but has an abnormal role. This adds an exception check to allow AltTab to show the ColorSlurp window.
