### PR TITLE
fix: replace deprecated `activate()` calls with a hidden API

### DIFF
--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -170,6 +170,7 @@
 		D04BAFB973C3D28718FAEB87 /* Windows.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BACD976030676FD0761D5 /* Windows.swift */; };
 		D04BAFBC862BA5FE0294EA7A /* AXUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA6F823BC0EDA9AA4B80A /* AXUIElement.swift */; };
 		D04BAFF30A98CF287F85DA1E /* BlacklistsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA27695D9A5824720BD7B /* BlacklistsTab.swift */; };
+		E0E22E0A221877C9875462A5 /* WindowOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0E22BAE671741C630C4493E /* WindowOwner.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -438,6 +439,7 @@
 		D04BAF77F9D94C397EB646AE /* 1-row.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "1-row.jpg"; sourceTree = "<group>"; };
 		D04BAFA20F13FB588F6CCB81 /* bug_report.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = bug_report.md; sourceTree = "<group>"; };
 		D04BAFDA9E2623E21CBD6CEF /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = InfoPlist.strings; sourceTree = "<group>"; };
+		E0E22BAE671741C630C4493E /* WindowOwner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowOwner.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -963,6 +965,7 @@
 				D04BA8DB8AA7E5570DAC568A /* Sysctl.swift */,
 				D04BA514F1C4B475B3CA6EB6 /* Bash.swift */,
 				BF0C82E4DE5A28800F1DA6E6 /* MissionControl.swift */,
+				E0E22BAE671741C630C4493E /* WindowOwner.swift */,
 			);
 			path = "api-wrappers";
 			sourceTree = "<group>";
@@ -1688,6 +1691,7 @@
 				BF0C898511686611E4D7D81E /* Button.swift in Sources */,
 				BF0C8E16F38203AEC71E062B /* TableView.swift in Sources */,
 				BF0C832C5BF4C8E9C95F7767 /* MissionControl.swift in Sources */,
