### PR TITLE
feat: limit windows per app

### DIFF
--- a/src/logic/Applications.swift
+++ b/src/logic/Applications.swift
@@ -59,7 +59,7 @@ class Applications {
             // comparing pid here can fail here, as it can be already nil; we use isEqual here to avoid the issue
             Applications.list.removeAll { $0.runningApplication.isEqual(runningApp) }
             Windows.list.enumerated().forEach { (index, window) in
-                if window.application.runningApplication.isEqual(runningApp) && index < Windows.focusedWindowIndex && window.shouldShowTheUser {
+                if window.application.runningApplication.isEqual(runningApp) && index < Windows.focusedWindowIndex && window.shouldReallyShowTheUser {
                     windowsOnTheLeftOfFocusedWindow += 1
                 }
             }

--- a/src/logic/DebugProfile.swift
+++ b/src/logic/DebugProfile.swift
@@ -85,6 +85,7 @@ class DebugProfile {
             ("isTabbed", String(window.isTabbed)),
             ("isOnAllSpaces", String(window.isOnAllSpaces)),
             ("shouldShowTheUser", String(window.shouldShowTheUser)),
+            ("shouldHideTheUser", String(window.shouldHideTheUser)),
             ("spaceId", String(window.spaceId)),
             ("spaceIndex", String(window.spaceIndex)),
         ])

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -95,6 +95,16 @@ class Preferences {
         "hideWindowlessApps": "false",
         "hideThumbnails": "false",
         "previewFocusedWindow": "false",
+        "limitWindowCountPerApp": "false",
+        "limitWindowCountPerApp2": "false",
+        "limitWindowCountPerApp3": "false",
+        "limitWindowCountPerApp4": "false",
+        "limitWindowCountPerApp5": "false",
+        "windowCountPerApp": "1",
+        "windowCountPerApp2": "1",
+        "windowCountPerApp3": "1",
+        "windowCountPerApp4": "1",
+        "windowCountPerApp5": "1",
     ]
 
     // system preferences
@@ -141,6 +151,8 @@ class Preferences {
     static var startAtLogin: Bool { defaults.bool("startAtLogin") }
     static var blacklist: [BlacklistEntry] { jsonDecode([BlacklistEntry].self, defaults.string("blacklist")) }
     static var previewFocusedWindow: Bool { defaults.bool("previewFocusedWindow") }
+    static var limitWindowCountPerApp: [Bool] { ["limitWindowCountPerApp", "limitWindowCountPerApp2", "limitWindowCountPerApp3", "limitWindowCountPerApp4", "limitWindowCountPerApp5"].map { defaults.bool($0) } }
+    static var windowCountPerApp: [Int] { ["windowCountPerApp", "windowCountPerApp2", "windowCountPerApp3", "windowCountPerApp4", "windowCountPerApp5"].map { defaults.int($0) } }
 
     // macro values
     static var theme: ThemePreference { defaults.macroPref("theme", ThemePreference.allCases) }

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -10,6 +10,8 @@ class Window {
     var thumbnailFullSize: NSSize?
     var icon: NSImage? { get { application.icon } }
     var shouldShowTheUser = true
+    var shouldHideTheUser = false
+    var shouldReallyShowTheUser: Bool { shouldShowTheUser && !shouldHideTheUser }
     var isTabbed: Bool = false
     var isHidden: Bool { get { application.isHidden } }
     var dockLabel: String? { get { application.dockLabel } }

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -251,10 +251,13 @@ class App: AppCenterApplication, NSApplicationDelegate {
         Spaces.refreshAllIdsAndIndexes()
         guard appIsBeingUsed else { return }
         refreshSpecificWindows(windowsToUpdate, currentScreen)
-        if (!Windows.list.contains { $0.shouldShowTheUser }) { hideUi(); return }
+        if (!Windows.list.contains { $0.shouldReallyShowTheUser }) { hideUi(); return }
         guard appIsBeingUsed else { return }
         Windows.reorderList()
         Windows.updateFocusedWindowIndex()
+        guard appIsBeingUsed else { return }
+        Windows.refreshWhichWindowsToHideTheUser()
+        if (!Windows.list.contains { $0.shouldReallyShowTheUser }) { hideUi(); return }
         guard appIsBeingUsed else { return }
         thumbnailsPanel.thumbnailsView.updateItemsAndLayout(currentScreen)
         guard appIsBeingUsed else { return }
@@ -295,7 +298,8 @@ class App: AppCenterApplication, NSApplicationDelegate {
             self.shortcutIndex = shortcutIndex
             Windows.refreshWhichWindowsToShowTheUser(screen)
             Windows.reorderList()
-            if (!Windows.list.contains { $0.shouldShowTheUser }) { hideUi(); return }
+            Windows.refreshWhichWindowsToHideTheUser()
+            if (!Windows.list.contains { $0.shouldReallyShowTheUser }) { hideUi(); return }
             Windows.setInitialFocusedAndHoveredWindowIndex()
             delayedDisplayScheduled += 1
             DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Preferences.windowDisplayDelay) { () -> () in

--- a/src/ui/main-window/ThumbnailsView.swift
+++ b/src/ui/main-window/ThumbnailsView.swift
@@ -106,7 +106,7 @@ class ThumbnailsView: NSVisualEffectView {
         rows.append([ThumbnailView]())
         for (index, window) in Windows.list.enumerated() {
             guard App.app.appIsBeingUsed else { return nil }
-            guard window.shouldShowTheUser else { continue }
+            guard window.shouldReallyShowTheUser else { continue }
             let view = ThumbnailsView.recycledViews[index]
             view.updateRecycledCellWithNewContent(window, index, height, screen)
             let width = view.frame.size.width
@@ -172,7 +172,7 @@ class ThumbnailsView: NSVisualEffectView {
         var rowY = Preferences.interCellPadding
         for (index, window) in Windows.list.enumerated() {
             guard App.app.appIsBeingUsed else { return }
-            guard window.shouldShowTheUser else { continue }
+            guard window.shouldReallyShowTheUser else { continue }
             let view = ThumbnailsView.recycledViews[index]
             if view.frame.origin.y == rowY {
                 rowWidth += view.frame.size.width + Preferences.interCellPadding

--- a/src/ui/preferences-window/tabs/ControlsTab.swift
+++ b/src/ui/preferences-window/tabs/ControlsTab.swift
@@ -116,6 +116,8 @@ class ControlsTab {
         let showHiddenWindows = LabelAndControl.makeDropdown(Preferences.indexToName("showHiddenWindows", index), ShowHowPreference.allCases)
         let showFullscreenWindows = LabelAndControl.makeDropdown(Preferences.indexToName("showFullscreenWindows", index), ShowHowPreference.allCases.filter { $0 != .showAtTheEnd })
         let windowOrder = LabelAndControl.makeDropdown(Preferences.indexToName("windowOrder", index), WindowOrderPreference.allCases)
+        let limitWindowCountPerApp = LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Limit windows per app:", comment: ""), Preferences.indexToName("limitWindowCountPerApp", index))
+        let windowCountPerApp = LabelAndControl.makeLabelWithSlider("", Preferences.indexToName("windowCountPerApp", index), 1, 10, 10, true)
         let separator = NSBox()
         separator.boxType = .separator
         let nextWindowShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Select next window", comment: ""), Preferences.indexToName("nextWindowShortcut", index), Preferences.nextWindowShortcut[index], labelPosition: .right)
@@ -129,12 +131,13 @@ class ControlsTab {
             [toShowExplanations3, showHiddenWindows],
             [toShowExplanations4, showFullscreenWindows],
             [windowOrderExplanation, windowOrder],
+            [limitWindowCountPerApp[0], StackView([limitWindowCountPerApp[1], windowCountPerApp[1], windowCountPerApp[2]], .horizontal, false)],
             [separator],
             [holdAndPress, StackView(nextWindowShortcut)],
             shortcutStyle,
         ], TabView.padding)
         tab.column(at: 0).xPlacement = .trailing
-        tab.mergeCells(inHorizontalRange: NSRange(location: 0, length: 2), verticalRange: NSRange(location: 5, length: 1))
+        tab.mergeCells(inHorizontalRange: NSRange(location: 0, length: 2), verticalRange: NSRange(location: 6, length: 1))
         tab.fit()
         return (holdShortcut, nextWindowShortcut, tab)
     }


### PR DESCRIPTION
It could be useful to limit the number of windows in a shortcut with all the apps. A shortcut with the active app can still be used if necessary.