### PR TITLE
fix: use normalLevel for CrossOver level check

### DIFF
--- a/src/api-wrappers/AXUIElement.swift
+++ b/src/api-wrappers/AXUIElement.swift
@@ -215,7 +215,7 @@ extension AXUIElement {
     }
 
     private static func crossoverWindow(_ runningApp: NSRunningApplication, _ role: String?, _ subrole: String?, _ level: CGWindowLevel) -> Bool {
-        return runningApp.bundleIdentifier == nil && role == kAXWindowRole && subrole == kAXUnknownSubrole && level == CGWindow.baseLevel
+        return runningApp.bundleIdentifier == nil && role == kAXWindowRole && subrole == kAXUnknownSubrole && level == CGWindow.normalLevel
             && (runningApp.localizedName == "wine64-preloader" || runningApp.executableURL?.absoluteString.contains("/winetemp-") ?? false)
     }
 

--- a/src/api-wrappers/CGWindow.swift
+++ b/src/api-wrappers/CGWindow.swift
@@ -4,7 +4,6 @@ typealias CGWindow = [CFString: Any]
 
 extension CGWindow {
     static let normalLevel = CGWindowLevelForKey(.normalWindow)
-    static let baseLevel = CGWindowLevelForKey(.baseWindow)
     static let floatingWindow = CGWindowLevelForKey(.floatingWindow)
 
     static func windows(_ option: CGWindowListOption) -> [CGWindow] {


### PR DESCRIPTION
The `baseLevel` comparison was incorrect. CrossOver windows are at level 0 (`normalLevel`), while `baseLevel` == MIN_SIGNED_INTEGER.
