### PR TITLE
fix: adjust Quit button position based on system language direction

### DIFF
--- a/src/ui/preferences-window/PreferencesWindow.swift
+++ b/src/ui/preferences-window/PreferencesWindow.swift
@@ -23,7 +23,11 @@ class PreferencesWindow: NSWindow, NSToolbarDelegate {
         titleBarView.addSubview(quitButton)
         quitButton.translatesAutoresizingMaskIntoConstraints = false
         quitButton.topAnchor.constraint(equalTo: titleBarView.topAnchor, constant: 5).isActive = true
-        quitButton.rightAnchor.constraint(equalTo: titleBarView.rightAnchor, constant: -8).isActive = true
+        if self.windowTitlebarLayoutDirection == .rightToLeft {
+            quitButton.leftAnchor.constraint(equalTo: titleBarView.leftAnchor, constant: 8).isActive = true
+        } else {
+            quitButton.rightAnchor.constraint(equalTo: titleBarView.rightAnchor, constant: -8).isActive = true
+        }
     }
 
     private func setupView() {


### PR DESCRIPTION
These changes should work, although I haven't tested them locally as I couldn't build the project - I get an error:
```
No such module 'ShortcutRecorder'
```
![CleanShot 2024-07-14 at 03 53 42@2x](https://github.com/user-attachments/assets/f34b1ddb-baa8-4c2f-8d8d-5fed9da05f52)


closes #3487