### PR TITLE
feat: Hiding windowless apps can be customized per shortcut

### DIFF
--- a/src/logic/Application.swift
+++ b/src/logic/Application.swift
@@ -111,8 +111,7 @@ class Application: NSObject {
     }
 
     func addWindowslessAppsIfNeeded() -> [Window]? {
-        if !Preferences.hideWindowlessApps &&
-               runningApplication.activationPolicy == .regular &&
+        if runningApplication.activationPolicy == .regular &&
                !runningApplication.isTerminated &&
                (Windows.list.firstIndex { $0.application.pid == pid }) == nil {
             let window = Window(self)

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -307,7 +307,7 @@ class Windows {
             } ?? false) &&
             !(Preferences.appsToShow[App.app.shortcutIndex] == .active && window.application.runningApplication.processIdentifier != NSWorkspace.shared.frontmostApplication?.processIdentifier) &&
             !(!(Preferences.showHiddenWindows[App.app.shortcutIndex] != .hide) && window.isHidden) &&
-            ((!Preferences.hideWindowlessApps && window.isWindowlessApp) ||
+                ((!Preferences.hideWindowlessApps[App.app.shortcutIndex] && window.isWindowlessApp) ||
                 !window.isWindowlessApp &&
                 !(!(Preferences.showFullscreenWindows[App.app.shortcutIndex] != .hide) && window.isFullscreen) &&
                 !(!(Preferences.showMinimizedWindows[App.app.shortcutIndex] != .hide) && window.isMinimized) &&

--- a/src/ui/preferences-window/tabs/AppearanceTab.swift
+++ b/src/ui/preferences-window/tabs/AppearanceTab.swift
@@ -30,7 +30,6 @@ class AppearanceTab {
             LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Show standard tabs as windows:", comment: ""), "showTabsAsWindows"),
             LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Hide colored circles on mouse hover:", comment: ""), "hideColoredCircles"),
             LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Hide app badges:", comment: ""), "hideAppBadges"),
-            LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Hide apps with no open window:", comment: ""), "hideWindowlessApps"),
             LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Preview selected window:", comment: ""), "previewFocusedWindow"),
         ])
         grid.column(at: 0).xPlacement = .trailing

--- a/src/ui/preferences-window/tabs/ControlsTab.swift
+++ b/src/ui/preferences-window/tabs/ControlsTab.swift
@@ -121,6 +121,7 @@ class ControlsTab {
         let nextWindowShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Select next window", comment: ""), Preferences.indexToName("nextWindowShortcut", index), Preferences.nextWindowShortcut[index], labelPosition: .right)
         let shortcutStyle = LabelAndControl.makeLabelWithDropdown(NSLocalizedString("Then release:", comment: ""), Preferences.indexToName("shortcutStyle", index), ShortcutStylePreference.allCases)
         let toShowDropdowns = StackView([appsToShow, spacesToShow, screensToShow], .vertical, false)
+        let hideWindowlessApps = LabelAndControl.makeLabelWithCheckbox(NSLocalizedString("Hide apps with no open window:", comment: ""), Preferences.indexToName("hideWindowlessApps", index))
         toShowDropdowns.spacing = TabView.padding
         toShowDropdowns.fit()
         let tab = GridView([
@@ -130,6 +131,7 @@ class ControlsTab {
             [toShowExplanations4, showFullscreenWindows],
             [windowOrderExplanation, windowOrder],
             [separator],
+            hideWindowlessApps,
             [holdAndPress, StackView(nextWindowShortcut)],
             shortcutStyle,
         ], TabView.padding)


### PR DESCRIPTION
This PR allows to hide windowless apps from Alt Tab per shortcut instead of just having a single global option.

I have a shortcut to only show windows from visible spaces, which I find very helpful when dealing with Apples terrible keyboard handling in Mission Control. For this shortcut I didn't want to see any windowless apps, but for my main shortcut I wanted to be able to see all open apps, including the windowless ones. Alt Tab wasn't able to provide this, which motivated me to create this PR.

Users from previous versions of Alt Tab will have their global configuration applied to all shortcuts once after updating, allowing a seemless transition.