### PR TITLE
fix: shortcut tabs right margin

### DIFF
--- a/src/ui/preferences-window/LabelAndControl.swift
+++ b/src/ui/preferences-window/LabelAndControl.swift
@@ -193,11 +193,15 @@ class TabView: NSTabView, NSTabViewDelegate {
         self.init(frame: .zero)
         translatesAutoresizingMaskIntoConstraints = false
         labelsAndViews.enumerated().forEach { (i, tuple) in
+            let containerView = NSView()
+            containerView.addSubview(tuple.1)
+            containerView.widthAnchor.constraint(greaterThanOrEqualTo: tuple.1.widthAnchor).isActive = true
+            containerView.heightAnchor.constraint(greaterThanOrEqualTo: tuple.1.heightAnchor).isActive = true
             let tab = NSTabViewItem(identifier: i)
             tab.label = tuple.0
-            tab.view = tuple.1
+            tab.view = containerView
             addTabViewItem(tab)
-            tab.view!.fit()
+            tuple.1.fit()
         }
     }
 }

--- a/src/ui/preferences-window/tabs/ControlsTab.swift
+++ b/src/ui/preferences-window/tabs/ControlsTab.swift
@@ -59,6 +59,7 @@ class ControlsTab {
         grid.column(at: 0).xPlacement = .trailing
         grid.mergeCells(inHorizontalRange: NSRange(location: 0, length: 2), verticalRange: NSRange(location: 0, length: 1))
         grid.cell(atColumnIndex: 0, rowIndex: 0).xPlacement = .leading
+        tabView.rightAnchor.constraint(equalTo: grid.rightAnchor, constant: -GridView.padding).isActive = true
 
         // TODO: better layout logic. Maybe freeze the width of the preference window and have labels wrap on multiple lines
         // currently this looks bad if the right column inside the tabView is larger than the right column of the top gridView


### PR DESCRIPTION
Make the side margins of the shortcut tabs symmetrical.