### PR TITLE
Per-Shortcut “Show in Switcher” Configuration for a More Flexible Alt-Tab Experience

### DIFF
--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -51,7 +51,10 @@ class Preferences {
         "showOnScreen": ShowOnScreenPreference.active.indexAsString,
         "titleTruncation": TitleTruncationPreference.end.indexAsString,
         "alignThumbnails": AlignThumbnailsPreference.center.indexAsString,
-        "showAppsOrWindows": ShowAppsOrWindowsPreference.windows.indexAsString,
+        "showAppsOrWindows": ShowAppsOrWindowsPreference.applications.indexAsString,
+        "showAppsOrWindows2": ShowAppsOrWindowsPreference.windows.indexAsString,
+        "showAppsOrWindows3": ShowAppsOrWindowsPreference.windows.indexAsString,
+        "showAppsOrWindows4": ShowAppsOrWindowsPreference.windows.indexAsString,
         "showTitles": ShowTitlesPreference.windowTitle.indexAsString,
         "appsToShow": AppsToShowPreference.all.indexAsString,
         "appsToShow2": AppsToShowPreference.active.indexAsString,
@@ -133,7 +136,16 @@ class Preferences {
     static var showOnScreen: ShowOnScreenPreference { CachedUserDefaults.macroPref("showOnScreen", ShowOnScreenPreference.allCases) }
     static var titleTruncation: TitleTruncationPreference { CachedUserDefaults.macroPref("titleTruncation", TitleTruncationPreference.allCases) }
     static var alignThumbnails: AlignThumbnailsPreference { CachedUserDefaults.macroPref("alignThumbnails", AlignThumbnailsPreference.allCases) }
-    static var showAppsOrWindows: ShowAppsOrWindowsPreference { CachedUserDefaults.macroPref("showAppsOrWindows", ShowAppsOrWindowsPreference.allCases) }
+    static var showAppsOrWindows: [ShowAppsOrWindowsPreference] {
+        return [
+            "showAppsOrWindows",
+            "showAppsOrWindows2",
+            "showAppsOrWindows3",
+            "showAppsOrWindows4"
+        ].map { key in
+            CachedUserDefaults.macroPref(key, ShowAppsOrWindowsPreference.allCases)
+        }
+    }
     static var showTitles: ShowTitlesPreference { CachedUserDefaults.macroPref("showTitles", ShowTitlesPreference.allCases) }
     static var updatePolicy: UpdatePolicyPreference { CachedUserDefaults.macroPref("updatePolicy", UpdatePolicyPreference.allCases) }
     static var crashPolicy: CrashPolicyPreference { CachedUserDefaults.macroPref("crashPolicy", CrashPolicyPreference.allCases) }
@@ -177,8 +189,21 @@ class Preferences {
 
     static var all: [String: Any] { UserDefaults.standard.persistentDomain(forName: App.bundleIdentifier)! }
 
-    static func onlyShowApplications() -> Bool {
-        return Preferences.showAppsOrWindows == .applications && Preferences.appearanceStyle != .thumbnails
+    static func onlyShowApplications(_ index: Int) -> Bool {
+        Logger.info("Vitor 2")
+        Logger.info("index")
+        Logger.info(index)
+        Logger.info("index setting")
+        Logger.info(showAppsOrWindows[index])
+        Logger.info("style")
+        Logger.info(appearanceStyle)
+        
+        
+        Logger.info(showAppsOrWindows[index] == .applications
+                    && appearanceStyle != .thumbnails)
+        
+        return showAppsOrWindows[index] == .applications
+            && appearanceStyle != .thumbnails
     }
 
     /// key-above-tab is ` on US keyboard, but can be different on other keyboards

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -167,7 +167,7 @@ class Window {
             App.shared.activate(ignoringOtherApps: true)
             App.app.window(withWindowNumber: Int(cgWindowId!))?.makeKeyAndOrderFront(nil)
             Windows.previewFocusedWindowIfNeeded()
-        } else if isWindowlessApp || cgWindowId == nil || Preferences.onlyShowApplications() {
+        } else if isWindowlessApp || cgWindowId == nil || Preferences.onlyShowApplications(App.app.shortcutIndex) {
             if let bundleUrl, isWindowlessApp {
                 if (try? NSWorkspace.shared.launchApplication(at: bundleUrl, configuration: [:])) == nil {
                     application.runningApplication.activate(options: .activateAllWindows)

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -192,7 +192,7 @@ class Windows {
 
     static func previewFocusedWindowIfNeeded() {
         if App.app.appIsBeingUsed && SystemPermissions.screenRecordingPermission == .granted
-               && Preferences.previewFocusedWindow && !Preferences.onlyShowApplications()
+               && Preferences.previewFocusedWindow && !Preferences.onlyShowApplications(App.app.shortcutIndex)
                && App.app.thumbnailsPanel.isKeyWindow,
            let window = focusedWindow(),
            let id = window.cgWindowId,
@@ -341,7 +341,7 @@ class Windows {
     }
 
     static func refreshWhichWindowsToShowTheUser() {
-        if Preferences.onlyShowApplications() {
+        if Preferences.onlyShowApplications(App.app.shortcutIndex) {
             // Group windows by application and select the optimal main window
             let windowsGroupedByApp = Dictionary(grouping: list) { $0.application.pid }
             windowsGroupedByApp.forEach { (app, windows) in

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -200,7 +200,7 @@ class App: AppCenterApplication {
 
     func refreshOpenUi(_ windowsToScreenshot: [Window], _ source: RefreshCausedBy) {
         if !windowsToScreenshot.isEmpty && SystemPermissions.screenRecordingPermission == .granted
-               && !Preferences.onlyShowApplications()
+               && !Preferences.onlyShowApplications(self.shortcutIndex)
                && (!Appearance.hideThumbnails || Preferences.previewFocusedWindow) {
             Windows.refreshThumbnails(windowsToScreenshot, source)
             if source == .refreshOnlyThumbnailsAfterShowUi { return }
@@ -227,7 +227,8 @@ class App: AppCenterApplication {
     }
 
     func showUiOrCycleSelection(_ shortcutIndex: Int) {
-        Logger.debug(shortcutIndex, self.shortcutIndex, isFirstSummon)
+        Logger.info(shortcutIndex, self.shortcutIndex, isFirstSummon)
+        Logger.info("Vitor")
         App.app.appIsBeingUsed = true
         if isFirstSummon || shortcutIndex != self.shortcutIndex {
             if isVeryFirstSummon {

--- a/src/ui/main-window/ThumbnailView.swift
+++ b/src/ui/main-window/ThumbnailView.swift
@@ -449,7 +449,7 @@ class ThumbnailView: FlippedView {
     private func getAppOrAndWindowTitle() -> String {
         let appName = window_?.application.localizedName
         let windowTitle = window_?.title
-        if Preferences.onlyShowApplications() || Preferences.showTitles == .appName {
+        if Preferences.onlyShowApplications(App.app.shortcutIndex) || Preferences.showTitles == .appName {
             return appName ?? ""
         } else if Preferences.showTitles == .appNameAndWindowTitle {
             return [appName, windowTitle].compactMap { $0 }.joined(separator: " - ")

--- a/src/ui/preferences-window/tabs/appearance/AppearanceTab.swift
+++ b/src/ui/preferences-window/tabs/appearance/AppearanceTab.swift
@@ -246,7 +246,7 @@ class ShowHideIllustratedView {
 
     static func isDisabledOnApplications(_ row: ShowHideRowInfo) -> Bool {
         let contains = ["showTabsAsWindows", "previewFocusedWindow"].contains(where: { $0 == row.rowId })
-        return contains && Preferences.onlyShowApplications()
+        return contains && Preferences.onlyShowApplications(App.app.shortcutIndex)
     }
 
     func setStateOnApplications(row: ShowHideRowInfo? = nil) {

--- a/src/ui/preferences-window/tabs/appearance/CustomizeStyleSheet.swift
+++ b/src/ui/preferences-window/tabs/appearance/CustomizeStyleSheet.swift
@@ -9,7 +9,6 @@ class CustomizeStyleSheet: SheetWindow {
 
     var alignThumbnails: TableGroupView.Row!
     var titleTruncation: TableGroupView.Row!
-    var showAppsOrWindows: TableGroupView.Row!
     var showTitles: TableGroupView.Row!
     var showTitlesRowInfo: TableGroupView.RowInfo!
 
@@ -20,6 +19,7 @@ class CustomizeStyleSheet: SheetWindow {
     override func makeContentView() -> NSView {
         makeComponents()
         showHideView = showHideIllustratedView.makeView()
+
         if style == .thumbnails {
             advancedView = makeThumbnailsView()
         } else if style == .appIcons {
@@ -27,14 +27,24 @@ class CustomizeStyleSheet: SheetWindow {
         } else if style == .titles {
             advancedView = makeTitlesView()
         }
-        control = NSSegmentedControl(labels: [
-            NSLocalizedString("Show & Hide", comment: ""),
-            NSLocalizedString("Advanced", comment: "")
-        ], trackingMode: .selectOne, target: self, action: #selector(switchTab(_:)))
+
+        control = NSSegmentedControl(
+            labels: [
+                NSLocalizedString("Show & Hide", comment: ""),
+                NSLocalizedString("Advanced", comment: "")
+            ],
+            trackingMode: .selectOne,
+            target: self,
+            action: #selector(switchTab(_:))
+        )
         control.selectedSegment = 0
         control.segmentStyle = .automatic
         control.widthAnchor.constraint(equalToConstant: CustomizeStyleSheet.width).isActive = true
-        let view = TableGroupSetView(originalViews: [illustratedImageView, control, showHideView, advancedView], padding: 0)
+
+        let view = TableGroupSetView(
+            originalViews: [illustratedImageView, control, showHideView, advancedView],
+            padding: 0
+        )
         return view
     }
 
@@ -46,48 +56,61 @@ class CustomizeStyleSheet: SheetWindow {
     private func makeComponents() {
         illustratedImageView = IllustratedImageThemeView(style, CustomizeStyleSheet.illustratedImageWidth)
         showHideIllustratedView = ShowHideIllustratedView(style, illustratedImageView)
-        alignThumbnails = TableGroupView.Row(leftTitle: NSLocalizedString("Align windows", comment: ""),
+
+        alignThumbnails = TableGroupView.Row(
+            leftTitle: NSLocalizedString("Align windows", comment: ""),
             rightViews: LabelAndControl.makeRadioButtons(
-                "alignThumbnails", AlignThumbnailsPreference.allCases, extraAction: { _ in
-                self.showAlignThumbnailsIllustratedImage()
-            }))
-        titleTruncation = TableGroupView.Row(leftTitle: NSLocalizedString("Title truncation", comment: ""),
-            rightViews: LabelAndControl.makeRadioButtons("titleTruncation", TitleTruncationPreference.allCases))
-        let showAppWindowsInfo = LabelAndControl.makeInfoButton(onMouseEntered: { (event, view) in
-            Popover.shared.show(event: event, positioningView: view,
-                message: NSLocalizedString("Show an item in the switcher for each window, or for each application. Windows will be focused, whereas applications will be activated.", comment: ""))
-        }, onMouseExited: { (event, view) in
-            Popover.shared.hide()
-        })
-        showAppsOrWindows = TableGroupView.Row(leftTitle: NSLocalizedString("Show in switcher", comment: ""),
-            rightViews: LabelAndControl.makeRadioButtons("showAppsOrWindows", ShowAppsOrWindowsPreference.allCases, extraAction: { _ in
-                self.showHideIllustratedView.setStateOnApplications()
-                self.toggleAppNamesWindowTitles()
-                self.showAppsOrWindowsIllustratedImage()
-            }) + [showAppWindowsInfo])
-        showTitles = TableGroupView.Row(leftTitle: NSLocalizedString("Show titles", comment: ""),
-            rightViews: [LabelAndControl.makeDropdown(
-                "showTitles", ShowTitlesPreference.allCases, extraAction: { _ in
-                self.showAppsOrWindowsIllustratedImage()
-            })])
+                "alignThumbnails",
+                AlignThumbnailsPreference.allCases,
+                extraAction: { _ in self.showAlignThumbnailsIllustratedImage() }
+            )
+        )
+
+        titleTruncation = TableGroupView.Row(
+            leftTitle: NSLocalizedString("Title truncation", comment: ""),
+            rightViews: LabelAndControl.makeRadioButtons(
+                "titleTruncation",
+                TitleTruncationPreference.allCases
+            )
+        )
+
+        showTitles = TableGroupView.Row(
+            leftTitle: NSLocalizedString("Show titles", comment: ""),
+            rightViews: [
+                LabelAndControl.makeDropdown(
+                    "showTitles",
+                    ShowTitlesPreference.allCases,
+                    extraAction: { _ in self.showAlignThumbnailsIllustratedImage() }
+                )
+            ]
+        )
     }
 
     private func makeThumbnailsView() -> TableGroupSetView {
         let table = TableGroupView(width: CustomizeStyleSheet.width)
-        showTitlesRowInfo = table.addRow(showTitles, onMouseEntered: { event, view in
-            self.showAppsOrWindowsIllustratedImage()
-        })
+
+        showTitlesRowInfo = table.addRow(
+            showTitles,
+            onMouseEntered: { event, view in
+                self.showAlignThumbnailsIllustratedImage()
+            }
+        )
         table.addNewTable()
-        table.addRow(alignThumbnails, onMouseEntered: { event, view in
-            self.showAlignThumbnailsIllustratedImage()
-        }, onMouseExited: { event, view in
-            IllustratedImageThemeView.resetImage(self.illustratedImageView, event, view)
-        })
+        table.addRow(
+            alignThumbnails,
+            onMouseEntered: { event, view in
+                self.showAlignThumbnailsIllustratedImage()
+            },
+            onMouseExited: { event, view in
+                IllustratedImageThemeView.resetImage(self.illustratedImageView, event, view)
+            }
+        )
         table.addRow(titleTruncation)
         table.onMouseExited = { event, view in
             IllustratedImageThemeView.resetImage(self.illustratedImageView, event, view)
         }
         table.fit()
+
         let view = TableGroupSetView(originalViews: [table], padding: 0)
         return view
     }
@@ -95,13 +118,17 @@ class CustomizeStyleSheet: SheetWindow {
     private func makeAppIconsView() -> TableGroupSetView {
         let table = makeAppWindowTableGroupView()
         table.addNewTable()
-        table.addRow(alignThumbnails, onMouseEntered: { event, view in
-            self.showAlignThumbnailsIllustratedImage()
-        })
+        table.addRow(
+            alignThumbnails,
+            onMouseEntered: { event, view in
+                self.showAlignThumbnailsIllustratedImage()
+            }
+        )
         table.onMouseExited = { event, view in
             IllustratedImageThemeView.resetImage(self.illustratedImageView, event, view)
         }
         table.fit()
+
         let view = TableGroupSetView(originalViews: [table], padding: 0)
         toggleAppNamesWindowTitles()
         return view
@@ -112,6 +139,7 @@ class CustomizeStyleSheet: SheetWindow {
         table.addNewTable()
         table.addRow(titleTruncation)
         table.fit()
+
         let view = TableGroupSetView(originalViews: [table], padding: 0)
         toggleAppNamesWindowTitles()
         return view
@@ -119,13 +147,16 @@ class CustomizeStyleSheet: SheetWindow {
 
     private func makeAppWindowTableGroupView() -> TableGroupView {
         let view = TableGroupView(width: CustomizeStyleSheet.width)
-        view.addRow(showAppsOrWindows, onMouseEntered: { event, view in
-            self.showAppsOrWindowsIllustratedImage()
-        })
+
+        // Removed the old “Show in switcher” row entirely.
+
         view.addNewTable()
-        showTitlesRowInfo = view.addRow(showTitles, onMouseEntered: { event, view in
-            self.showAppsOrWindowsIllustratedImage()
-        })
+        showTitlesRowInfo = view.addRow(
+            showTitles,
+            onMouseEntered: { event, view in
+                self.showAlignThumbnailsIllustratedImage()
+            }
+        )
         view.onMouseExited = { event, view in
             IllustratedImageThemeView.resetImage(self.illustratedImageView, event, view)
         }
@@ -133,49 +164,39 @@ class CustomizeStyleSheet: SheetWindow {
     }
 
     private func toggleAppNamesWindowTitles() {
-        var isEnabled = false
-        if Preferences.showAppsOrWindows == .windows || Preferences.appearanceStyle == .thumbnails {
-            isEnabled = true
-        }
+        // Now read the per-shortcut “Show in switcher” value using the current index
+        let isEnabled = (Preferences.showAppsOrWindows[App.app.shortcutIndex] == .windows)
+                        || (Preferences.appearanceStyle == .thumbnails)
+
         showTitlesRowInfo.leftViews?.forEach { view in
-            if let view = view as? NSTextField {
-                view.textColor = isEnabled ? NSColor.textColor : NSColor.gray
+            if let tf = view as? NSTextField {
+                tf.textColor = isEnabled ? .textColor : .gray
             }
         }
         showTitlesRowInfo.rightViews?.forEach { view in
-            if let view = view as? NSControl {
-                view.isEnabled = isEnabled
+            if let ctrl = view as? NSControl {
+                ctrl.isEnabled = isEnabled
             }
         }
     }
 
     private func showAlignThumbnailsIllustratedImage() {
-        illustratedImageView.highlight(true, Preferences.alignThumbnails.image.name)
-    }
-
-    private func showAppsOrWindowsIllustratedImage() {
-        var imageName = Preferences.showTitles.image.name
-        if Preferences.onlyShowApplications() {
-            imageName = ShowTitlesPreference.appName.image.name
-        }
-        illustratedImageView.highlight(true, imageName)
+        illustratedImageView.highlight(
+            true,
+            Preferences.alignThumbnails.image.name
+        )
     }
 
     @objc func switchTab(_ sender: NSSegmentedControl) {
         let selectedIndex = sender.selectedSegment
         [showHideView, advancedView].enumerated().forEach { (index, view) in
-            if selectedIndex == index {
-                view!.isHidden = false
-            } else {
-                view!.isHidden = true
-            }
+            view!.isHidden = (index != selectedIndex)
         }
         adjustWindowHeight()
     }
 
     private func adjustWindowHeight() {
         guard let contentView else { return }
-        // Calculate the fitting height of the content view
         let fittingSize = contentView.fittingSize
         var windowFrame = frame
         windowFrame.size.height = fittingSize.height

--- a/src/ui/preferences-window/tabs/controls/ControlsTab.swift
+++ b/src/ui/preferences-window/tabs/controls/ControlsTab.swift
@@ -99,25 +99,114 @@ class ControlsTab {
     }
 
     private static func controlTab(_ index: Int, _ trigger: [NSView]) -> TableGroupView {
-        let appsToShow = LabelAndControl.makeDropdown(Preferences.indexToName("appsToShow", index), AppsToShowPreference.allCases)
-        let spacesToShow = LabelAndControl.makeDropdown(Preferences.indexToName("spacesToShow", index), SpacesToShowPreference.allCases)
-        let screensToShow = LabelAndControl.makeDropdown(Preferences.indexToName("screensToShow", index), ScreensToShowPreference.allCases)
-        let showMinimizedWindows = LabelAndControl.makeDropdown(Preferences.indexToName("showMinimizedWindows", index), ShowHowPreference.allCases)
-        let showHiddenWindows = LabelAndControl.makeDropdown(Preferences.indexToName("showHiddenWindows", index), ShowHowPreference.allCases)
-        let showFullscreenWindows = LabelAndControl.makeDropdown(Preferences.indexToName("showFullscreenWindows", index), ShowHowPreference.allCases.filter { $0 != .showAtTheEnd })
-        let windowOrder = LabelAndControl.makeDropdown(Preferences.indexToName("windowOrder", index), WindowOrderPreference.allCases)
-        let shortcutStyle = LabelAndControl.makeDropdown(Preferences.indexToName("shortcutStyle", index), ShortcutStylePreference.allCases)
+        // ───────────────────────────────────────────────────────────────────
+        // First, build each dropdown for this tab index “index”
+        let shortcutStyle = LabelAndControl.makeDropdown(
+            Preferences.indexToName("shortcutStyle", index),
+            ShortcutStylePreference.allCases
+        )
+
+        // NEW: “Show in switcher” dropdown (Applications vs Windows)
+        let showAppsOrWindows = LabelAndControl.makeDropdown(
+            Preferences.indexToName("showAppsOrWindows", index),
+            ShowAppsOrWindowsPreference.allCases
+        )
+
+        // The existing “Show windows from applications” (appsToShow) row:
+        let appsToShow = LabelAndControl.makeDropdown(
+            Preferences.indexToName("appsToShow", index),
+            AppsToShowPreference.allCases
+        )
+
+        let spacesToShow = LabelAndControl.makeDropdown(
+            Preferences.indexToName("spacesToShow", index),
+            SpacesToShowPreference.allCases
+        )
+        let screensToShow = LabelAndControl.makeDropdown(
+            Preferences.indexToName("screensToShow", index),
+            ScreensToShowPreference.allCases
+        )
+        let showMinimizedWindows = LabelAndControl.makeDropdown(
+            Preferences.indexToName("showMinimizedWindows", index),
+            ShowHowPreference.allCases
+        )
+        let showHiddenWindows = LabelAndControl.makeDropdown(
+            Preferences.indexToName("showHiddenWindows", index),
+            ShowHowPreference.allCases
+        )
+        let showFullscreenWindows = LabelAndControl.makeDropdown(
+            Preferences.indexToName("showFullscreenWindows", index),
+            ShowHowPreference.allCases.filter { $0 != .showAtTheEnd }
+        )
+        let windowOrder = LabelAndControl.makeDropdown(
+            Preferences.indexToName("windowOrder", index),
+            WindowOrderPreference.allCases
+        )
+
+        // ───────────────────────────────────────────────────────────────────
+        // Now create the table itself and insert rows in this order:
         let table = TableGroupView(width: PreferencesWindow.width)
-        table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Trigger shortcut", comment: ""), rightViews: trigger))
-        table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("After release", comment: ""), rightViews: [shortcutStyle]))
+
+        // 1) “Trigger shortcut” / “After release”
+        table.addRow(
+          TableGroupView.Row(
+            leftTitle: NSLocalizedString("Trigger shortcut", comment: ""),
+            rightViews: trigger
+          )
+        )
+        table.addRow(
+          TableGroupView.Row(
+            leftTitle: NSLocalizedString("After release", comment: ""),
+            rightViews: [shortcutStyle]
+          )
+        )
+
         table.addNewTable()
-        table.addRow(leftViews: [TableGroupView.makeText(NSLocalizedString("Show windows from applications", comment: ""))], rightViews: [appsToShow])
-        table.addRow(leftViews: [TableGroupView.makeText(NSLocalizedString("Show windows from Spaces", comment: ""))], rightViews: [spacesToShow])
-        table.addRow(leftViews: [TableGroupView.makeText(NSLocalizedString("Show windows from screens", comment: ""))], rightViews: [screensToShow])
-        table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Show minimized windows", comment: ""), rightViews: [showMinimizedWindows]))
-        table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Show hidden windows", comment: ""), rightViews: [showHiddenWindows]))
-        table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Show fullscreen windows", comment: ""), rightViews: [showFullscreenWindows]))
-        table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Order windows by", comment: ""), rightViews: [windowOrder]))
+
+        // 2) **NEW** “Show in switcher” row
+        table.addRow(
+          leftViews: [ TableGroupView.makeText(NSLocalizedString("Show in switcher", comment: "")) ],
+          rightViews: [ showAppsOrWindows ]
+        )
+
+        // 3) The rest of the “Show windows …” rows
+        table.addRow(
+          leftViews: [ TableGroupView.makeText(NSLocalizedString("Show windows from applications", comment: "")) ],
+          rightViews: [ appsToShow ]
+        )
+        table.addRow(
+          leftViews: [ TableGroupView.makeText(NSLocalizedString("Show windows from Spaces", comment: "")) ],
+          rightViews: [ spacesToShow ]
+        )
+        table.addRow(
+          leftViews: [ TableGroupView.makeText(NSLocalizedString("Show windows from screens", comment: "")) ],
+          rightViews: [ screensToShow ]
+        )
+        table.addRow(
+          TableGroupView.Row(
+            leftTitle: NSLocalizedString("Show minimized windows", comment: ""),
+            rightViews: [ showMinimizedWindows ]
+          )
+        )
+        table.addRow(
+          TableGroupView.Row(
+            leftTitle: NSLocalizedString("Show hidden windows", comment: ""),
+            rightViews: [ showHiddenWindows ]
+          )
+        )
+        table.addRow(
+          TableGroupView.Row(
+            leftTitle: NSLocalizedString("Show fullscreen windows", comment: ""),
+            rightViews: [ showFullscreenWindows ]
+          )
+        )
+        table.addRow(
+          TableGroupView.Row(
+            leftTitle: NSLocalizedString("Order windows by", comment: ""),
+            rightViews: [ windowOrder ]
+          )
+        )
+
         table.fit()
         return table
     }


### PR DESCRIPTION
## Summary

Enable per-shortcut “Show in switcher” settings so each AltTab binding can independently show either applications or windows.

## Motivation

- Previously, a single global toggle controlled whether the switcher displayed windows or applications.  
- Users expect macOS-style behavior: for example, in Google Chrome you may want ⌘ Tab to cycle through all running apps, but ⌘ ` to cycle only through Chrome’s open windows.  
- Without per-shortcut configuration, pressing ⌘ ` still showed every app instead of Chrome windows, forcing manual filtering.  
- This change restores that flexibility by allowing each of the three configurable shortcuts to choose its own mode (applications vs. windows).

## Implementation Notes

- **⚠️ Not a Swift developer**  
  I used AI assistance to develop and test these changes. If maintainers want more context or provide me help to merging upstream, I’m happy to assist with any follow-up reviews or refinements.