### PR TITLE
fix: update thumbnail size

### DIFF
--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -203,17 +203,10 @@ class Windows {
                     let window = list[currentIndex]
                     if window.shouldShowTheUser && !window.isWindowlessApp {
                         window.refreshThumbnail()
-                        DispatchQueue.main.async {
-                            let view = ThumbnailsView.recycledViews[currentIndex]
-                            if view.thumbnail.image != window.thumbnail {
-                                let oldSize = view.thumbnail.frame.size
-                                view.thumbnail.image = window.thumbnail
-                                view.thumbnail.image?.size = oldSize
-                                view.thumbnail.frame.size = oldSize
-                            }
-                        }
                     }
                     refreshThumbnailsAsync(screen, currentIndex + 1)
+                } else {
+                    DispatchQueue.main.async { App.app.refreshOpenUi() }
                 }
             }
         }


### PR DESCRIPTION
When a window is created, its thumbnail is not always ready (non-existent or in appearance animation). The thumbnails were correctly updated afterwards but not their display which forced the previous size.