### PR TITLE
feat: add support for macOS accent color

### DIFF
--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -95,6 +95,7 @@ class Preferences {
         "hideWindowlessApps": "false",
         "hideThumbnails": "false",
         "previewFocusedWindow": "false",
+        "showMacosAccentColor": "false",
     ]
 
     // system preferences
@@ -141,6 +142,7 @@ class Preferences {
     static var startAtLogin: Bool { defaults.bool("startAtLogin") }
     static var blacklist: [BlacklistEntry] { jsonDecode([BlacklistEntry].self, defaults.string("blacklist")) }
     static var previewFocusedWindow: Bool { defaults.bool("previewFocusedWindow") }
+    static var showMacosAccentColor: Bool { defaults.bool("showMacosAccentColor") }
 
     // macro values
     static var theme: ThemePreference { defaults.macroPref("theme", ThemePreference.allCases) }

--- a/src/ui/main-window/ThumbnailView.swift
+++ b/src/ui/main-window/ThumbnailView.swift
@@ -103,7 +103,7 @@ class ThumbnailView: NSStackView {
         let isFocused = indexInRecycledViews == Windows.focusedWindowIndex
         let isHovered = indexInRecycledViews == Windows.hoveredWindowIndex
         layer!.backgroundColor = (Preferences.theme == .macOs && isFocused) || (Preferences.theme == .windows10 && isHovered)
-            ? ThumbnailView.highlightBackgroundColor.cgColor : .clear
+            ? getEffectiveHighlightBackgroundColor().cgColor : .clear
         layer!.borderColor = (Preferences.theme == .macOs && isHovered) || (Preferences.theme == .windows10 && isFocused)
             ? ThumbnailView.highlightBorderColor.cgColor : .clear
         let newFrameInset = (isFocused) ? -Preferences.intraCellPadding : Preferences.intraCellPadding
@@ -227,6 +227,18 @@ class ThumbnailView: NSStackView {
             return "Red badge with number \(dockLabelInt)"
         }
         return "Red badge"
+    }
+  
+    // Returns macOS's accent color when enabled with Preferences.showMacosAccentColor,
+    // else defaults to ThumbnailView.highlightBackgroundColor.
+    private func getEffectiveHighlightBackgroundColor() -> NSColor {
+        if #available(macOS 10.14, *) {
+            return Preferences.theme == .macOs && Preferences.showMacosAccentColor
+                ? NSColor.controlAccentColor
+                : ThumbnailView.highlightBackgroundColor
+        } else {
+            return ThumbnailView.highlightBackgroundColor
+        }
     }
 
     private func observeDragAndDrop() {

--- a/src/ui/preferences-window/tabs/AppearanceTab.swift
+++ b/src/ui/preferences-window/tabs/AppearanceTab.swift
@@ -32,6 +32,7 @@ class AppearanceTab {
             LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Hide app badges:", comment: ""), "hideAppBadges"),
             LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Hide apps with no open window:", comment: ""), "hideWindowlessApps"),
             LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Preview selected window:", comment: ""), "previewFocusedWindow"),
+            LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Show macOS accent color:", comment: ""), "showMacosAccentColor"),
         ])
         grid.column(at: 0).xPlacement = .trailing
         grid.fit()


### PR DESCRIPTION
Adds an option to appearances to highlight `ThumbnailView` background with macOS accent color instead of the default black, while they're using the macOS theme.

<img width=350 src="https://github.com/lwouis/alt-tab-macos/assets/38878482/345e4378-833a-4086-b184-340c61f5e8fa" />



*In the picture it's using the hidden iMac purple accent that everyone can unlock with:*
`defaults write -g NSColorSimulateHardwareAccent -bool YES`
`defaults write -g NSColorSimulatedHardwareEnclosureNumber -int 7`


