### PR TITLE
fix: close preview window after focus completed

### DIFF
--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -178,6 +178,7 @@ class Window {
         } else if let bundleID = application.runningApplication.bundleIdentifier, bundleID == App.id {
             App.shared.activate(ignoringOtherApps: true)
             App.app.window(withWindowNumber: Int(cgWindowId!))?.makeKeyAndOrderFront(nil)
+            Windows.previewFocusedWindowIfNeeded()
         } else {
             // macOS bug: when switching to a System Preferences window in another space, it switches to that space,
             // but quickly switches back to another window in that space
@@ -189,6 +190,9 @@ class Window {
                 _SLPSSetFrontProcessWithOptions(&psn, self.cgWindowId!, SLPSMode.userGenerated.rawValue)
                 self.makeKeyWindow(psn)
                 self.axUiElement.focusWindow()
+                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
+                    Windows.previewFocusedWindowIfNeeded()
+                }
             }
         }
     }

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -109,13 +109,15 @@ class App: AppCenterApplication, NSApplicationDelegate {
         App.shared.terminate(self)
     }
 
-    func hideUi() {
+    func hideUi(_ keepPreview: Bool = false) {
         debugPrint("hideUi")
         appIsBeingUsed = false
         isFirstSummon = true
         MouseEvents.toggle(false)
         hideThumbnailPanelWithoutChangingKeyWindow()
-        previewPanel.orderOut(nil)
+        if !keepPreview {
+            previewPanel.orderOut(nil)
+        }
         hideAllTooltips()
     }
 
@@ -201,8 +203,11 @@ class App: AppCenterApplication, NSApplicationDelegate {
     }
 
     func focusSelectedWindow(_ selectedWindow: Window?) {
-        hideUi()
-        guard let window = selectedWindow, !CGWindow.isMissionControlActive() else { return }
+        hideUi(true)
+        guard let window = selectedWindow, !CGWindow.isMissionControlActive() else {
+            previewPanel.orderOut(nil)
+            return
+        }
         window.focus()
         if Preferences.cursorFollowFocusEnabled {
             moveCursorToSelectedWindow(window)


### PR DESCRIPTION
Tries to fix #2432. I'm not sure if the 50ms delay is enough. I tried waiting for kAXFocusedWindowChangedNotification but there was still flickering and it was more complicated.