+				E0E22E0A221877C9875462A5 /* WindowOwner.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/src/api-wrappers/PrivateApis.swift
+++ b/src/api-wrappers/PrivateApis.swift
@@ -46,6 +46,11 @@ func CGSHWCaptureWindowList(_ cid: CGSConnectionID, _ windowList: inout CGWindow
 @_silgen_name("CGSGetWindowOwner") @discardableResult
 func CGSGetWindowOwner(_ cid: CGSConnectionID, _ wid: CGWindowID, _ windowCid: inout CGSConnectionID) -> CGError
 
+// forces the given wid to be active.
+// * maxOS 10.10+
+@_silgen_name("CGSSetWindowActive") @discardableResult
+func CGSSetWindowActive(_ cid: CGSConnectionID, _ wid: CGWindowID, _ isActive: Bool) -> CGError
+
 // returns the PSN for the provided connection ID
 // * macOS 10.10+
 @_silgen_name("CGSGetConnectionPSN") @discardableResult

--- a/src/api-wrappers/WindowOwner.swift
+++ b/src/api-wrappers/WindowOwner.swift
@@ -1,0 +1,20 @@
+//
+// Created by Zachary Wander on 6/27/23.
+// Copyright (c) 2023 lwouis. All rights reserved.
+//
+
+import Foundation
+
+class WindowOwner {
+    var window: Window
+    var connection: CGSConnectionID
+
+    init(_ window: Window, _ connection: CGSConnectionID) {
+        self.window = window
+        self.connection = connection
+    }
+
+    func setActive(_ active: Bool) {
+        CGSSetWindowActive(connection, window.cgWindowId!, active)
+    }
+}

--- a/src/logic/AppCenterCrashes.swift
+++ b/src/logic/AppCenterCrashes.swift
@@ -40,7 +40,7 @@ class AppCenterCrash: NSObject, CrashesDelegate {
 
     func checkIfShouldSend() -> Bool {
         if Preferences.crashPolicy == .ask {
-            App.app.activate(ignoringOtherApps: true)
+            App.app.activateCompat()
             let alert = NSAlert()
             alert.alertStyle = .warning
             alert.messageText = NSLocalizedString("Send a crash report?", comment: "")

--- a/src/logic/SystemPermissions.swift
+++ b/src/logic/SystemPermissions.swift
@@ -94,7 +94,7 @@ class SystemPermissions {
         } else {
             permissionsWindow = PermissionsWindow()
             permissionsWindow.center()
-            App.shared.activate(ignoringOtherApps: true)
+            App.app.activateCompat()
             permissionsWindow.makeKeyAndOrderFront(nil)
             observePermissionsPreStartup(startupBlock)
         }

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -179,11 +179,11 @@ class Window {
             if let bundleID = application.runningApplication.bundleIdentifier {
                 NSWorkspace.shared.launchApplication(withBundleIdentifier: bundleID, additionalEventParamDescriptor: nil, launchIdentifier: nil)
             } else {
-                application.runningApplication.activate(options: .activateIgnoringOtherApps)
+                getOwner().setActive(true)
             }
         } else if let bundleID = application.runningApplication.bundleIdentifier, bundleID == App.id {
-            App.shared.activate(ignoringOtherApps: true)
-            App.app.window(withWindowNumber: Int(cgWindowId!))?.makeKeyAndOrderFront(nil)
+            let appWindow = App.app.window(withWindowNumber: Int(cgWindowId!))?.makeKeyAndOrderFront(nil)
+            getOwner().setActive(true)
             Windows.previewFocusedWindowIfNeeded()
         } else {
             // macOS bug: when switching to a System Preferences window in another space, it switches to that space,
@@ -277,6 +277,14 @@ class Window {
         // TODO: handle the case where the app has multiple window-groups. In that case, we need to find the right
         //       window-group, instead of picking the focused one
         return isTabbed ? application.focusedWindow : self
+    }
+
+    func getOwner() -> WindowOwner {
+        var connection = CGSConnectionID()
+
+        CGSGetWindowOwner(cgsMainConnectionId, cgWindowId!, &connection)
+
+        return WindowOwner(self, connection)
     }
 }
 

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -178,7 +178,7 @@ class App: AppCenterApplication, NSApplicationDelegate {
     func showSecondaryWindow(_ window: NSWindow?) {
         if let window = window {
             NSScreen.preferred().repositionPanel(window, .appleCentered)
-            App.shared.activate(ignoringOtherApps: true)
+            activateCompat()
             window.makeKeyAndOrderFront(nil)
         }
     }
@@ -327,6 +327,14 @@ class App: AppCenterApplication, NSApplicationDelegate {
         KeyboardEvents.toggleGlobalShortcuts(shortcutsShouldBeDisabled)
         if shortcutsShouldBeDisabled && App.app.appIsBeingUsed {
             App.app.hideUi()
+        }
+    }
+
+    func activateCompat() {
+        if #available(macOS 14.0, *) {
+            App.shared.activate()
+        } else {
+            App.shared.activate(ignoringOtherApps: true)
         }
     }
 }


### PR DESCRIPTION
macOS 14 is deprecating the `NSRunningApplication.activate(options: .activateIgnoringOtherApps)` option. While not removed, it claims it will no longer have any effect.

This PR replaces that call (and similar calls to `NSApplicationDelegate.activate(ignoringOtherApps: true)`) with a hidden API with the same functionality where relevant, and by simply removing the option elsewhere.

As far as I can tell, `CGSSetWindowActive()` was added in macOS 10.10. It's also still present in the current macOS 14 beta SDK. That obviously isn't a guarantee that it won't be removed when the stable SDK comes out, and it looks like the old behavior of `ignoringOtherApps` is still working in the betas, so it probably doesn't make sense to merge this PR right away.

It would be good to have other people test this out, though. I'm not sure how to reproduce the deprecation warning dialog when running a debug app built on the test computer, so I don't know if this resolves everything.