### PR TITLE
Skip of multiple Snagit's floaty windows

### DIFF
--- a/src/api-wrappers/AXUIElement.swift
+++ b/src/api-wrappers/AXUIElement.swift
@@ -111,9 +111,13 @@ extension AXUIElement {
                     mustHaveIfJetbrainApp(runningApp, title, subrole, size!) &&
                         mustHaveIfSteam(runningApp, title, role) &&
                         mustHaveIfColorSlurp(runningApp, title, subrole)
-                )
+                ) && skipSnagitFloatyWindows(runningApp, title)
             )
         )
+    }
+    
+    private static func skipSnagitFloatyWindows(_ runningApp: NSRunningApplication, _ title: String?) -> Bool {
+            return !(runningApp.bundleIdentifier?.hasPrefix("com.TechSmith.Snagit") ?? false && title == "Floaty")
     }
 
     private static func mustHaveIfJetbrainApp(_ runningApp: NSRunningApplication, _ title: String?, _ subrole: String?, _ size: NSSize) -> Bool {


### PR DESCRIPTION
AltTab shows Snagit's floaty windows on every screenshot. That's redundant because it's same window (same content inside).
<img width="516" alt="image" src="https://github.com/lwouis/alt-tab-macos/assets/21338924/1f9add5b-d4ff-4d83-9a67-64baceceae57">


