### PR TITLE
fix: check if some shortcuts are triggerable

### DIFF
--- a/src/logic/Application.swift
+++ b/src/logic/Application.swift
@@ -125,9 +125,12 @@ class Application: NSObject {
         }
     }
 
-    func quit() {
+    func quit(_ alertSound: Bool = false) {
         // only let power users quit Finder if they opt-in
-        if runningApplication.bundleIdentifier == "com.apple.finder" && !Preferences.finderShowsQuitMenuItem { return }
+        if runningApplication.bundleIdentifier == "com.apple.finder" && !Preferences.finderShowsQuitMenuItem {
+            if alertSound { NSSound.beep() }
+            return
+        }
         if alreadyRequestedToQuit {
             runningApplication.forceTerminate()
         } else {

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -101,8 +101,11 @@ class Window {
         }
     }
 
-    func close() {
-        if isWindowlessApp { return }
+    func close(_ alertSound: Bool = false) {
+        if isWindowlessApp {
+            if alertSound { NSSound.beep() }
+            return
+        }
         BackgroundWork.accessibilityCommandsQueue.asyncWithCap { [weak self] in
             guard let self = self else { return }
             if self.isFullscreen {
@@ -114,8 +117,11 @@ class Window {
         }
     }
 
-    func minDemin() {
-        if isWindowlessApp { return }
+    func minDemin(_ alertSound: Bool = false) {
+        if isWindowlessApp || isTabbed {
+            if alertSound { NSSound.beep() }
+            return
+        }
         BackgroundWork.accessibilityCommandsQueue.asyncWithCap { [weak self] in
             guard let self = self else { return }
             if self.isFullscreen {

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -125,15 +125,15 @@ class App: AppCenterApplication, NSApplicationDelegate {
     }
 
     func closeSelectedWindow() {
-        Windows.focusedWindow()?.close()
+        Windows.focusedWindow()?.close(true)
     }
 
     func minDeminSelectedWindow() {
-        Windows.focusedWindow()?.minDemin()
+        Windows.focusedWindow()?.minDemin(true)
     }
 
     func quitSelectedApp() {
-        Windows.focusedWindow()?.application.quit()
+        Windows.focusedWindow()?.application.quit(true)
     }
 
     func hideShowSelectedApp() {


### PR DESCRIPTION
Check if some of the shortcuts are triggerable, add a "Toggle fullscreen window" shortcut, and add a "New window" shortcut and thumbnail button.

The colors of the "New window" thumbnail button are rather placeholders.