### PR TITLE
feat: add vim key window navigation

### DIFF
--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -30,6 +30,7 @@ class Preferences {
         "quitAppShortcut": "Q",
         "hideShowAppShortcut": "H",
         "arrowKeysEnabled": "true",
+        "vimKeysEnabled": "false",
         "mouseHoverEnabled": "false",
         "cursorFollowFocusEnabled": "false",
         "showMinimizedWindows": ShowHowPreference.show.rawValue,
@@ -125,6 +126,7 @@ class Preferences {
     static var quitAppShortcut: String { defaults.string("quitAppShortcut") }
     static var hideShowAppShortcut: String { defaults.string("hideShowAppShortcut") }
     static var arrowKeysEnabled: Bool { defaults.bool("arrowKeysEnabled") }
+    static var vimKeysEnabled: Bool { defaults.bool("vimKeysEnabled") }
     static var mouseHoverEnabled: Bool { defaults.bool("mouseHoverEnabled") }
     static var cursorFollowFocusEnabled: Bool { defaults.bool("cursorFollowFocusEnabled") }
     static var showTabsAsWindows: Bool { defaults.bool("showTabsAsWindows") }

--- a/src/ui/generic-components/CustomRecorderControl.swift
+++ b/src/ui/generic-components/CustomRecorderControl.swift
@@ -50,11 +50,20 @@ class CustomRecorderControl: RecorderControl, RecorderControlDelegate {
 
     func alertIfSameShortcutAlreadyAssigned(_ shortcut: Shortcut, _ shortcutAlreadyAssigned: ATShortcut) {
         let isArrowKeys = ["←", "→", "↑", "↓"].contains(shortcutAlreadyAssigned.id)
+        let isVimKeys = shortcutAlreadyAssigned.id.contains("vimCycle")
         let existing = ControlsTab.shortcutControls[shortcutAlreadyAssigned.id]
         let alert = NSAlert()
         alert.alertStyle = .warning
         alert.messageText = NSLocalizedString("Conflicting shortcut", comment: "")
-        alert.informativeText = String(format: NSLocalizedString("Shortcut already assigned to another action: %@", comment: ""), (isArrowKeys ? "Arrow keys" : existing!.1).replacingOccurrences(of: " ", with: "\u{00A0}"))
+        let informativeText: String
+        if isArrowKeys {
+            informativeText = "Arrow keys"
+        } else if isVimKeys {
+            informativeText = "Vim keys"
+        } else {
+            informativeText = existing!.1
+        }
+        alert.informativeText = String(format: NSLocalizedString("Shortcut already assigned to another action: %@", comment: ""), informativeText.replacingOccurrences(of: " ", with: "\u{00A0}"))
         if !id.starts(with: "holdShortcut") {
             alert.addButton(withTitle: NSLocalizedString("Unassign existing shortcut and continue", comment: "")).setAccessibilityFocused(true)
         }
@@ -69,6 +78,10 @@ class CustomRecorderControl: RecorderControl, RecorderControlDelegate {
                 ControlsTab.arrowKeysCheckbox.state = .off
                 ControlsTab.arrowKeysEnabledCallback(ControlsTab.arrowKeysCheckbox)
                 LabelAndControl.controlWasChanged(ControlsTab.arrowKeysCheckbox, nil)
+            } else if isVimKeys {
+                ControlsTab.vimKeysCheckbox.state = .off
+                ControlsTab.vimKeysEnabledCallback(ControlsTab.vimKeysCheckbox)
+                LabelAndControl.controlWasChanged(ControlsTab.vimKeysCheckbox, nil)
             } else {
                 existing!.0.objectValue = nil
                 ControlsTab.shortcutChangedCallback(existing!.0)

--- a/src/ui/preferences-window/tabs/ControlsTab.swift
+++ b/src/ui/preferences-window/tabs/ControlsTab.swift
@@ -21,6 +21,10 @@ class ControlsTab {
         "←": { App.app.cycleSelection(.left) },
         "↑": { App.app.cycleSelection(.up) },
         "↓": { App.app.cycleSelection(.down) },
+        "vimCycleRight": { App.app.cycleSelection(.right) },
+        "vimCycleLeft": { App.app.cycleSelection(.left) },
+        "vimCycleUp": { App.app.cycleSelection(.up) },
+        "vimCycleDown": { App.app.cycleSelection(.down) },
         "cancelShortcut": { App.app.hideUi() },
         "closeWindowShortcut": { App.app.closeSelectedWindow() },
         "minDeminWindowShortcut": { App.app.minDeminSelectedWindow() },
@@ -29,6 +33,7 @@ class ControlsTab {
         "hideShowAppShortcut": { App.app.hideShowSelectedApp() },
     ]
     static var arrowKeysCheckbox: NSButton!
+    static var vimKeysCheckbox: NSButton!
 
     static func initTab() -> NSView {
         let focusWindowShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Focus selected window", comment: ""), "focusWindowShortcut", Preferences.focusWindowShortcut, labelPosition: .right)
@@ -40,11 +45,13 @@ class ControlsTab {
         let quitAppShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Quit app", comment: ""), "quitAppShortcut", Preferences.quitAppShortcut, labelPosition: .right)
         let hideShowAppShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Hide/Show app", comment: ""), "hideShowAppShortcut", Preferences.hideShowAppShortcut, labelPosition: .right)
         let enableArrows = LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Arrow keys", comment: ""), "arrowKeysEnabled", extraAction: ControlsTab.arrowKeysEnabledCallback, labelPosition: .right)
+        let enableVimKeys = LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Vim keys", comment: ""), "vimKeysEnabled", extraAction: ControlsTab.vimKeysEnabledCallback, labelPosition: .right)
         arrowKeysCheckbox = enableArrows[0] as? NSButton
+        vimKeysCheckbox = enableVimKeys[0] as? NSButton
         let enableMouse = LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Mouse hover", comment: ""), "mouseHoverEnabled", labelPosition: .right)
         let enableCursorFollowFocus = LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Cursor follows focus", comment: ""), "cursorFollowFocusEnabled", labelPosition: .right)
         let selectWindowcheckboxesExplanations = LabelAndControl.makeLabel(NSLocalizedString("Also select windows using:", comment: ""))
-        let selectWindowCheckboxes = StackView([StackView(enableArrows), StackView(enableMouse)], .vertical)
+        let selectWindowCheckboxes = StackView([StackView(enableArrows), StackView(enableVimKeys), StackView(enableMouse)], .vertical)
         let miscCheckboxesExplanations = LabelAndControl.makeLabel(NSLocalizedString("Miscellaneous:", comment: ""))
         let miscCheckboxes = StackView([StackView(enableCursorFollowFocus)], .vertical)
         let shortcuts = StackView([focusWindowShortcut, previousWindowShortcut, cancelShortcut, closeWindowShortcut, minDeminWindowShortcut, toggleFullscreenWindowShortcut, quitAppShortcut, hideShowAppShortcut].map { (view: [NSView]) in StackView(view) }, .vertical)
@@ -63,6 +70,7 @@ class ControlsTab {
         ])
 
         ControlsTab.arrowKeysEnabledCallback(arrowKeysCheckbox)
+        ControlsTab.vimKeysEnabledCallback(vimKeysCheckbox)
         // trigger shortcutChanged for these shortcuts to trigger .restrictModifiers
         [holdShortcut, holdShortcut2, holdShortcut3, holdShortcut4, holdShortcut5].forEach { ControlsTab.shortcutChangedCallback($0[1] as! NSControl) }
         [nextWindowShortcut, nextWindowShortcut2, nextWindowShortcut3, nextWindowShortcut4, nextWindowShortcut5].forEach { ControlsTab.shortcutChangedCallback($0[0] as! NSControl) }
@@ -217,6 +225,69 @@ class ControlsTab {
         } else {
             keys.forEach { removeShortcutIfExists($0) }
         }
+    }
+
+    @objc static func vimKeysEnabledCallback(_ sender: NSControl) {
+        let keyActions = [
+            "h": "vimCycleLeft",
+            "l": "vimCycleRight",
+            "k": "vimCycleUp",
+            "j": "vimCycleDown"
+        ]
+        if (sender as! NSButton).state == .on {
+            if isClearVimKeysSuccessful() {
+                keyActions.forEach { addShortcut(.down, .local, Shortcut(keyEquivalent: $0)!, $1, nil) }
+            } else {
+                vimKeysCheckbox.state = .off
+            }
+        } else {
+            keyActions.forEach { removeShortcutIfExists($1) }
+        }
+    }
+
+    private static func isClearVimKeysSuccessful() -> Bool {
+        let vimKeys = ["h", "l", "j", "k"]
+        var conflicts = [String: String]()
+        shortcuts.forEach {
+            let keymap = $1.shortcut.characters
+            if keymap != nil && vimKeys.contains(keymap!) {
+                let control_id = $1.id
+                let labelText = shortcutControls[control_id]!.1
+
+                conflicts[control_id] = labelText
+            }
+        }
+        if !conflicts.isEmpty {
+            let shouldClearConflicts = shouldClearConflictingShortcuts(conflicts.map{ $0.value })
+            if !shouldClearConflicts {
+                return false
+            }
+
+            conflicts.forEach {
+                removeShortcutIfExists($0.key)
+                let existing = shortcutControls[$0.key]
+
+                if existing != nil {
+                    existing!.0.objectValue = nil
+                    shortcutChangedCallback(existing!.0)
+                    LabelAndControl.controlWasChanged(existing!.0, $0.key)
+                }
+            }
+        }
+        return true
+    }
+
+    private static func shouldClearConflictingShortcuts(_ conflicts: [String]) -> Bool {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = NSLocalizedString("Conflicting shortcuts", comment: "")
+        let informativeText = conflicts.joined(separator: ", ")
+        alert.informativeText = String(format: NSLocalizedString("Vim keys are already assigned to other actions: [%@]", comment: ""), informativeText.replacingOccurrences(of: " ", with: "\u{00A0}"))
+        alert.addButton(withTitle: NSLocalizedString("Unassign existing shortcuts and continue", comment: "")).setAccessibilityFocused(true)
+        let cancelButton = alert.addButton(withTitle: NSLocalizedString("Cancel", comment: ""))
+        cancelButton.keyEquivalent = "\u{1b}"
+        let userChoice = alert.runModal()
+        return userChoice == .alertFirstButtonReturn
     }
 
     private static func removeShortcutIfExists(_ controlId: String) {


### PR DESCRIPTION
This change adds the ability to use vim keys (h, j, k, l for left, down, up, and right respectively) to cycle through windows with the _Vim Keys_ option. Closes #1229.

AltTab uses the `h` key to hide/show app. When the _Vim Keys_ option is turned on, a conflicting shortcuts alert is presented with options to: 
1. Unassign the existing shortcuts and activate vim keys which clears the existing conflicting shortcuts.
2. Cancel activating vim keys.

This PR is heavily inspired by #1272 and implements the UX discussed in the PR.

### Screenshots

**Vim keys option**

<img width="588" alt="Screenshot 2023-10-09 at 4 44 45 PM" src="https://github.com/lwouis/alt-tab-macos/assets/41965293/f765b706-f523-45e5-92dc-696b44b6d948">

**Alert upon checking the Vim Keys option with conflicting shortcuts**

<img width="588" alt="Screenshot 2023-10-09 at 4 45 26 PM" src="https://github.com/lwouis/alt-tab-macos/assets/41965293/cdf27baf-85c7-4e43-9885-e86177985d5a">

**Cancel the alert**
<img width="588" alt="Screenshot 2023-10-09 at 4 45 40 PM" src="https://github.com/lwouis/alt-tab-macos/assets/41965293/abef799c-ab72-42e3-ab01-3becba38c6aa">

**Upon clicking unassign shortcuts button (Hide/show app shortcut is cleared)**
<img width="588" alt="Screenshot 2023-10-09 at 4 45 57 PM" src="https://github.com/lwouis/alt-tab-macos/assets/41965293/e84eeba3-3a50-4b03-b217-6984f9736264">

**Assigning a vim key shortcut to other action with Vim Keys enabled**
<img width="588" alt="Screenshot 2023-10-09 at 4 50 30 PM" src="https://github.com/lwouis/alt-tab-macos/assets/41965293/6e7754ab-1587-422b-a4a8-e4fc59571d65">

**Upon clicking unassign shortcut button (Vim Keys is disabled)**
<img width="588" alt="Screenshot 2023-10-09 at 4 50 47 PM" src="https://github.com/lwouis/alt-tab-macos/assets/41965293/4149bd87-de3a-4aff-983a-41439970faeb">
