### PR TITLE
fix: fix the the shape of fullscreen/defullscreen traffic light button

### DIFF
--- a/src/ui/generic-components/TrafficLightButton.swift
+++ b/src/ui/generic-components/TrafficLightButton.swift
@@ -117,32 +117,93 @@ class TrafficLightButton: NSButton {
     }
 
     private func drawSymbol(_ lineColor: NSColor) {
+        let symbol = NSBezierPath()
         if (type == .fullscreen) {
-            let symbol = NSBezierPath()
-            symbol.move(to: NSMakePoint(bounds.width * 0.25, bounds.height * 0.75))
-            symbol.line(to: NSMakePoint(bounds.width * 0.25, bounds.height * 1 / 3))
-            symbol.line(to: NSMakePoint(bounds.width * 2 / 3, bounds.height * 0.75))
-            symbol.close()
-            lineColor.setFill()
-            symbol.fill()
-            symbol.move(to: NSMakePoint(bounds.width * 0.75, bounds.height * 0.25))
-            symbol.line(to: NSMakePoint(bounds.width * 0.75, bounds.height * 2 / 3))
-            symbol.line(to: NSMakePoint(bounds.width * 1 / 3, bounds.height * 0.25))
-            symbol.close()
-            lineColor.setFill()
-            symbol.fill()
-            // maximize cross
-            // NSGraphicsContext.current?.shouldAntialias = false
-            // var symbol = NSBezierPath()
-            // symbol.move(to: NSMakePoint(bounds.width / 2, bounds.height * 0.20))
-            // symbol.line(to: NSMakePoint(bounds.width / 2, bounds.height * 0.80))
-            // symbol.move(to: NSMakePoint(bounds.width * 0.80, bounds.height / 2))
-            // symbol.line(to: NSMakePoint(bounds.width * 0.20, bounds.height / 2))
-            // symbol.lineWidth = 0.75
-            // NSGraphicsContext.current?.shouldAntialias = true
+            // First original triangle vertices
+            let pointA = NSMakePoint(bounds.width * 0.25, bounds.height * 0.75)
+            let pointB = NSMakePoint(bounds.width * 0.25, bounds.height * 1 / 3)
+            let pointC = NSMakePoint(bounds.width * 2 / 3, bounds.height * 0.75)
+
+            // Second original triangle vertices
+            let pointD = NSMakePoint(bounds.width * 0.75, bounds.height * 0.25)
+            let pointE = NSMakePoint(bounds.width * 0.75, bounds.height * 2 / 3)
+            let pointF = NSMakePoint(bounds.width * 1 / 3, bounds.height * 0.25)
+
+            // Rotated 90 degrees counterclockwise around the center
+            var transform = NSAffineTransform()
+            // Set the rotation center point to the center of the view
+            transform.translateX(by: bounds.midX, yBy: bounds.midY)
+            // Rotate counterclockwise by 90 degrees
+            transform.rotate(byDegrees: -90)
+            // Translate back to the original coordinate system
+            transform.translateX(by: -bounds.midX, yBy: -bounds.midY)
+            // Apply the transformation
+            transform.concat()
+
+            if window_?.isFullscreen ?? true {
+                // Draw defullscreen symbol (two triangles with points facing away from each other)
+                // Center of the triangle
+                let centerX = (pointA.x + pointB.x + pointC.x) / 3
+                let centerY = (pointA.y + pointB.y + pointC.y) / 3
+
+                // Rotated vertices
+                let rotatedA = NSMakePoint(2 * centerX - pointA.x, 2 * centerY - pointA.y)
+                let rotatedB = NSMakePoint(2 * centerX - pointB.x, 2 * centerY - pointB.y)
+                let rotatedC = NSMakePoint(2 * centerX - pointC.x, 2 * centerY - pointC.y)
+
+                // Offset to separate the triangles
+                let offset: CGFloat = 0.5
+
+                // Draw the first rotated triangle with offset applied
+                symbol.move(to: NSMakePoint(rotatedA.x - offset, rotatedA.y + offset))
+                symbol.line(to: rotatedB)
+                symbol.line(to: rotatedC)
+                symbol.close()
+                lineColor.setFill()
+                symbol.fill()
+
+                // Clear path for the next triangle
+                symbol.removeAllPoints()
+
+                // Center of the second triangle
+                let centerX2 = (pointD.x + pointE.x + pointF.x) / 3
+                let centerY2 = (pointD.y + pointE.y + pointF.y) / 3
+
+                // Rotated vertices for the second triangle
+                let rotatedD = NSMakePoint(2 * centerX2 - pointD.x, 2 * centerY2 - pointD.y)
+                let rotatedE = NSMakePoint(2 * centerX2 - pointE.x, 2 * centerY2 - pointE.y)
+                let rotatedF = NSMakePoint(2 * centerX2 - pointF.x, 2 * centerY2 - pointF.y)
+
+                // Draw the second rotated triangle with offset applied
+                symbol.move(to: NSMakePoint(rotatedD.x + offset, rotatedD.y - offset))
+                symbol.line(to: rotatedE)
+                symbol.line(to: rotatedF)
+                symbol.close()
+                lineColor.setFill()
+                symbol.fill()
+            } else {
+                // Draw fullscreen symbol (two triangles)
+                // Draw first triangle
+                symbol.move(to: pointA)
+                symbol.line(to: pointB)
+                symbol.line(to: pointC)
+                symbol.close()
+                lineColor.setFill()
+                symbol.fill()
+
+                // Clear path for the next triangle
+                symbol.removeAllPoints()
+
+                // Draw second triangle
+                symbol.move(to: pointD)
+                symbol.line(to: pointE)
+                symbol.line(to: pointF)
+                symbol.close()
+                lineColor.setFill()
+                symbol.fill()
+            }
         } else if (type == .miniaturize) {
             NSGraphicsContext.current?.shouldAntialias = false
-            let symbol = NSBezierPath()
             symbol.move(to: NSMakePoint(bounds.width * 0.20, bounds.height / 2))
             symbol.line(to: NSMakePoint(bounds.width * 0.80, bounds.height / 2))
             symbol.lineWidth = 0.75
@@ -150,7 +211,6 @@ class TrafficLightButton: NSButton {
             symbol.stroke()
             NSGraphicsContext.current?.shouldAntialias = true
         } else if (type == .close) {
-            let symbol = NSBezierPath()
             symbol.move(to: NSMakePoint(bounds.width * 0.30, bounds.height * 0.30))
             symbol.line(to: NSMakePoint(bounds.width * 0.70, bounds.height * 0.70))
             symbol.move(to: NSMakePoint(bounds.width * 0.70, bounds.height * 0.30))
@@ -160,7 +220,6 @@ class TrafficLightButton: NSButton {
             symbol.stroke()
         } else if (type == .quit) {
             let mouthAngle = CGFloat(80) / 2
-            let symbol = NSBezierPath()
             symbol.appendArc(
                 withCenter: NSMakePoint(bounds.width / 2, bounds.height / 2),
                 radius: bounds.width * 0.27,

--- a/src/ui/generic-components/TrafficLightButton.swift
+++ b/src/ui/generic-components/TrafficLightButton.swift
@@ -119,30 +119,30 @@ class TrafficLightButton: NSButton {
     private func drawSymbol(_ lineColor: NSColor) {
         let symbol = NSBezierPath()
         if (type == .fullscreen) {
-            var pointA, pointB, pointC, pointD, pointE, pointF: NSPoint!
+            var firstPointA, firstPointB, firstPointC, secondPointA, secondPointB, secondPointC: NSPoint!
             if window_?.isFullscreen ?? true {
                 // Defullscreen symbol that the angles of the two triangles are face-to-face
-                pointA = NSMakePoint(bounds.width * 0.5, bounds.height * 0.5)
-                pointB = NSMakePoint(bounds.width * 0.12, bounds.height * 0.5)
-                pointC = NSMakePoint(bounds.width * 0.5, bounds.height * 0.12)
+                firstPointA = NSMakePoint(bounds.width * 0.5, bounds.height * 0.5)
+                firstPointB = NSMakePoint(bounds.width * 0.12, bounds.height * 0.5)
+                firstPointC = NSMakePoint(bounds.width * 0.5, bounds.height * 0.12)
 
-                pointD = NSMakePoint(bounds.width * 0.5, bounds.height * 0.5)
-                pointE = NSMakePoint(bounds.width * 0.5, bounds.height * 0.88)
-                pointF = NSMakePoint(bounds.width * 0.88, bounds.height * 0.5)
+                secondPointA = NSMakePoint(bounds.width * 0.5, bounds.height * 0.5)
+                secondPointB = NSMakePoint(bounds.width * 0.5, bounds.height * 0.88)
+                secondPointC = NSMakePoint(bounds.width * 0.88, bounds.height * 0.5)
             } else {
                 // Fullscreen symbol that the angles of the two triangles are back-to-back
-                pointA = NSMakePoint(bounds.width * 0.25, bounds.height * 0.25)
-                pointB = NSMakePoint(bounds.width * 0.25, bounds.height * 0.65)
-                pointC = NSMakePoint(bounds.width * 0.65, bounds.height * 0.25)
+                firstPointA = NSMakePoint(bounds.width * 0.25, bounds.height * 0.25)
+                firstPointB = NSMakePoint(bounds.width * 0.25, bounds.height * 0.65)
+                firstPointC = NSMakePoint(bounds.width * 0.65, bounds.height * 0.25)
 
-                pointD = NSMakePoint(bounds.width * 0.75, bounds.height * 0.75)
-                pointE = NSMakePoint(bounds.width * 0.35, bounds.height * 0.75)
-                pointF = NSMakePoint(bounds.width * 0.75, bounds.height * 0.35)
+                secondPointA = NSMakePoint(bounds.width * 0.75, bounds.height * 0.75)
+                secondPointB = NSMakePoint(bounds.width * 0.35, bounds.height * 0.75)
+                secondPointC = NSMakePoint(bounds.width * 0.75, bounds.height * 0.35)
             }
             // Draw first triangle
-            symbol.move(to: pointA)
-            symbol.line(to: pointB)
-            symbol.line(to: pointC)
+            symbol.move(to: firstPointA)
+            symbol.line(to: firstPointB)
+            symbol.line(to: firstPointC)
             symbol.close()
             lineColor.setFill()
             symbol.fill()
@@ -151,9 +151,9 @@ class TrafficLightButton: NSButton {
             symbol.removeAllPoints()
 
             // Draw second triangle
-            symbol.move(to: pointD)
-            symbol.line(to: pointE)
-            symbol.line(to: pointF)
+            symbol.move(to: secondPointA)
+            symbol.line(to: secondPointB)
+            symbol.line(to: secondPointC)
             symbol.close()
             lineColor.setFill()
             symbol.fill()

--- a/src/ui/generic-components/TrafficLightButton.swift
+++ b/src/ui/generic-components/TrafficLightButton.swift
@@ -119,89 +119,44 @@ class TrafficLightButton: NSButton {
     private func drawSymbol(_ lineColor: NSColor) {
         let symbol = NSBezierPath()
         if (type == .fullscreen) {
-            // First original triangle vertices
-            let pointA = NSMakePoint(bounds.width * 0.25, bounds.height * 0.75)
-            let pointB = NSMakePoint(bounds.width * 0.25, bounds.height * 1 / 3)
-            let pointC = NSMakePoint(bounds.width * 2 / 3, bounds.height * 0.75)
-
-            // Second original triangle vertices
-            let pointD = NSMakePoint(bounds.width * 0.75, bounds.height * 0.25)
-            let pointE = NSMakePoint(bounds.width * 0.75, bounds.height * 2 / 3)
-            let pointF = NSMakePoint(bounds.width * 1 / 3, bounds.height * 0.25)
-
-            // Rotated 90 degrees counterclockwise around the center
-            var transform = NSAffineTransform()
-            // Set the rotation center point to the center of the view
-            transform.translateX(by: bounds.midX, yBy: bounds.midY)
-            // Rotate counterclockwise by 90 degrees
-            transform.rotate(byDegrees: -90)
-            // Translate back to the original coordinate system
-            transform.translateX(by: -bounds.midX, yBy: -bounds.midY)
-            // Apply the transformation
-            transform.concat()
-
+            var pointA, pointB, pointC, pointD, pointE, pointF: NSPoint!
             if window_?.isFullscreen ?? true {
-                // Draw defullscreen symbol (two triangles with points facing away from each other)
-                // Center of the triangle
-                let centerX = (pointA.x + pointB.x + pointC.x) / 3
-                let centerY = (pointA.y + pointB.y + pointC.y) / 3
+                // Defullscreen symbol that the angles of the two triangles are face-to-face
+                pointA = NSMakePoint(bounds.width * 0.5, bounds.height * 0.5)
+                pointB = NSMakePoint(bounds.width * 0.12, bounds.height * 0.5)
+                pointC = NSMakePoint(bounds.width * 0.5, bounds.height * 0.12)
 
-                // Rotated vertices
-                let rotatedA = NSMakePoint(2 * centerX - pointA.x, 2 * centerY - pointA.y)
-                let rotatedB = NSMakePoint(2 * centerX - pointB.x, 2 * centerY - pointB.y)
-                let rotatedC = NSMakePoint(2 * centerX - pointC.x, 2 * centerY - pointC.y)
-
-                // Offset to separate the triangles
-                let offset: CGFloat = 0.5
-
-                // Draw the first rotated triangle with offset applied
-                symbol.move(to: NSMakePoint(rotatedA.x - offset, rotatedA.y + offset))
-                symbol.line(to: rotatedB)
-                symbol.line(to: rotatedC)
-                symbol.close()
-                lineColor.setFill()
-                symbol.fill()
-
-                // Clear path for the next triangle
-                symbol.removeAllPoints()
-
-                // Center of the second triangle
-                let centerX2 = (pointD.x + pointE.x + pointF.x) / 3
-                let centerY2 = (pointD.y + pointE.y + pointF.y) / 3
-
-                // Rotated vertices for the second triangle
-                let rotatedD = NSMakePoint(2 * centerX2 - pointD.x, 2 * centerY2 - pointD.y)
-                let rotatedE = NSMakePoint(2 * centerX2 - pointE.x, 2 * centerY2 - pointE.y)
-                let rotatedF = NSMakePoint(2 * centerX2 - pointF.x, 2 * centerY2 - pointF.y)
-
-                // Draw the second rotated triangle with offset applied
-                symbol.move(to: NSMakePoint(rotatedD.x + offset, rotatedD.y - offset))
-                symbol.line(to: rotatedE)
-                symbol.line(to: rotatedF)
-                symbol.close()
-                lineColor.setFill()
-                symbol.fill()
+                pointD = NSMakePoint(bounds.width * 0.5, bounds.height * 0.5)
+                pointE = NSMakePoint(bounds.width * 0.5, bounds.height * 0.88)
+                pointF = NSMakePoint(bounds.width * 0.88, bounds.height * 0.5)
             } else {
-                // Draw fullscreen symbol (two triangles)
-                // Draw first triangle
-                symbol.move(to: pointA)
-                symbol.line(to: pointB)
-                symbol.line(to: pointC)
-                symbol.close()
-                lineColor.setFill()
-                symbol.fill()
+                // Fullscreen symbol that the angles of the two triangles are back-to-back
+                pointA = NSMakePoint(bounds.width * 0.25, bounds.height * 0.25)
+                pointB = NSMakePoint(bounds.width * 0.25, bounds.height * 0.65)
+                pointC = NSMakePoint(bounds.width * 0.65, bounds.height * 0.25)
 
-                // Clear path for the next triangle
-                symbol.removeAllPoints()
-
-                // Draw second triangle
-                symbol.move(to: pointD)
-                symbol.line(to: pointE)
-                symbol.line(to: pointF)
-                symbol.close()
-                lineColor.setFill()
-                symbol.fill()
+                pointD = NSMakePoint(bounds.width * 0.75, bounds.height * 0.75)
+                pointE = NSMakePoint(bounds.width * 0.35, bounds.height * 0.75)
+                pointF = NSMakePoint(bounds.width * 0.75, bounds.height * 0.35)
             }
+            // Draw first triangle
+            symbol.move(to: pointA)
+            symbol.line(to: pointB)
+            symbol.line(to: pointC)
+            symbol.close()
+            lineColor.setFill()
+            symbol.fill()
+
+            // Clear path for the next triangle
+            symbol.removeAllPoints()
+
+            // Draw second triangle
+            symbol.move(to: pointD)
+            symbol.line(to: pointE)
+            symbol.line(to: pointF)
+            symbol.close()
+            lineColor.setFill()
+            symbol.fill()
         } else if (type == .miniaturize) {
             NSGraphicsContext.current?.shouldAntialias = false
             symbol.move(to: NSMakePoint(bounds.width * 0.20, bounds.height / 2))

--- a/src/ui/main-window/ThumbnailView.swift
+++ b/src/ui/main-window/ThumbnailView.swift
@@ -17,7 +17,7 @@ class ThumbnailView: NSStackView {
     var quitIcon = TrafficLightButton(.quit, NSLocalizedString("Quit app", comment: ""), windowsControlSize)
     var closeIcon = TrafficLightButton(.close, NSLocalizedString("Close window", comment: ""), windowsControlSize)
     var minimizeIcon = TrafficLightButton(.miniaturize, NSLocalizedString("Minimize/Deminimize window", comment: ""), windowsControlSize)
-    var maximizeIcon = TrafficLightButton(.fullscreen, NSLocalizedString("Fullscreen window", comment: ""), windowsControlSize)
+    var maximizeIcon = TrafficLightButton(.fullscreen, NSLocalizedString("Fullscreen/Defullscreen window", comment: ""), windowsControlSize)
     var hStackView: NSStackView!
     var mouseUpCallback: (() -> Void)!
     var mouseMovedCallback: (() -> Void)!
@@ -95,6 +95,9 @@ class ThumbnailView: NSStackView {
                         yOffset += ThumbnailView.windowsControlSize + ThumbnailView.windowsControlSpacing
                     }
                 }
+                // Force the icons to redraw, or after clicking the fullscreen button,
+                // it will still appear to be in fullscreen mode.
+                icon.display()
             }
         }
     }


### PR DESCRIPTION
Fix the the shape of fullscreen/defullscreen traffic light button.

before fixed:
- fullscreen
![b0f0e599e5809beac06e90d8134c61fb](https://github.com/lwouis/alt-tab-macos/assets/5805484/9fc62a75-70d6-4208-9972-867ba938cd8d)

- defullscreen
![b0f0e599e5809beac06e90d8134c61fb](https://github.com/lwouis/alt-tab-macos/assets/5805484/87cb9e15-47f2-4aef-986a-f1b7dd0d76b0)


after fixed:
- fullscreen
![b43f7b01ab3e71a235c73710e6799051](https://github.com/lwouis/alt-tab-macos/assets/5805484/0779ba57-7c91-4555-b31c-c82125a1d4b3)

- defullscreen
![925086e1a44fc40c498d9af47f119d10](https://github.com/lwouis/alt-tab-macos/assets/5805484/5978ca13-b270-4bfd-96df-3f69acd5b2b2)
