### PR TITLE
feat: add option to minimize other windows when switching

### DIFF
--- a/src/logic/ATShortcut.swift
+++ b/src/logic/ATShortcut.swift
@@ -64,7 +64,7 @@ class ATShortcut {
                 App.app.appIsBeingUsed = true
                 return true
             }
-            if triggerPhase == .up && App.app.appIsBeingUsed && (index == nil || index == App.app.shortcutIndex) && Preferences.shortcutStyle[App.app.shortcutIndex] == .focusOnRelease {
+            if triggerPhase == .up && App.app.appIsBeingUsed && (index == nil || index == App.app.shortcutIndex) && Preferences.shortcutStyle[App.app.shortcutIndex] != .doNothingOnRelease {
                 return true
             }
         }

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -28,6 +28,7 @@ class Preferences {
         "minDeminWindowShortcut": "M",
         "quitAppShortcut": "Q",
         "hideShowAppShortcut": "H",
+        "minimizeOtherWindowsShortcut": "1",
         "arrowKeysEnabled": "true",
         "mouseHoverEnabled": "true",
         "cursorFollowFocusEnabled": "false",
@@ -117,6 +118,7 @@ class Preferences {
     static var minDeminWindowShortcut: String { defaults.string("minDeminWindowShortcut") }
     static var quitAppShortcut: String { defaults.string("quitAppShortcut") }
     static var hideShowAppShortcut: String { defaults.string("hideShowAppShortcut") }
+    static var minimizeOtherWindowsShortcut: String { defaults.string("minimizeOtherWindowsShortcut") }
     static var arrowKeysEnabled: Bool { defaults.bool("arrowKeysEnabled") }
     static var mouseHoverEnabled: Bool { defaults.bool("mouseHoverEnabled") }
     static var cursorFollowFocusEnabled: Bool { defaults.bool("cursorFollowFocusEnabled") }
@@ -458,11 +460,13 @@ enum MenubarIconPreference: String, CaseIterable, MacroPreference {
 enum ShortcutStylePreference: String, CaseIterable, MacroPreference {
     case focusOnRelease = "0"
     case doNothingOnRelease = "1"
+    case minimizeOthersOnRelease = "2"
 
     var localizedString: LocalizedString {
         switch self {
             case .focusOnRelease: return NSLocalizedString("Focus selected window", comment: "")
             case .doNothingOnRelease: return NSLocalizedString("Do nothing", comment: "")
+            case .minimizeOthersOnRelease: return NSLocalizedString("Minimize other windows", comment: "")
         }
     }
 }

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -114,6 +114,14 @@ class Windows {
         return list.count > focusedWindowIndex ? list[focusedWindowIndex] : nil
     }
 
+    static func minimizeOtherWindows() {
+        Windows.list.enumerated().forEach {
+            if $0.offset != focusedWindowIndex && !$0.element.isMinimized && !$0.element.isWindowlessApp && $0.element.shouldShowTheUser {
+                $0.element.minDemin()
+            }
+        }
+    }
+
     static func cycleFocusedWindowIndex(_ step: Int) {
         let nextIndex = windowIndexAfterCycling(step)
         if ((step > 0 && nextIndex < focusedWindowIndex) || (step < 0 && nextIndex > focusedWindowIndex)) &&

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -149,9 +149,24 @@ class App: AppCenterApplication, NSApplicationDelegate {
         Windows.focusedWindow()?.application.hideOrShow()
     }
 
+    func minimizeOtherWindows() {
+        debugPrint("minimizeOtherWindows")
+        Windows.minimizeOtherWindows()
+    }
+
     func focusTarget() {
         debugPrint("focusTarget")
         focusSelectedWindow(Windows.focusedWindow())
+    }
+    
+    func handleHold(_ shortcutIndex: Int) {
+        let shortcutStyle = Preferences.shortcutStyle[shortcutIndex]
+        if shortcutStyle == .focusOnRelease {
+            focusTarget()
+        } else if shortcutStyle == .minimizeOthersOnRelease {
+            minimizeOtherWindows()
+            focusTarget()
+        }
     }
 
     @objc func checkForUpdatesNow(_ sender: NSMenuItem) {

--- a/src/ui/preferences-window/tabs/ControlsTab.swift
+++ b/src/ui/preferences-window/tabs/ControlsTab.swift
@@ -5,11 +5,11 @@ class ControlsTab {
     static var shortcuts = [String: ATShortcut]()
     static var shortcutControls = [String: (CustomRecorderControl, String)]()
     static var shortcutsActions = [
-        "holdShortcut": { App.app.focusTarget() },
-        "holdShortcut2": { App.app.focusTarget() },
-        "holdShortcut3": { App.app.focusTarget() },
-        "holdShortcut4": { App.app.focusTarget() },
-        "holdShortcut5": { App.app.focusTarget() },
+        "holdShortcut": { App.app.handleHold(0) },
+        "holdShortcut2": { App.app.handleHold(1) },
+        "holdShortcut3": { App.app.handleHold(2) },
+        "holdShortcut4": { App.app.handleHold(3) },
+        "holdShortcut5": { App.app.handleHold(4) },
         "focusWindowShortcut": { App.app.focusTarget() },
         "nextWindowShortcut": { App.app.showUiOrCycleSelection(0) },
         "nextWindowShortcut2": { App.app.showUiOrCycleSelection(1) },
@@ -26,6 +26,7 @@ class ControlsTab {
         "minDeminWindowShortcut": { App.app.minDeminSelectedWindow() },
         "quitAppShortcut": { App.app.quitSelectedApp() },
         "hideShowAppShortcut": { App.app.hideShowSelectedApp() },
+        "minimizeOtherWindowsShortcut": { App.app.minimizeOtherWindows() },
     ]
     static var arrowKeysCheckbox: NSButton!
 
@@ -37,6 +38,7 @@ class ControlsTab {
         let minDeminWindowShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Minimize/Deminimize window", comment: ""), "minDeminWindowShortcut", Preferences.minDeminWindowShortcut, labelPosition: .right)
         let quitAppShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Quit app", comment: ""), "quitAppShortcut", Preferences.quitAppShortcut, labelPosition: .right)
         let hideShowAppShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Hide/Show app", comment: ""), "hideShowAppShortcut", Preferences.hideShowAppShortcut, labelPosition: .right)
+        let minimizeOtherWindowsShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Minimize other windows", comment: ""), "minimizeOtherWindowsShortcut", Preferences.minimizeOtherWindowsShortcut, labelPosition: .right)
         let enableArrows = LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Arrow keys", comment: ""), "arrowKeysEnabled", extraAction: ControlsTab.arrowKeysEnabledCallback, labelPosition: .right)
         arrowKeysCheckbox = enableArrows[0] as? NSButton
         let enableMouse = LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Mouse hover", comment: ""), "mouseHoverEnabled", labelPosition: .right)
@@ -45,7 +47,7 @@ class ControlsTab {
         let selectWindowCheckboxes = StackView([StackView(enableArrows), StackView(enableMouse)], .vertical)
         let miscCheckboxesExplanations = LabelAndControl.makeLabel(NSLocalizedString("Miscellaneous:", comment: ""))
         let miscCheckboxes = StackView([StackView(enableCursorFollowFocus)], .vertical)
-        let shortcuts = StackView([focusWindowShortcut, previousWindowShortcut, cancelShortcut, closeWindowShortcut, minDeminWindowShortcut, quitAppShortcut, hideShowAppShortcut].map { (view: [NSView]) in StackView(view) }, .vertical)
+        let shortcuts = StackView([focusWindowShortcut, previousWindowShortcut, cancelShortcut, closeWindowShortcut, minDeminWindowShortcut, quitAppShortcut, hideShowAppShortcut, minimizeOtherWindowsShortcut].map { (view: [NSView]) in StackView(view) }, .vertical)
         let orPress = LabelAndControl.makeLabel(NSLocalizedString("While open, press:", comment: ""), shouldFit: false)
         let (holdShortcut, nextWindowShortcut, tab1View) = toShowSection(0)
         let (holdShortcut2, nextWindowShortcut2, tab2View) = toShowSection(1)


### PR DESCRIPTION
This PR adds a feature to minimise other windows, both as an intentional action from the switching window, and as a configurable default action when completing a switch.

I'm not sure you'll want to keep adding features to AltTab until it becomes all things to all people, so I won't be offended if you'd prefer not to add this functionality :-) There do look to be a few requests for something similar: https://github.com/lwouis/alt-tab-macos/issues/1530, https://github.com/lwouis/alt-tab-macos/issues/1902, https://github.com/lwouis/alt-tab-macos/issues/2086 . These FRs asked for the ability to *hide* other apps on switching, but that feels like quite a heavy action on MacOS - hiding all windows across all spaces - whereas minimising other windows can be implemented in a way that just applies to the set of windows that the current AltTab action is applying to, whether that be a single space or all spaces.

I've tried to change the existing logic as little as possible, as my impression is that it's probably been polished in the face of a thousand edge cases! I'm not sure the implementation is as clean as it could be, and we could happily streamline it if you're happy to risk changing the logic more (in particular, the thing that could be cleaned up, I think, is how the "action" to either focus the selected window, or minimise the other windows is triggered inside `ATShortcut` when the `triggerPhase` is `up`).