### PR TITLE
fix: exclude org.mozilla.plugincontainer

### DIFF
--- a/src/logic/Applications.swift
+++ b/src/logic/Applications.swift
@@ -110,7 +110,7 @@ class Applications {
     private static func isActualApplication(_ app: NSRunningApplication) -> Bool {
         // an app can start with .activationPolicy == .prohibited, then transition to != .prohibited later
         // an app can be both activationPolicy == .accessory and XPC (e.g. com.apple.dock.etci)
-        return (isNotXpc(app) || isAndroidEmulator(app)) && !app.processIdentifier.isZombie()
+        return (isNotXpc(app) || isAndroidEmulator(app)) && !app.processIdentifier.isZombie() && !isInvalidActivationPolicy(app)
     }
 
     private static func isNotXpc(_ app: NSRunningApplication) -> Bool {
@@ -126,6 +126,12 @@ class Applications {
     // e.g. hiding the thumbnails panel gives focus to the preferences panel if open, thus changing its order in the list
     private static func notAltTab(_ app: NSRunningApplication) -> Bool {
         return app.processIdentifier != ProcessInfo.processInfo.processIdentifier
+    }
+
+    // these apps report their activationPolicy as accessory but do not support AXObserverAddNotification
+    private static func isInvalidActivationPolicy(_ app: NSRunningApplication) -> Bool {
+        let bundleId = app.bundleIdentifier
+        return app.activationPolicy == .accessory && bundleId == "org.mozilla.plugincontainer"
     }
 
     static func isAndroidEmulator(_ app: NSRunningApplication) -> Bool {


### PR DESCRIPTION
As a special case, make Applications.isActualApplication return false for Firefox plugincontainer so that it is not observed with the accessibility API. These processes do not support AX observer notifications although they report activationPolicy=accessory.

ref:
https://developer.apple.com/documentation/appkit/nsapplication/activationpolicy/accessory

github: fix #2225

Thank you for opening a PR! Please make sure that:

* The title and description of the PR convey what the change is about, by mentioning the ticket it addresses for instance.
* The commits messages [follow the convention](https://www.conventionalcommits.org/en/v1.0.0-beta.4/#summary), so your PR can be merged.
