### PR TITLE
fix: title direction in RTL langs

### DIFF
--- a/src/ui/generic-components/TableGroupView.swift
+++ b/src/ui/generic-components/TableGroupView.swift
@@ -235,13 +235,13 @@ class TableGroupView: ClickHoverStackView {
     private func setupTitleView() {
         if title == nil && subTitle == nil { return }
         titleStackView.orientation = .vertical
-        titleStackView.alignment = .left
+        titleStackView.alignment = .leading
         titleStackView.spacing = TableGroupView.rowIntraSpacing
 
         if let title = title {
             titleLabel.stringValue = title
             titleLabel.font = NSFont.boldSystemFont(ofSize: 13)
-            titleLabel.alignment = .left
+            titleLabel.alignment = .natural
             titleLabel.lineBreakMode = .byWordWrapping
             titleLabel.maximumNumberOfLines = 0
 
@@ -261,7 +261,7 @@ class TableGroupView: ClickHoverStackView {
             subTitleLabel.stringValue = subTitle
             subTitleLabel.font = NSFont.systemFont(ofSize: 12)
             subTitleLabel.textColor = .gray
-            subTitleLabel.alignment = .left
+            subTitleLabel.alignment = .natural
             subTitleLabel.lineBreakMode = .byWordWrapping
             subTitleLabel.maximumNumberOfLines = 0
 


### PR DESCRIPTION
Fix titles so that AppKit automatically aligns them to the right when RTL language is selected, instead of hard-coding them to the left.

before
![CleanShot 2024-10-11 at 13 58 34@2x](https://github.com/user-attachments/assets/d4647a29-5ac2-42da-b76c-15d34332c9d6)
after
![CleanShot 2024-10-11 at 14 49 39@2x](https://github.com/user-attachments/assets/03b7a41f-4f0d-4410-89b7-22846a9dc230)

