### PR TITLE
fix: support CrossOver and ColorSlurp windows

### DIFF
--- a/src/api-wrappers/AXUIElement.swift
+++ b/src/api-wrappers/AXUIElement.swift
@@ -84,27 +84,31 @@ extension AXUIElement {
 
         // Some non-windows have cgWindowId == 0 (e.g. windows of apps starting at login with the checkbox "Hidden" checked)
         return wid != 0 && size != nil &&
-            (books(runningApp) || keynote(runningApp) || iina(runningApp) || openFlStudio(runningApp, title) || (
-                // CGWindowLevel == .normalWindow helps filter out iStats Pro and other top-level pop-overs, and floating windows
-                level == CGWindow.normalLevel &&
-                    ([kAXStandardWindowSubrole, kAXDialogSubrole].contains(subrole) ||
-                        openBoard(runningApp) ||
-                        adobeAudition(runningApp, subrole) ||
-                        adobeAfterEffects(runningApp, subrole) ||
-                        steam(runningApp, title, role) ||
-                        worldOfWarcraft(runningApp, role) ||
-                        battleNetBootstrapper(runningApp, role) ||
-                        firefox(runningApp, role, size) ||
-                        vlcFullscreenVideo(runningApp, role) ||
-                        sanGuoShaAirWD(runningApp) ||
-                        dvdFab(runningApp) ||
-                        drBetotte(runningApp) ||
-                        androidEmulator(runningApp, title) ||
-                        colorSlurp(runningApp)
-                    ) &&
-                    mustHaveIfJetbrainApp(runningApp, title, subrole, size!) &&
-                    mustHaveIfSteam(runningApp, title, role)
-            ))
+                (books(runningApp) ||
+                        keynote(runningApp) ||
+                        iina(runningApp) ||
+                        openFlStudio(runningApp, title) ||
+                        crossoverWindow(runningApp, role, subrole, level) ||
+                        // CGWindowLevel == .normalWindow helps filter out iStats Pro and other top-level pop-overs, and floating windows
+                        (level == CGWindow.normalLevel &&
+                                ([kAXStandardWindowSubrole, kAXDialogSubrole].contains(subrole) ||
+                                        openBoard(runningApp) ||
+                                        adobeAudition(runningApp, subrole) ||
+                                        adobeAfterEffects(runningApp, subrole) ||
+                                        steam(runningApp, title, role) ||
+                                        worldOfWarcraft(runningApp, role) ||
+                                        battleNetBootstrapper(runningApp, role) ||
+                                        firefox(runningApp, role, size) ||
+                                        vlcFullscreenVideo(runningApp, role) ||
+                                        sanGuoShaAirWD(runningApp) ||
+                                        dvdFab(runningApp) ||
+                                        drBetotte(runningApp) ||
+                                        androidEmulator(runningApp, title) ||
+                                        colorSlurp(runningApp)
+                                ) &&
+                                mustHaveIfJetbrainApp(runningApp, title, subrole, size!) &&
+                                mustHaveIfSteam(runningApp, title, role)
+                        ))
     }
 
     private static func mustHaveIfJetbrainApp(_ runningApp: NSRunningApplication, _ title: String?, _ subrole: String?, _ size: NSSize) -> Bool {
@@ -204,6 +208,11 @@ extension AXUIElement {
     private static func colorSlurp(_ runningApp: NSRunningApplication) -> Bool {
         // ColorSlurp presents its dialog as a kAXSystemDialogSubrole, so we need a special check
         return runningApp.bundleIdentifier == "com.IdeaPunch.ColorSlurp"
+    }
+
+    private static func crossoverWindow(_ runningApp: NSRunningApplication, _ role: String?, _ subrole: String?, _ level: CGWindowLevel) -> Bool {
+        runningApp.bundleIdentifier == nil && role == kAXWindowRole && subrole == kAXUnknownSubrole &&
+                level == 0 && runningApp.localizedName == "wine64-preloader"
     }
 
     func position() throws -> CGPoint? {


### PR DESCRIPTION
This PR adds two new functions to `AXUIElement`:

- `colorSlurp()`
- `crossoverWindow()`

For whatever reason, ColorSlurp's window that pops up when you pick a color isn't presented as a normal window, so I made it so that if the window has the ColorSlurp bundleID, it will always be included. ColorSlurp doesn't seem to have any other window types, so this should be safe.

CrossOver windows are very weird, probably because of how hacky the whole WINE layering stuff is in general. I'm not fully convinced that the method I used for checking for CrossOver windows is safe, but it doesn't seem to hit any false positives in my testing. (Maybe it should be a default-disabled setting?)

With Game Porting Toolkit being based on CrossOver, and it already becoming popular, it's probably a good idea to be able to handle those windows.