### PR TITLE
feat: Allow changing window sort from most recent to alphabetical

### DIFF
--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -31,6 +31,8 @@ class Preferences {
         "showHiddenWindows2": ShowHowPreference.show.rawValue,
         "showFullscreenWindows": ShowHowPreference.show.rawValue,
         "showFullscreenWindows2": ShowHowPreference.show.rawValue,
+        "sortWindows": SortHowPreference.lastUsed.rawValue,
+        "sortWindows2": SortHowPreference.lastUsed.rawValue,
         "showTabsAsWindows": "false",
         "hideColoredCircles": "false",
         "windowDisplayDelay": "0",
@@ -118,6 +120,7 @@ class Preferences {
     static var showMinimizedWindows: [ShowHowPreference] { ["showMinimizedWindows", "showMinimizedWindows2"].map { defaults.macroPref($0, ShowHowPreference.allCases) } }
     static var showHiddenWindows: [ShowHowPreference] { ["showHiddenWindows", "showHiddenWindows2"].map { defaults.macroPref($0, ShowHowPreference.allCases) } }
     static var showFullscreenWindows: [ShowHowPreference] { ["showFullscreenWindows", "showFullscreenWindows2"].map { defaults.macroPref($0, ShowHowPreference.allCases) } }
+    static var sortWindows: [SortHowPreference] { ["sortWindows", "sortWindows2"].map { defaults.macroPref($0, SortHowPreference.allCases) } }
     static var shortcutStyle: [ShortcutStylePreference] { ["shortcutStyle", "shortcutStyle2"].map { defaults.macroPref($0, ShortcutStylePreference.allCases) } }
     static var menubarIcon: MenubarIconPreference { defaults.macroPref("menubarIcon", MenubarIconPreference.allCases) }
 
@@ -426,6 +429,22 @@ enum ShortcutStylePreference: String, CaseIterable, MacroPreference {
         switch self {
             case .focusOnRelease: return NSLocalizedString("Focus selected window", comment: "")
             case .doNothingOnRelease: return NSLocalizedString("Do nothing", comment: "")
+        }
+    }
+}
+
+enum SortHowPreference: String, CaseIterable, MacroPreference {
+    case lastUsed = "0"
+    case lastOpened = "1"
+    case mostFrequently = "2"
+    case application = "3"
+
+    var localizedString: LocalizedString {
+        switch self {
+            case .lastUsed: return NSLocalizedString("Last Used", comment: "")
+            case .lastOpened: return NSLocalizedString("Last Opened", comment: "")
+            case .mostFrequently: return NSLocalizedString("Most Frequently Used", comment: "")
+            case .application: return NSLocalizedString("Name", comment: "")
         }
     }
 }

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -1,8 +1,11 @@
 import Cocoa
 
 class Window {
+    static var maxOpenedOrder = Int.zero
     var cgWindowId: CGWindowID?
     var lastFocusOrder = Int.zero
+    var lastOpenedOrder = Int.zero
+    var focusCount = Int.zero
     var title: String!
     var thumbnail: NSImage?
     var thumbnailFullSize: NSSize?
@@ -45,6 +48,8 @@ class Window {
         self.position = position
         self.size = size
         self.title = bestEffortTitle(axTitle)
+        Window.maxOpenedOrder += 1
+        self.lastOpenedOrder = Window.maxOpenedOrder
         if !Preferences.hideThumbnails {
             refreshThumbnail()
         }
@@ -58,6 +63,8 @@ class Window {
         isWindowlessApp = true
         self.application = application
         self.title = application.runningApplication.localizedName
+        Window.maxOpenedOrder += 1
+        self.lastOpenedOrder = Window.maxOpenedOrder
         debugPrint("Adding app-window", title ?? "nil", application.runningApplication.bundleIdentifier ?? "nil")
     }
 

--- a/src/ui/preferences-window/tabs/ControlsTab.swift
+++ b/src/ui/preferences-window/tabs/ControlsTab.swift
@@ -79,6 +79,7 @@ class ControlsTab {
         let toShowExplanations2 = LabelAndControl.makeLabel(NSLocalizedString("Minimized windows:", comment: ""))
         let toShowExplanations3 = LabelAndControl.makeLabel(NSLocalizedString("Hidden windows:", comment: ""))
         let toShowExplanations4 = LabelAndControl.makeLabel(NSLocalizedString("Fullscreen windows:", comment: ""))
+        let sortExplanations = LabelAndControl.makeLabel(NSLocalizedString("Sort windows by:", comment: ""))
         var holdShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Hold", comment: ""), "holdShortcut" + postfix, Preferences.holdShortcut[postfix == "" ? 0 : 1], false, labelPosition: .leftWithoutSeparator)
         holdShortcut.append(LabelAndControl.makeLabel(NSLocalizedString("and press:", comment: "")))
         let holdAndPress = StackView(holdShortcut)
@@ -88,6 +89,7 @@ class ControlsTab {
         let showMinimizedWindows = LabelAndControl.makeDropdown("showMinimizedWindows" + postfix, ShowHowPreference.allCases)
         let showHiddenWindows = LabelAndControl.makeDropdown("showHiddenWindows" + postfix, ShowHowPreference.allCases)
         let showFullscreenWindows = LabelAndControl.makeDropdown("showFullscreenWindows" + postfix, ShowHowPreference.allCases.filter { $0 != .showAtTheEnd })
+        let sortWindows = LabelAndControl.makeDropdown("sortWindows" + postfix, SortHowPreference.allCases)
         let separator = NSBox()
         separator.boxType = .separator
         let nextWindowShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Select next window", comment: ""), "nextWindowShortcut" + postfix, Preferences.nextWindowShortcut[postfix == "" ? 0 : 1], labelPosition: .right)
@@ -100,12 +102,13 @@ class ControlsTab {
             [toShowExplanations2, showMinimizedWindows],
             [toShowExplanations3, showHiddenWindows],
             [toShowExplanations4, showFullscreenWindows],
+            [sortExplanations, sortWindows],
             [separator],
             [holdAndPress, StackView(nextWindowShortcut)],
             shortcutStyle,
         ], TabView.padding)
         tab.column(at: 0).xPlacement = .trailing
-        tab.mergeCells(inHorizontalRange: NSRange(location: 0, length: 2), verticalRange: NSRange(location: 4, length: 1))
+        tab.mergeCells(inHorizontalRange: NSRange(location: 0, length: 2), verticalRange: NSRange(location: 5, length: 1))
         tab.fit()
         return (holdShortcut, nextWindowShortcut, tab)
     }


### PR DESCRIPTION
Add a now config option that allows the windows to be sorted recentFirst (as today) or alphabetical.

<img width="564" alt="2022-09-08 at 11 22 30@2x" src="https://user-images.githubusercontent.com/1904898/189197286-b4c9af0c-d4c7-432c-ad85-f50d20edf8a1.png">

