### PR TITLE
fix: use plain number formatter for initial slider label

### DIFF
--- a/src/ui/preferences-window/LabelAndControl.swift
+++ b/src/ui/preferences-window/LabelAndControl.swift
@@ -66,7 +66,9 @@ class LabelAndControl: NSObject {
 
     static func makeLabelWithSlider(_ labelText: String, _ rawName: String, _ minValue: Double, _ maxValue: Double, _ numberOfTickMarks: Int, _ allowsTickMarkValuesOnly: Bool, _ unitText: String = "", extraAction: ActionClosure? = nil) -> [NSView] {
         let value = defaults.double(rawName)
-        let suffixText = MeasurementFormatter().string(from: Measurement(value: value, unit: Unit(symbol: unitText)))
+        let formatter = MeasurementFormatter()
+        formatter.numberFormatter = NumberFormatter()
+        let suffixText = formatter.string(from: Measurement(value: value, unit: Unit(symbol: unitText)))
         let slider = NSSlider()
         slider.minValue = minValue
         slider.maxValue = maxValue


### PR DESCRIPTION
Fixes an issue where a slider's label value is not updated correctly if it is initially formatted with grouping.

How to reproduce:
- Set the appearance delay to >= 1000 ms.
- Restart AltTab.
- Update the appearance delay.