### PR TITLE
fix: Use EXPANDED_CODE_SIGN_IDENTITY in codesign_sparkle_embedded_apps.sh

### DIFF
--- a/scripts/codesign_sparkle_embedded_apps.sh
+++ b/scripts/codesign_sparkle_embedded_apps.sh
@@ -8,4 +8,4 @@ set -exu
 # codesign --deep is only 1 level deep. It misses Sparkle embedded app AutoUpdate
 # this build phase script works around the issue
 
-codesign --verbose --force --sign "$CODE_SIGN_IDENTITY" $OTHER_CODE_SIGN_FLAGS "${CODESIGNING_FOLDER_PATH}/Contents/Frameworks/Sparkle.framework/Versions/A/Resources/Autoupdate.app"
+codesign --verbose --force --sign "$EXPANDED_CODE_SIGN_IDENTITY" $OTHER_CODE_SIGN_FLAGS "${CODESIGNING_FOLDER_PATH}/Contents/Frameworks/Sparkle.framework/Versions/A/Resources/Autoupdate.app"


### PR DESCRIPTION
Updated the `codesign_sparkle_embedded_apps.sh` script to use `$EXPANDED_CODE_SIGN_IDENTITY` instead of `$CODE_SIGN_IDENTITY`. This prevents "Apple Development: ambiguous" errors when there are multiple matching code-signing identities from XCode with automatic code-signing enabled, ensuring the correct identity is used for signing the Sparkle embedded app AutoUpdate.

Example comparison of the envvar values. These can be observed by enabling the "show environment variables in build log" checkbox under the Run Script build phase for codesign_sparkle_embedded_apps.sh, and then checking the build log:
```
    export CODE_SIGN_IDENTITY\=Apple\ Development
    export CODE_SIGN_IDENTITY_NO\=Apple\ Development
    export EXPANDED_CODE_SIGN_IDENTITY\=2FCF2E9C47BBF33DA64E1BXC648A32A6D7C6F314
    export EXPANDED_CODE_SIGN_IDENTITY_NAME\=Apple\ Development:\ example@me.com\ \(7X2KK4Z37L\)
```

![image-20240208144431245](https://github.com/lwouis/alt-tab-macos/assets/18545667/c971e398-eed4-4459-a5f3-9e6ca50cb77e)
