### PR TITLE
feat: Add search bar

### DIFF
--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -95,7 +95,7 @@ class Windows {
         let focusedView = ThumbnailsView.recycledViews[focusedWindowIndex]
         focusedView.highlight(true)
         App.app.thumbnailsPanel.thumbnailsView.scrollView.contentView.scrollToVisible(focusedView.frame)
-        voiceOverFocusedWindow()
+        // voiceOverFocusedWindow()
     }
 
     static func voiceOverFocusedWindow() {
@@ -230,7 +230,8 @@ class Windows {
             } ?? false) &&
             !(Preferences.appsToShow[App.app.shortcutIndex] == .active && window.application.runningApplication.processIdentifier != NSWorkspace.shared.frontmostApplication?.processIdentifier) &&
             !(!(Preferences.showHiddenWindows[App.app.shortcutIndex] != .hide) && window.isHidden) &&
-            (searchText.isEmpty || (window.title?.contains(searchText) ?? true)) &&
+            (searchText.isEmpty || (window.title?.lowercased().contains(searchText) ?? true) ||
+             (window.application.runningApplication.localizedName?.lowercased().contains(searchText)) ?? true) &&
             ((!Preferences.hideWindowlessApps && window.isWindowlessApp) ||
                 !window.isWindowlessApp &&
                 !(!(Preferences.showFullscreenWindows[App.app.shortcutIndex] != .hide) && window.isFullscreen) &&

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -220,6 +220,7 @@ class Windows {
     }
 
     static func refreshIfWindowShouldBeShownToTheUser(_ window: Window, _ screen: NSScreen) {
+        let searchText = App.app.thumbnailsPanel.thumbnailsView.searchField.stringValue
         window.shouldShowTheUser =
             !(window.application.runningApplication.bundleIdentifier.flatMap { id in
                 Preferences.blacklist.contains {
@@ -229,6 +230,7 @@ class Windows {
             } ?? false) &&
             !(Preferences.appsToShow[App.app.shortcutIndex] == .active && window.application.runningApplication.processIdentifier != NSWorkspace.shared.frontmostApplication?.processIdentifier) &&
             !(!(Preferences.showHiddenWindows[App.app.shortcutIndex] != .hide) && window.isHidden) &&
+            (searchText.isEmpty || (window.title?.contains(searchText) ?? true)) &&
             ((!Preferences.hideWindowlessApps && window.isWindowlessApp) ||
                 !window.isWindowlessApp &&
                 !(!(Preferences.showFullscreenWindows[App.app.shortcutIndex] != .hide) && window.isFullscreen) &&

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -269,6 +269,7 @@ class App: AppCenterApplication, NSApplicationDelegate {
             Windows.updateSpaces()
             let screen = NSScreen.preferred()
             self.shortcutIndex = shortcutIndex
+            thumbnailsPanel.thumbnailsView.searchField.stringValue = ""
             Windows.refreshWhichWindowsToShowTheUser(screen)
             Windows.reorderList()
             if (!Windows.list.contains { $0.shouldShowTheUser }) { hideUi(); return }

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -238,7 +238,7 @@ class App: AppCenterApplication, NSApplicationDelegate {
         thumbnailsPanel.display()
         guard appIsBeingUsed else { return }
         currentScreen.repositionPanel(thumbnailsPanel, .appleCentered)
-        Windows.voiceOverFocusedWindow() // at this point ThumbnailViews are assigned to the window, and ready
+        // Windows.voiceOverFocusedWindow() // at this point ThumbnailViews are assigned to the window, and ready
     }
 
     private func refreshSpecificWindows(_ windowsToUpdate: [Window]?, _ currentScreen: NSScreen) -> ()? {

--- a/src/ui/main-window/ThumbnailsView.swift
+++ b/src/ui/main-window/ThumbnailsView.swift
@@ -148,11 +148,7 @@ class ThumbnailsView: NSVisualEffectView {
         frame.size = NSSize(width: min(maxX, widthMax) + Preferences.windowPadding * 2, height: min(maxY, heightMax) + Preferences.windowPadding * 2)
 
         searchField.frame.size = NSSize(width: min(maxX, widthMax), height: 40)
-        searchField.becomeFirstResponder()
         searchField.frame.origin = CGPoint(x: Preferences.windowPadding, y: min(maxY, heightMax) - Preferences.windowPadding)
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
-            self.searchField.becomeFirstResponder()
-        }
 
         scrollView.frame.size = NSSize(width: min(maxX, widthMax), height: min(maxY, heightMax) - 40)
         scrollView.frame.origin = CGPoint(x: Preferences.windowPadding, y: Preferences.windowPadding)


### PR DESCRIPTION
Initially I wanted to integrate alt-tab with Alfred as per #768, this covered a bunch of different things I tried, including extracting the images, and trying to figure out cross process communication in some way, such as with CFMessagePort etc.
But I realised that the primary benefit was for searching and a lot of the ordering and filtering tools options are already available in alt tab under the commands, and you can add lots of commands.

I realised that ultimately the best way was to integrate directly inside alt-tab, where everything is already in memory and low latency. I also saw that there's some buy in to do this with #590 so making this as a draft PR. This is "enough" for me, but there are some issues such as the changing window size, commented out instructions, manually changing the params to fit my needs, but maybe can get some direction or get some help with this.