### PR TITLE
fix: language switcher picked up as window

### DIFF
--- a/src/api-wrappers/AXUIElement.swift
+++ b/src/api-wrappers/AXUIElement.swift
@@ -238,8 +238,9 @@ extension AXUIElement {
         // Some non-windows have cgWindowId == 0 (e.g. windows of apps starting at login with the checkbox "Hidden" checked)
         return wid != 0
             // Finder's file copy dialogs are wide but < 100 height (see https://github.com/lwouis/alt-tab-macos/issues/1466)
-            // Sonoma introduced a bug: a caps-lock indicator shows as a small window. We try to hide it by filtering out tiny windows
-            && size != nil && (size!.width > 100 || size!.height > 100) && (
+            // Sonoma introduced a bug: a caps-lock & language indicators shows as a small window.
+            // We try to hide it by filtering out tiny windows
+            && size != nil && (size!.width > 100 && size!.height > 50) && (
             (
                 books(app) ||
                     keynote(app) ||


### PR DESCRIPTION
Modified the logic that checks which windows to include in the dialog so small windows like the small language switcher or the caps lock indicator aren't picked up as windows.

Fixes #4390 

In my testing, it still picks up the finder copy dialog, as it is taller than 50.

