### PR TITLE
feat: add vertically centered versions of themes

### DIFF
--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -445,6 +445,7 @@ struct ThemeParameters {
     let label: String
     let cellCornerRadius: CGFloat
     let windowCornerRadius: CGFloat
+    let verticalAlignment: VerticalAlignment
 }
 
 typealias LocalizedString = String
@@ -586,19 +587,25 @@ enum AlignThumbnailsPreference: String, CaseIterable, MacroPreference {
 
 enum ThemePreference: String, CaseIterable, MacroPreference {
     case macOs = "0"
-    case windows10 = "1"
+    case macOsCentered = "1"
+    case windows10 = "2"
+    case windows10Centered = "3"
 
     var localizedString: LocalizedString {
         switch self {
             case .macOs: return " macOS"
+            case .macOsCentered: return " macOS (Centered)"
             case .windows10: return "❖ Windows 10"
+            case .windows10Centered: return "❖ Windows 10 (Centered)"
         }
     }
 
     var themeParameters: ThemeParameters {
         switch self {
-            case .macOs: return ThemeParameters(label: localizedString, cellCornerRadius: 10, windowCornerRadius: 23)
-            case .windows10: return ThemeParameters(label: localizedString, cellCornerRadius: 0, windowCornerRadius: 0)
+        case .macOs: return ThemeParameters(label: localizedString, cellCornerRadius: 10, windowCornerRadius: 23, verticalAlignment: .appleCentered)
+        case .macOsCentered: return ThemeParameters(label: localizedString, cellCornerRadius: 10, windowCornerRadius: 23, verticalAlignment: .centered)
+        case .windows10: return ThemeParameters(label: localizedString, cellCornerRadius: 0, windowCornerRadius: 0, verticalAlignment: .appleCentered)
+        case .windows10Centered: return ThemeParameters(label: localizedString, cellCornerRadius: 0, windowCornerRadius: 0, verticalAlignment: .centered)
         }
     }
 }

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -587,9 +587,9 @@ enum AlignThumbnailsPreference: String, CaseIterable, MacroPreference {
 
 enum ThemePreference: String, CaseIterable, MacroPreference {
     case macOs = "0"
-    case macOsCentered = "1"
-    case windows10 = "2"
-    case windows10Centered = "3"
+    case macOsCentered = "0 Centered"
+    case windows10 = "1"
+    case windows10Centered = "1 Centered"
 
     var localizedString: LocalizedString {
         switch self {

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -189,7 +189,7 @@ class App: AppCenterApplication, NSApplicationDelegate {
 
     func showSecondaryWindow(_ window: NSWindow?) {
         if let window = window {
-            NSScreen.preferred().repositionPanel(window, .appleCentered)
+            NSScreen.preferred().repositionPanel(window, Preferences.theme.themeParameters.verticalAlignment)
             App.shared.activate(ignoringOtherApps: true)
             window.makeKeyAndOrderFront(nil)
         }
@@ -261,7 +261,7 @@ class App: AppCenterApplication, NSApplicationDelegate {
         thumbnailsPanel.setContentSize(thumbnailsPanel.thumbnailsView.frame.size)
         thumbnailsPanel.display()
         guard appIsBeingUsed else { return }
-        currentScreen.repositionPanel(thumbnailsPanel, .appleCentered)
+        currentScreen.repositionPanel(thumbnailsPanel, Preferences.theme.themeParameters.verticalAlignment)
         Windows.voiceOverWindow() // at this point ThumbnailViews are assigned to the window, and ready
     }
 


### PR DESCRIPTION
Adds vertically centered versions of both the MacOS and Windows themes to address issue #585