### PR TITLE
feat: support for always-on-top scrcpy windows

### DIFF
--- a/src/api-wrappers/AXUIElement.swift
+++ b/src/api-wrappers/AXUIElement.swift
@@ -84,7 +84,7 @@ extension AXUIElement {
 
         // Some non-windows have cgWindowId == 0 (e.g. windows of apps starting at login with the checkbox "Hidden" checked)
         return wid != 0 && size != nil &&
-            (books(runningApp) || keynote(runningApp) || iina(runningApp) || openFlStudio(runningApp, title) || (
+            (books(runningApp) || keynote(runningApp) || iina(runningApp) || openFlStudio(runningApp, title) || isAlwaysOnTopScrcpy(runningApp, level, role, subrole) || (
                 // CGWindowLevel == .normalWindow helps filter out iStats Pro and other top-level pop-overs, and floating windows
                 level == CGWindow.normalLevel &&
                     ([kAXStandardWindowSubrole, kAXDialogSubrole].contains(subrole) ||
@@ -204,6 +204,12 @@ extension AXUIElement {
     private static func colorSlurp(_ runningApp: NSRunningApplication) -> Bool {
         // ColorSlurp presents its dialog as a kAXSystemDialogSubrole, so we need a special check
         return runningApp.bundleIdentifier == "com.IdeaPunch.ColorSlurp"
+    }
+
+    private static func isAlwaysOnTopScrcpy(_ runningApp: NSRunningApplication, _ level: CGWindowLevel, _ role: String?, _ subrole: String?) -> Bool {
+        // scrcpy presents as a floating window when "Always on top" is enabled, so it doesn't get picked up normally.
+        // It also doesn't have a bundle ID, so we need to match using the localized name, which should always be the same.
+        return runningApp.localizedName == "scrcpy" && level == CGWindow.floatingWindow && role == kAXWindowRole && subrole == kAXStandardWindowSubrole
     }
 
     func position() throws -> CGPoint? {

--- a/src/api-wrappers/CGWindow.swift
+++ b/src/api-wrappers/CGWindow.swift
@@ -4,6 +4,7 @@ typealias CGWindow = [CFString: Any]
 
 extension CGWindow {
     static let normalLevel = CGWindowLevelForKey(.normalWindow)
+    static let floatingWindow = CGWindowLevelForKey(.floatingWindow)
 
     static func windows(_ option: CGWindowListOption) -> [CGWindow] {
         return CGWindowListCopyWindowInfo([.excludeDesktopElements, option], kCGNullWindowID) as! [CGWindow]


### PR DESCRIPTION
scrcpy uses the floating window level when the "always on top" option is enabled, which means it doesn't get picked up by alt-tab.

This PR does a check for scrcpy windows at that level and adds them to the valid window list.