### PR TITLE
fix: always compute preview window origin.y using primary display

### DIFF
--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -161,7 +161,10 @@ class Windows {
         }
         App.app.previewPanel.setPreview(preview)
         var frame = NSRect(origin: position, size: size)
-        frame.origin.y = NSScreen.preferred().frame.maxY - frame.maxY
+        // Flip Y coordinate from Quartz (0,0 at bottom-left) to Cocoa coordinates (0,0 at top-left)
+        // Always use the primary screen as reference since all coordinates are relative to it
+        let primaryScreen = NSScreen.screens.first!
+        frame.origin.y = primaryScreen.frame.maxY - frame.maxY
         App.app.previewPanel.setFrame(frame, display: false)
         App.app.previewPanel.order(.below, relativeTo: App.app.thumbnailsPanel.windowNumber)
     }


### PR DESCRIPTION
The `previewFocusedWindowIfNeeded` function incorrectly positions the preview window when multiple monitors are in use, and the `Preferences.showOnScreen` setting is not set to `includingMenubar`. This happens because`NSScreen.preferred()` uses the screen with the mouse or the currently active screen when performing its calculation for the coordinate inversion of the window Preview Frame y origin position. Instead, it should **always** use the primary screen (`NSScreen.screens.first`), which is the reference point for the global coordinate system, to determine the correct position of the preview panel.

https://github.com/user-attachments/assets/1407c549-bcd8-4e19-94e5-322eaac8766f

