### PR TITLE
feat: adding shadows

### DIFF
--- a/src/ui/main-window/ThumbnailsPanel.swift
+++ b/src/ui/main-window/ThumbnailsPanel.swift
@@ -10,7 +10,7 @@ class ThumbnailsPanel: NSPanel, NSWindowDelegate {
         isFloatingPanel = true
         animationBehavior = .none
         hidesOnDeactivate = false
-        hasShadow = false
+        hasShadow = true
         titleVisibility = .hidden
         backgroundColor = .clear
         contentView! = thumbnailsView


### PR DESCRIPTION
Adding shadows makes the panel easier to distinguish against window backgrounds of different colors.

* The feature of adding shadow is inconsistent with the default window switching style of mac system.
* But it has the same style as the dock, both with shadows. 