### PR TITLE
fix: hide some thumbnail buttons for tabs

### DIFF
--- a/src/ui/main-window/ThumbnailView.swift
+++ b/src/ui/main-window/ThumbnailView.swift
@@ -78,7 +78,8 @@ class ThumbnailView: NSStackView {
             [quitIcon, closeIcon, minimizeIcon, maximizeIcon].forEach { icon in
                 icon.isHidden = !shouldShow ||
                     ((window_?.isWindowlessApp ?? true) && icon.type != .quit) ||
-                    (icon.type == .quit && window_?.application.runningApplication.bundleIdentifier == "com.apple.finder" && !Preferences.finderShowsQuitMenuItem)
+                    (icon.type == .quit && window_?.application.runningApplication.bundleIdentifier == "com.apple.finder" && !Preferences.finderShowsQuitMenuItem) ||
+                    ((icon.type == .miniaturize || icon.type == .fullscreen) && (window_?.isTabbed ?? true))
                 if !icon.isHidden {
                     icon.setFrameOrigin(NSPoint(
                         x: 3 + (ThumbnailView.windowsControlSpacing + ThumbnailView.windowsControlSize) * offset,


### PR DESCRIPTION
Do not show the minimize and full screen thumbnail buttons on the tabs as they do not seem to work.