### PR TITLE
fix: reduce flag event tap latency

### DIFF
--- a/src/logic/BackgroundWork.swift
+++ b/src/logic/BackgroundWork.swift
@@ -10,6 +10,7 @@ class BackgroundWork {
     static var mouseEventsThread: BackgroundThreadWithRunLoop!
     static var systemPermissionsThread: BackgroundThreadWithRunLoop!
     static var repeatingKeyThread: BackgroundThreadWithRunLoop!
+    static var keyboardEventsThread: BackgroundThreadWithRunLoop!
 
     // we cap concurrent tasks to .processorCount to avoid thread explosion on the .global queue
     static let globalSemaphore = DispatchSemaphore(value: ProcessInfo.processInfo.processorCount)
@@ -25,6 +26,7 @@ class BackgroundWork {
         accessibilityEventsThread = BackgroundThreadWithRunLoop("accessibilityEventsThread", .userInteractive)
         mouseEventsThread = BackgroundThreadWithRunLoop("mouseEventsThread", .userInteractive)
         repeatingKeyThread = BackgroundThreadWithRunLoop("repeatingKeyThread", .userInteractive)
+        keyboardEventsThread = BackgroundThreadWithRunLoop("keyboardEventsThread", .userInteractive)
     }
 
     static func startSystemPermissionThread() {

--- a/src/logic/events/KeyboardEvents.swift
+++ b/src/logic/events/KeyboardEvents.swift
@@ -92,7 +92,7 @@ class KeyboardEvents {
             userInfo: nil)
         if let eventTap = eventTap {
             let runLoopSource = CFMachPortCreateRunLoopSource(nil, eventTap, 0)
-            CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+            CFRunLoopAddSource(BackgroundWork.keyboardEventsThread.runLoop, runLoopSource, .commonModes)
         } else {
             App.app.restart()
         }
@@ -134,10 +134,12 @@ class KeyboardEvents {
 @discardableResult
 fileprivate func handleEvent(_ id: EventHotKeyID?, _ shortcutState: ShortcutState?, _ keyCode: UInt32?, _ modifiers: UInt32?, _ isARepeat: Bool) -> Bool {
     var someShortcutTriggered = false
-    for shortcut in ControlsTab.shortcuts.values {
-        if shortcut.matches(id, shortcutState, keyCode, modifiers, isARepeat) && shortcut.shouldTrigger() {
-            shortcut.executeAction(isARepeat)
-            someShortcutTriggered = true
+    ControlsTab.shortcutsLock.withLock {
+        for shortcut in ControlsTab.shortcuts.values {
+            if shortcut.matches(id, shortcutState, keyCode, modifiers, isARepeat) && shortcut.shouldTrigger() {
+                shortcut.executeAction(isARepeat)
+                someShortcutTriggered = true
+            }
         }
     }
     return someShortcutTriggered

--- a/src/ui/preferences-window/tabs/ControlsTab.swift
+++ b/src/ui/preferences-window/tabs/ControlsTab.swift
@@ -3,6 +3,7 @@ import ShortcutRecorder
 
 class ControlsTab {
     static var shortcuts = [String: ATShortcut]()
+    static var shortcutsLock = NSLock()
     static var shortcutControls = [String: (CustomRecorderControl, String)]()
     static var shortcutsActions = [
         "holdShortcut": { App.app.focusTarget() },
@@ -129,7 +130,9 @@ class ControlsTab {
     private static func addShortcut(_ triggerPhase: ShortcutTriggerPhase, _ scope: ShortcutScope, _ shortcut: Shortcut, _ controlId: String, _ index: Int?) {
         let atShortcut = ATShortcut(shortcut, controlId, scope, triggerPhase, index)
         removeShortcutIfExists(controlId) // remove the previous shortcut
-        shortcuts[controlId] = atShortcut
+        shortcutsLock.withLock {
+            shortcuts[controlId] = atShortcut
+        }
         if scope == .global {
             KeyboardEvents.addGlobalShortcut(controlId, atShortcut.shortcut)
         }
@@ -220,7 +223,9 @@ class ControlsTab {
             if atShortcut.scope == .global {
                 KeyboardEvents.removeGlobalShortcut(controlId, atShortcut.shortcut)
             }
-            shortcuts.removeValue(forKey: controlId)
+            shortcutsLock.withLock {
+                shortcuts.removeValue(forKey: controlId)
+            }
         }
     }
 }


### PR DESCRIPTION
Using a dedicated thread. Too high latency of an event tap can affect other apps.