### PR TITLE
feat: allow choosing windows order

### DIFF
--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -47,11 +47,11 @@ class Preferences {
         "showFullscreenWindows3": ShowHowPreference.show.rawValue,
         "showFullscreenWindows4": ShowHowPreference.show.rawValue,
         "showFullscreenWindows5": ShowHowPreference.show.rawValue,
-        "windowOrder": WindowOrderPreference.lastUsed.rawValue,
-        "windowOrder2": WindowOrderPreference.lastUsed.rawValue,
-        "windowOrder3": WindowOrderPreference.lastUsed.rawValue,
-        "windowOrder4": WindowOrderPreference.lastUsed.rawValue,
-        "windowOrder5": WindowOrderPreference.lastUsed.rawValue,
+        "windowOrder": WindowOrderPreference.lastFocused.rawValue,
+        "windowOrder2": WindowOrderPreference.lastFocused.rawValue,
+        "windowOrder3": WindowOrderPreference.lastFocused.rawValue,
+        "windowOrder4": WindowOrderPreference.lastFocused.rawValue,
+        "windowOrder5": WindowOrderPreference.lastFocused.rawValue,
         "showTabsAsWindows": "false",
         "hideColoredCircles": "false",
         "windowDisplayDelay": "0",
@@ -486,16 +486,16 @@ enum ShowHowPreference: String, CaseIterable, MacroPreference {
 }
 
 enum WindowOrderPreference: String, CaseIterable, MacroPreference {
-    case lastUsed = "0"
+    case lastFocused = "0"
     case lastCreated = "1"
     case alphabetical = "2"
     case alphabeticalBySpace = "3"
     
     var localizedString: LocalizedString{
         switch self{
-            case .lastUsed: return NSLocalizedString("Last Used", comment: "")
-            case .lastCreated: return NSLocalizedString("Last Opened", comment: "")
-            case .alphabetical: return NSLocalizedString("Name", comment: "")
+            case .lastFocused: return NSLocalizedString("Last Focused", comment: "")
+            case .lastCreated: return NSLocalizedString("Last Created", comment: "")
+            case .alphabetical: return NSLocalizedString("Alphabetical", comment: "")
             case .alphabeticalBySpace: return NSLocalizedString("Space", comment: "")
         }
     }

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -487,16 +487,14 @@ enum ShowHowPreference: String, CaseIterable, MacroPreference {
 
 enum WindowOrderPreference: String, CaseIterable, MacroPreference {
     case lastUsed = "0"
-    case lastOpened = "1"
-    case mostFrequently = "2"
-    case alphabetical = "3"
-    case alphabeticalBySpace = "4"
+    case lastCreated = "1"
+    case alphabetical = "2"
+    case alphabeticalBySpace = "3"
     
     var localizedString: LocalizedString{
         switch self{
             case .lastUsed: return NSLocalizedString("Last Used", comment: "")
-            case .lastOpened: return NSLocalizedString("Last Opened", comment: "")
-            case .mostFrequently: return NSLocalizedString("Most Frequently", comment: "")
+            case .lastCreated: return NSLocalizedString("Last Opened", comment: "")
             case .alphabetical: return NSLocalizedString("Name", comment: "")
             case .alphabeticalBySpace: return NSLocalizedString("Space", comment: "")
         }

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -47,6 +47,11 @@ class Preferences {
         "showFullscreenWindows3": ShowHowPreference.show.rawValue,
         "showFullscreenWindows4": ShowHowPreference.show.rawValue,
         "showFullscreenWindows5": ShowHowPreference.show.rawValue,
+        "windowOrder": WindowOrderPreference.lastUsed.rawValue,
+        "windowOrder2": WindowOrderPreference.lastUsed.rawValue,
+        "windowOrder3": WindowOrderPreference.lastUsed.rawValue,
+        "windowOrder4": WindowOrderPreference.lastUsed.rawValue,
+        "windowOrder5": WindowOrderPreference.lastUsed.rawValue,
         "showTabsAsWindows": "false",
         "hideColoredCircles": "false",
         "windowDisplayDelay": "0",
@@ -148,6 +153,8 @@ class Preferences {
     static var showMinimizedWindows: [ShowHowPreference] { ["showMinimizedWindows", "showMinimizedWindows2", "showMinimizedWindows3", "showMinimizedWindows4", "showMinimizedWindows5"].map { defaults.macroPref($0, ShowHowPreference.allCases) } }
     static var showHiddenWindows: [ShowHowPreference] { ["showHiddenWindows", "showHiddenWindows2", "showHiddenWindows3", "showHiddenWindows4", "showHiddenWindows5"].map { defaults.macroPref($0, ShowHowPreference.allCases) } }
     static var showFullscreenWindows: [ShowHowPreference] { ["showFullscreenWindows", "showFullscreenWindows2", "showFullscreenWindows3", "showFullscreenWindows4", "showFullscreenWindows5"].map { defaults.macroPref($0, ShowHowPreference.allCases) } }
+    static var windowOrder: [WindowOrderPreference] { ["windowOrder", "windowOrder2", "windowOrder3",
+         "windowOrder4", "windowOrder5"].map { defaults.macroPref($0, WindowOrderPreference.allCases) } }
     static var shortcutStyle: [ShortcutStylePreference] { ["shortcutStyle", "shortcutStyle2", "shortcutStyle3", "shortcutStyle4", "shortcutStyle5"].map { defaults.macroPref($0, ShortcutStylePreference.allCases) } }
     static var menubarIcon: MenubarIconPreference { defaults.macroPref("menubarIcon", MenubarIconPreference.allCases) }
 
@@ -474,6 +481,24 @@ enum ShowHowPreference: String, CaseIterable, MacroPreference {
             case .show: return NSLocalizedString("Show", comment: "")
             case .showAtTheEnd: return NSLocalizedString("Show at the end", comment: "")
             case .hide: return NSLocalizedString("Hide", comment: "")
+        }
+    }
+}
+
+enum WindowOrderPreference: String, CaseIterable, MacroPreference {
+    case lastUsed = "0"
+    case lastOpened = "1"
+    case mostFrequently = "2"
+    case alphabetical = "3"
+    case alphabeticalBySpace = "4"
+    
+    var localizedString: LocalizedString{
+        switch self{
+            case .lastUsed: return NSLocalizedString("Last Used", comment: "")
+            case .lastOpened: return NSLocalizedString("Last Opened", comment: "")
+            case .mostFrequently: return NSLocalizedString("Most Frequently", comment: "")
+            case .alphabetical: return NSLocalizedString("Name", comment: "")
+            case .alphabeticalBySpace: return NSLocalizedString("Space", comment: "")
         }
     }
 }

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -1,8 +1,11 @@
 import Cocoa
 
 class Window {
+    static var globalOpenedOrder = Int.zero
     var cgWindowId: CGWindowID?
     var lastFocusOrder = Int.zero
+    var openedOrder = Int.zero
+    var focusCount = Int.zero
     var title: String!
     var thumbnail: NSImage?
     var thumbnailFullSize: NSSize?
@@ -45,6 +48,8 @@ class Window {
         self.position = position
         self.size = size
         self.title = bestEffortTitle(axTitle)
+        self.openedOrder = Window.globalOpenedOrder
+        Window.globalOpenedOrder += 1
         if !Preferences.hideThumbnails {
             refreshThumbnail()
         }
@@ -58,6 +63,8 @@ class Window {
         isWindowlessApp = true
         self.application = application
         self.title = application.runningApplication.localizedName
+        self.openedOrder = Window.globalOpenedOrder
+        Window.globalOpenedOrder += 1
         debugPrint("Adding app-window", title ?? "nil", application.runningApplication.bundleIdentifier ?? "nil")
     }
 

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -1,11 +1,10 @@
 import Cocoa
 
 class Window {
-    static var globalOpenedOrder = Int.zero
+    static var globalCreationCounter = Int.zero
     var cgWindowId: CGWindowID?
     var lastFocusOrder = Int.zero
-    var openedOrder = Int.zero
-    var focusCount = Int.zero
+    var creationOrder = Int.zero
     var title: String!
     var thumbnail: NSImage?
     var thumbnailFullSize: NSSize?
@@ -48,8 +47,8 @@ class Window {
         self.position = position
         self.size = size
         self.title = bestEffortTitle(axTitle)
-        self.openedOrder = Window.globalOpenedOrder
-        Window.globalOpenedOrder += 1
+        Window.globalCreationCounter += 1
+        self.creationOrder = Window.globalCreationCounter
         if !Preferences.hideThumbnails {
             refreshThumbnail()
         }
@@ -63,8 +62,6 @@ class Window {
         isWindowlessApp = true
         self.application = application
         self.title = application.runningApplication.localizedName
-        self.openedOrder = Window.globalOpenedOrder
-        Window.globalOpenedOrder += 1
         debugPrint("Adding app-window", title ?? "nil", application.runningApplication.bundleIdentifier ?? "nil")
     }
 

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -25,11 +25,8 @@ class Windows {
             let sortType = Preferences.windowOrder[App.app.shortcutIndex]
             var order: ComparisonResult = .orderedSame
             
-            if sortType == .lastOpened {
-                order = sortByIntAttribute($1.openedOrder, $0.openedOrder)
-            }
-            if sortType == .mostFrequently{
-                order = sortByIntAttribute($1.focusCount, $0.focusCount)
+            if sortType == .lastCreated {
+                order = sortByIntAttribute($1.creationOrder, $0.creationOrder)
             }
             if sortType == .alphabetical {
                 order = sortByWindowStringAttribute($0, $1)
@@ -108,7 +105,6 @@ class Windows {
     static func updateLastFocus(_ otherWindowAxUiElement: AXUIElement, _ otherWindowWid: CGWindowID) -> [Window]? {
         if let focusedWindow = (list.first { $0.isEqualRobust(otherWindowAxUiElement, otherWindowWid) }) {
             let focusedWindowOldFocusOrder = focusedWindow.lastFocusOrder
-            focusedWindow.focusCount += 1
             var windowsToRefresh = [focusedWindow]
             list.forEach {
                 if $0.lastFocusOrder == focusedWindowOldFocusOrder {

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -25,6 +25,7 @@ class Windows {
             let sortType = Preferences.windowOrder[App.app.shortcutIndex]
             var order: ComparisonResult = .orderedSame
             
+            // The earlier window is created, the smaller creationOrder is.
             if sortType == .lastCreated {
                 order = sortByIntAttribute($1.creationOrder, $0.creationOrder)
             }
@@ -39,7 +40,7 @@ class Windows {
             }
         
             // fallback
-            if order == .orderedSame || sortType == .lastUsed {
+            if order == .orderedSame || sortType == .lastFocused {
                 order = sortByIntAttribute($0.lastFocusOrder, $1.lastFocusOrder)
             }
             
@@ -55,8 +56,10 @@ class Windows {
             hoveredWindowIndex = nil
             ThumbnailsView.highlight(oldIndex)
         }
+        let sortType = Preferences.windowOrder[App.app.shortcutIndex]
+        
         if let app = Applications.find(NSWorkspace.shared.frontmostApplication?.processIdentifier),
-           app.focusedWindow == nil,
+           (app.focusedWindow == nil || sortType != .lastFocused),
            let lastFocusedWindowIndex = getLastFocusedWindowIndex() {
             updateFocusedAndHoveredWindowIndex(lastFocusedWindowIndex)
         } else {

--- a/src/ui/preferences-window/tabs/ControlsTab.swift
+++ b/src/ui/preferences-window/tabs/ControlsTab.swift
@@ -97,6 +97,7 @@ class ControlsTab {
         let toShowExplanations2 = LabelAndControl.makeLabel(NSLocalizedString("Minimized windows:", comment: ""))
         let toShowExplanations3 = LabelAndControl.makeLabel(NSLocalizedString("Hidden windows:", comment: ""))
         let toShowExplanations4 = LabelAndControl.makeLabel(NSLocalizedString("Fullscreen windows:", comment: ""))
+        let windowOrderExplanation = LabelAndControl.makeLabel(NSLocalizedString("Window order:", comment: ""))
         var holdShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Hold", comment: ""), Preferences.indexToName("holdShortcut", index), Preferences.holdShortcut[index], false, labelPosition: .leftWithoutSeparator)
         holdShortcut.append(LabelAndControl.makeLabel(NSLocalizedString("and press:", comment: "")))
         let holdAndPress = StackView(holdShortcut)
@@ -106,6 +107,7 @@ class ControlsTab {
         let showMinimizedWindows = LabelAndControl.makeDropdown(Preferences.indexToName("showMinimizedWindows", index), ShowHowPreference.allCases)
         let showHiddenWindows = LabelAndControl.makeDropdown(Preferences.indexToName("showHiddenWindows", index), ShowHowPreference.allCases)
         let showFullscreenWindows = LabelAndControl.makeDropdown(Preferences.indexToName("showFullscreenWindows", index), ShowHowPreference.allCases.filter { $0 != .showAtTheEnd })
+        let windowOrder = LabelAndControl.makeDropdown(Preferences.indexToName("windowOrder",index), WindowOrderPreference.allCases)
         let separator = NSBox()
         separator.boxType = .separator
         let nextWindowShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Select next window", comment: ""), Preferences.indexToName("nextWindowShortcut", index), Preferences.nextWindowShortcut[index], labelPosition: .right)
@@ -118,12 +120,13 @@ class ControlsTab {
             [toShowExplanations2, showMinimizedWindows],
             [toShowExplanations3, showHiddenWindows],
             [toShowExplanations4, showFullscreenWindows],
+            [windowOrderExplanation, windowOrder],
             [separator],
             [holdAndPress, StackView(nextWindowShortcut)],
             shortcutStyle,
         ], TabView.padding)
         tab.column(at: 0).xPlacement = .trailing
-        tab.mergeCells(inHorizontalRange: NSRange(location: 0, length: 2), verticalRange: NSRange(location: 4, length: 1))
+        tab.mergeCells(inHorizontalRange: NSRange(location: 0, length: 2), verticalRange: NSRange(location: 5, length: 1))
         tab.fit()
         return (holdShortcut, nextWindowShortcut, tab)
     }


### PR DESCRIPTION
This PR tries to fix https://github.com/lwouis/alt-tab-macos/issues/515. Since the current PR https://github.com/lwouis/alt-tab-macos/pull/1936 is inactive and there are still some problems left, I opened this PR for an alternative.

**Summary**
This PR introduces an option called "Window order". The four options available now is:
- Last Focused: the default behavior same as the original alt-tab does.
- Last Created: we record the creation time of a window, then sort the windows by descending time order, i.e. eariler created window will be put more at the end.
- Alphabetical: we sort the windows first by its application name, then by its window title. A lot of users want this mainly because they expect a deterministic order. Since the window title is more often to be changed (e.g. a browser window title will show the title of the webpage), application name first should be a better choice.
- Space: we sort the windows first by its space index, then use the same rule in Alphabetical. Users need this also because of a deterministic order. And they also organize windows by space (e.g. work stuff on space 1, personal stuff on space 3).

**Changes compared to #1936**
- I don't add "Most Frequently" here: how to define "frequency" is unclear, the "frecency" as well. I have tried some algorithms but they look a little weird and out of expectation. I think we can add this in later PR with more deep discussion. We can add an option to change order first, then decide what order should be added.
- I renamed "Last Used" to "Last Focused", and "Last Opened" to "Last Created". This should be unambiguous, since we won't say "focus an app" or "create an app".
- For order other than "Last Focused", I will make the initial focused window the same as the last focused window. When we use order other than "Last Focused", our window may (most probably!) not the first window in the order. Initially focus the second window don't make sense. And since users may not navigate right, move the focused window right by 1 is not a good choice. So I decide to make it the same as the last focused window, leaving the user to choose where to navigate.

**Other things**
In #1936 you state that the original PR failed to keep order for minimized/hidden window. I cannot reproduce the wrong behavior. I use the similar logic to #1936 and it looks fine to me. Can you provide more details to point out what is wrong?