### PR TITLE
adding screen number indicator

### DIFF
--- a/resources/l10n/Localizable.strings
+++ b/resources/l10n/Localizable.strings
@@ -585,3 +585,4 @@
 
 /* No comment provided by engineer. */
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Show screen numbers";

--- a/resources/l10n/ar.lproj/Localizable.strings
+++ b/resources/l10n/ar.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "لا يمكنك التراجع عن هذا الإجراء.";
 "You didn’t write your email, thus can’t receive any response." = "لم تكتب بريدك؛ فلذلك لن تحصل على رد.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "إظهار أرقام الشاشة";

--- a/resources/l10n/bg.lproj/Localizable.strings
+++ b/resources/l10n/bg.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Връщането на това действие не е възможно";
 "You didn’t write your email, thus can’t receive any response." = "Няма да получиш отговор, защото не си написал събщение.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Показване на номерата на екраните";

--- a/resources/l10n/bn.lproj/Localizable.strings
+++ b/resources/l10n/bn.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "আপনি এই ক্রিয়াটি পূর্বাবস্থায় ফিরিয়ে আনতে পারবেন না।";
 "You didn’t write your email, thus can’t receive any response." = "আপনি আপনার ইমেল লেখেননি, তাই কোনো রিপ্লেও পাবেন না।";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "স্ক্রিন নম্বরগুলি দেখান";

--- a/resources/l10n/ca.lproj/Localizable.strings
+++ b/resources/l10n/ca.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "Aquesta opció no es pot desfer.";
 "You didn’t write your email, thus can’t receive any response." = "No has indicat adreça de correu, no rebràs cap resposta.";
 "You may need to disable some conflicting system gestures" = "És possible que calgui deshabilitar gestos del sistema que entrin en conflicte";
+"Show screen numbers" = "Mostra els números de pantalla";

--- a/resources/l10n/cs.lproj/Localizable.strings
+++ b/resources/l10n/cs.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "Tuto akci nelze vrátit zpět.";
 "You didn’t write your email, thus can’t receive any response." = "Nezadali jste svůj e-mail, proto nemůžete obdržet žádnou odpověď.";
 "You may need to disable some conflicting system gestures" = "Možná bude potřeba zakázat některá konfliktní systémová gesta";
+"Show screen numbers" = "Zobrazit čísla obrazovek";

--- a/resources/l10n/da.lproj/Localizable.strings
+++ b/resources/l10n/da.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "Du kan ikke fortryde denne handling.";
 "You didn’t write your email, thus can’t receive any response." = "Du skrev ikke din e-mail og derfor kan du ikke få svar.";
 "You may need to disable some conflicting system gestures" = "Du skal muligvis deaktivere nogle systembevægelser, der er i konflikt";
+"Show screen numbers" = "Vis skærmnumre";

--- a/resources/l10n/de.lproj/Localizable.strings
+++ b/resources/l10n/de.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Diese Aktion kann nicht rückgängig gemacht werden.";
 "You didn’t write your email, thus can’t receive any response." = "Sie haben keine E-Mail-Adresse angegeben, sodass man Ihnen nicht antworten kann.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Bildschirmnummern anzeigen";

--- a/resources/l10n/el.lproj/Localizable.strings
+++ b/resources/l10n/el.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Αυτή η ενέργεια δεν είναι αναστρέψιμη.";
 "You didn’t write your email, thus can’t receive any response." = "Δεν γράψατε το email σας, επομένως δεν μπορείτε να λάβετε καμία απάντηση.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Εμφάνιση αριθμών οθονών";

--- a/resources/l10n/en.lproj/Localizable.strings
+++ b/resources/l10n/en.lproj/Localizable.strings
@@ -186,6 +186,7 @@
 "Show standard tabs as windows:" = "Show standard tabs as windows:";
 "Show titles" = "Show titles";
 "Show windows from applications" = "Show windows from applications";
+"Show screen numbers" = "Show screen numbers";
 "Show windows from screens" = "Show windows from screens";
 "Show windows from Spaces" = "Show windows from Spaces";
 "Show windows from:" = "Show windows from:";

--- a/resources/l10n/es.lproj/Localizable.strings
+++ b/resources/l10n/es.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "No puedes deshacer esta acción.";
 "You didn’t write your email, thus can’t receive any response." = "No has escrito tu correo electrónico, así que no podrás recibir respuesta.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Mostrar números de pantalla";

--- a/resources/l10n/et.lproj/Localizable.strings
+++ b/resources/l10n/et.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "You can’t undo this action.";
 "You didn’t write your email, thus can’t receive any response." = "Te ei kirjutanud oma e -posti, seega ei saa te vastust.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Kuva ekraaninumbrid";

--- a/resources/l10n/fa.lproj/Localizable.strings
+++ b/resources/l10n/fa.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "شما نمی توانید این عمل را خنثیسازی کنید.";
 "You didn’t write your email, thus can’t receive any response." = "شما ایمیل خود را ننوشتید ، بنابراین نمی توانید پاسخی دریافت کنید.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "نمایش شماره‌های صفحه";

--- a/resources/l10n/fi.lproj/Localizable.strings
+++ b/resources/l10n/fi.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "Et voi perua tätä toimintoa.";
 "You didn’t write your email, thus can’t receive any response." = "Et antanut sähköpostiosoitettasi, joten emme voi lähettää sinulle vastausta.";
 "You may need to disable some conflicting system gestures" = "Saatat joutua poistamaan käytöstä ristiriitaisia järjestelmäeleitä";
+"Show screen numbers" = "Näytä näyttöjen numerot";

--- a/resources/l10n/fr.lproj/Localizable.strings
+++ b/resources/l10n/fr.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "Vous ne pourrez pas annuler cette action.";
 "You didn’t write your email, thus can’t receive any response." = "Vous n’avez pas saisi votre email, et ne pourrez donc pas recevoir de réponse.";
 "You may need to disable some conflicting system gestures" = "Vous devriez désactiver des gestes systèmes en conflit";
+"Show screen numbers" = "Afficher les numéros d'écran";

--- a/resources/l10n/ga.lproj/Localizable.strings
+++ b/resources/l10n/ga.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "Ní féidir leat an gníomh seo a chealú.";
 "You didn’t write your email, thus can’t receive any response." = "Níor scríobh tú do ríomhphost, mar sin ní féidir leat freagra ar bith a fháil.";
 "You may need to disable some conflicting system gestures" = "Seans go mbeidh ort roinnt gothaí córais contrártha a dhíchumasú";
+"Show screen numbers" = "Taispeáin uimhreacha scáileáin";

--- a/resources/l10n/gl.lproj/Localizable.strings
+++ b/resources/l10n/gl.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Non podes desfacer esta acción.";
 "You didn’t write your email, thus can’t receive any response." = "Non escribiches o teu correo electrónico, así que non poderás recibir resposta.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Mostrar números de pantalla";

--- a/resources/l10n/he.lproj/Localizable.strings
+++ b/resources/l10n/he.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "לא ניתן לבטל פעולה זו.";
 "You didn’t write your email, thus can’t receive any response." = "לא רשמת את כתובת המייל שלך, ולא תוכל לקבל תגובה.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "הצג מספרי מסכים";

--- a/resources/l10n/hi.lproj/Localizable.strings
+++ b/resources/l10n/hi.lproj/Localizable.strings
@@ -247,3 +247,4 @@
 "You can’t undo this action." = "आप इस कार्रवाई को पूर्ववत नहीं कर सकते।";
 "You didn’t write your email, thus can’t receive any response." = "आपने अपना ईमेल नहीं लिखा, इसलिए कोई जवाब नहीं मिल सकता ।";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "स्क्रीन नंबर दिखाएं";

--- a/resources/l10n/hr.lproj/Localizable.strings
+++ b/resources/l10n/hr.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Ne možete poništiti ovu radnju.";
 "You didn’t write your email, thus can’t receive any response." = "Niste napisali svoju e -poštu, pa ne možete dobiti nikakav odgovor.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Prikaži brojeve zaslona";

--- a/resources/l10n/hu.lproj/Localizable.strings
+++ b/resources/l10n/hu.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Nem vonhatja vissza ezt a műveletet.";
 "You didn’t write your email, thus can’t receive any response." = "Ha nem ad meg e-mail címet, nem tudunk választ küldeni";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Képernyőszámok megjelenítése";

--- a/resources/l10n/id.lproj/Localizable.strings
+++ b/resources/l10n/id.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Anda tidak dapat membatalkan tindakan ini.";
 "You didn’t write your email, thus can’t receive any response." = "Anda tidak menulis email Anda, sehingga tidak dapat menerima tanggapan apa pun.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Tampilkan nomor layar";

--- a/resources/l10n/is.lproj/Localizable.strings
+++ b/resources/l10n/is.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Þú getur ekki afturkallað þessa aðgerð.";
 "You didn’t write your email, thus can’t receive any response." = "Þú gafst ekki upp netfang, því færðu ekki svar.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Sýna skjánúmer";

--- a/resources/l10n/it.lproj/Localizable.strings
+++ b/resources/l10n/it.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Non puoi annullare questa operazione.";
 "You didn’t write your email, thus can’t receive any response." = "Non hai fornito un indirizzo email: non potrai ricevere risposta.";
 "You may need to disable some conflicting system gestures" = "Potrebbe essere necessario disabilitare alcuni gesti di sistema per evitare conflitti di configurazione";
+"Show screen numbers" = "Mostra i numeri dello schermo";

--- a/resources/l10n/ja.lproj/Localizable.strings
+++ b/resources/l10n/ja.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "この操作は元に戻すことができません。";
 "You didn’t write your email, thus can’t receive any response." = "ご自身のEmailを入力しなかったため、回答を受信できません。";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "スクリーン番号を表示";

--- a/resources/l10n/jv.lproj/Localizable.strings
+++ b/resources/l10n/jv.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "You can’t undo this action.";
 "You didn’t write your email, thus can’t receive any response." = "You didn’t write your email, thus can’t receive any response.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Tampilake nomer layar";

--- a/resources/l10n/kn.lproj/Localizable.strings
+++ b/resources/l10n/kn.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "ಈ ಕ್ರಮವನ್ನು ರದ್ದು ಮಾಡಲಾಗದು.";
 "You didn’t write your email, thus can’t receive any response." = "ನೀವು ನಿಮ್ಮ ಇಮೇಲ್ ಕೊಡದಿದ್ದ ಕಾರಣ ಪ್ರತಿಕ್ರಿಯೆ ಲಭಿಸುವುದಿಲ್ಲ.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "ಸ್ಕ್ರೀನ್ ಸಂಖ್ಯೆಗಳನ್ನು ತೋರಿಸು";

--- a/resources/l10n/ko.lproj/Localizable.strings
+++ b/resources/l10n/ko.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "이 작업은 되돌릴 수 없습니다.";
 "You didn’t write your email, thus can’t receive any response." = "이메일을 적지 않으면 답변을 받을 수 없습니다.";
 "You may need to disable some conflicting system gestures" = "충돌하는 시스템 제스처를 비활성화하세요";
+"Show screen numbers" = "화면 번호 표시";

--- a/resources/l10n/ku.lproj/Localizable.strings
+++ b/resources/l10n/ku.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Hûn nekarin vê çalakiyê paşde bikin.";
 "You didn’t write your email, thus can’t receive any response." = "Te email xwe nenivisandiye, bi vî halî ji tere ti bersivek dê neyî şandin";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Nîşandana hejmarên dîmenê";

--- a/resources/l10n/lb.lproj/Localizable.strings
+++ b/resources/l10n/lb.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Dir kënnt dës Aktioun net ofhalen.";
 "You didn’t write your email, thus can’t receive any response." = "Dir hutt Är E-Mail net geschriwwen, also kann also keng Äntwert kréien.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Umschaltbildschirmnummere weisen";

--- a/resources/l10n/lt.lproj/Localizable.strings
+++ b/resources/l10n/lt.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "You can’t undo this action.";
 "You didn’t write your email, thus can’t receive any response." = "You didn’t write your email, thus can’t receive any response.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Rodyti ekrano numerius";

--- a/resources/l10n/ml.lproj/Localizable.strings
+++ b/resources/l10n/ml.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "You can’t undo this action.";
 "You didn’t write your email, thus can’t receive any response." = "You didn’t write your email, thus can’t receive any response.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "സ്ക്രീൻ നമ്പറുകൾ കാണിക്കുക";

--- a/resources/l10n/nb.lproj/Localizable.strings
+++ b/resources/l10n/nb.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Du kan ikke angre denne handlingen.";
 "You didn’t write your email, thus can’t receive any response." = "Du la ikke inn din epost, derfor kan du ikke få tilbakemelding.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Vis skjermnumre";

--- a/resources/l10n/nl.lproj/Localizable.strings
+++ b/resources/l10n/nl.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Je kan deze actie niet ongedaan maken.";
 "You didn’t write your email, thus can’t receive any response." = "Je hebt geen e-mail ingevoerd en kunt dus geen reactie ontvangen.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Toon schermnummers";

--- a/resources/l10n/nn.lproj/Localizable.strings
+++ b/resources/l10n/nn.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Du kan ikkje angra denne handlinga.";
 "You didn’t write your email, thus can’t receive any response." = "Du la ikkje inn e-postadressa di, difor kan du ikkje få tilbakemelding.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Vis skjermnummer";

--- a/resources/l10n/pl.lproj/Localizable.strings
+++ b/resources/l10n/pl.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Nie będzie można cofnąć tej operacji.";
 "You didn’t write your email, thus can’t receive any response." = "Nie napisałeś swojego adresu e-mail, \ndlatego nie możesz otrzymać odpowiedzi.";
 "You may need to disable some conflicting system gestures" = "Może być konieczne wyłączenie sprzecznych gestów systemowych";
+"Show screen numbers" = "Pokaż numery ekranów";

--- a/resources/l10n/pt-BR.lproj/Localizable.strings
+++ b/resources/l10n/pt-BR.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "Você não pode desfazer essa ação.";
 "You didn’t write your email, thus can’t receive any response." = "Você não informou seu e-mail, portanto não poderá receber uma resposta.";
 "You may need to disable some conflicting system gestures" = "Você pode ter que desativar alguns gestos do sistema conflitantes";
+"Show screen numbers" = "Mostrar números das telas";

--- a/resources/l10n/pt.lproj/Localizable.strings
+++ b/resources/l10n/pt.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "Não pode desfazer esta acção.";
 "You didn’t write your email, thus can’t receive any response." = "Não escreveu o seu endereço de email, logo não é possível enviar resposta";
 "You may need to disable some conflicting system gestures" = "Poderá ser necessário desactivar alguns gestos em conflito";
+"Show screen numbers" = "Mostrar números de ecrã";

--- a/resources/l10n/ro.lproj/Localizable.strings
+++ b/resources/l10n/ro.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "Această acțiune nu poate fi anulată.";
 "You didn’t write your email, thus can’t receive any response." = "Nu ai scris adresa ta de email, nu poți primi niciun răspuns.";
 "You may need to disable some conflicting system gestures" = "S-ar putea să fie necesar să dezactivezi unele gesturi sistem care intră în conflict";
+"Show screen numbers" = "Afișează numerele ecranelor";

--- a/resources/l10n/ru.lproj/Localizable.strings
+++ b/resources/l10n/ru.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "Вы не можете отменить это действие";
 "You didn’t write your email, thus can’t receive any response." = "Вы не написали свою электронную почту, поэтому не можете получить ответ.";
 "You may need to disable some conflicting system gestures" = "Вероятно, вам придётся отключить некоторые конфликтующие системные жесты.";
+"Show screen numbers" = "Показывать номера экранов";

--- a/resources/l10n/sk.lproj/Localizable.strings
+++ b/resources/l10n/sk.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Túto akciu nemôžete vrátiť späť.";
 "You didn’t write your email, thus can’t receive any response." = "Nezadali ste svoj e-mail, takže nemôžete dostávať žiadne odpovede.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Zobraziť čísla obrazoviek";

--- a/resources/l10n/sl.lproj/Localizable.strings
+++ b/resources/l10n/sl.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Tega dejanja ne morete razveljaviti.";
 "You didn’t write your email, thus can’t receive any response." = "Niste napisali svojega e -poštnega sporočila, zato ne morete prejeti nobenega odgovora.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Prikaži številke zaslonov";

--- a/resources/l10n/sq.lproj/Localizable.strings
+++ b/resources/l10n/sq.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Ju nuk mund ta zhbllokoni këtë veprim.";
 "You didn’t write your email, thus can’t receive any response." = "JU nuk keni shkruar email, kështu që nuk mund të pranoni përgjigje";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Shfaq numrat e ekranit";

--- a/resources/l10n/sr.lproj/Localizable.strings
+++ b/resources/l10n/sr.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Не можете поништити ову акцију.";
 "You didn’t write your email, thus can’t receive any response." = "Email adresa nije data, i zato neće biti odgovora.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Прикажи бројеве екрана";

--- a/resources/l10n/sv.lproj/Localizable.strings
+++ b/resources/l10n/sv.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Detta kan inte ångras.";
 "You didn’t write your email, thus can’t receive any response." = "Du uppgav ingen e-post och kan därför inte få svar.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Visa skärmnummer";

--- a/resources/l10n/ta.lproj/Localizable.strings
+++ b/resources/l10n/ta.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "இந்த செயலை நீங்கள் செயல்தவிர்க்க முடியாது.";
 "You didn’t write your email, thus can’t receive any response." = "உங்கள் மின்னஞ்சலை நீங்கள் எழுதவில்லை, இதனால் எந்த பதிலும் பெற முடியாது.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "திரை எண்களைக் காட்டு";

--- a/resources/l10n/th.lproj/Localizable.strings
+++ b/resources/l10n/th.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "คุณไม่สามารถยกเลิกการกระทํานี้ได้";
 "You didn’t write your email, thus can’t receive any response." = "คุณไม่ได้ระบุอีเมลของคุณ ดังนั้นจึงไม่สามารถรับการตอบกลับใดๆ";
 "You may need to disable some conflicting system gestures" = "คุณอาจต้องปิดใช้งานคำสั่งนิ้วของระบบที่ขัดแย้งกัน";
+"Show screen numbers" = "แสดงหมายเลขหน้าจอ";

--- a/resources/l10n/tr.lproj/Localizable.strings
+++ b/resources/l10n/tr.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Bu eylemi geri alamazsınız.";
 "You didn’t write your email, thus can’t receive any response." = "E-posta adresinizi yazmadığınız için yanıt alamayacaksınız.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Ekran numaralarını göster";

--- a/resources/l10n/uk.lproj/Localizable.strings
+++ b/resources/l10n/uk.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "Ви не можете відмінити цю дію.";
 "You didn’t write your email, thus can’t receive any response." = "Ви не вказали свою електронну пошту, тому не можете отримати жодної відповіді.";
 "You may need to disable some conflicting system gestures" = "Ймовірно вам доведеться вимкнути деякі конфліктні системні жести";
+"Show screen numbers" = "Показувати номери екранів";

--- a/resources/l10n/uz.lproj/Localizable.strings
+++ b/resources/l10n/uz.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Siz ushbu harakatni bekor qila olmaysiz.";
 "You didn’t write your email, thus can’t receive any response." = "Siz elektron pochtangizni yozmadingiz, shuning uchun hech qanday javob ololmaysiz.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Ekranning raqamlarini ko'rsatish";

--- a/resources/l10n/vi.lproj/Localizable.strings
+++ b/resources/l10n/vi.lproj/Localizable.strings
@@ -246,3 +246,4 @@
 "You can’t undo this action." = "Bạn không thể hoàn tác hành động này.";
 "You didn’t write your email, thus can’t receive any response." = "Bạn không điền email nên sẽ không nhận được phản hồi.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";
+"Show screen numbers" = "Hiển thị số màn hình";

--- a/resources/l10n/zh-CN.lproj/Localizable.strings
+++ b/resources/l10n/zh-CN.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "您无法撤消此操作";
 "You didn’t write your email, thus can’t receive any response." = "您未填写电子邮箱地址，将无法收到回复。";
 "You may need to disable some conflicting system gestures" = "您可能需要禁用一些有冲突的系统手势";
+"Show screen numbers" = "显示屏幕编号";

--- a/resources/l10n/zh-TW.lproj/Localizable.strings
+++ b/resources/l10n/zh-TW.lproj/Localizable.strings
@@ -250,3 +250,4 @@
 "You can’t undo this action." = "您無法復原此操作。";
 "You didn’t write your email, thus can’t receive any response." = "若沒有填寫電子信箱，您將無法收到回覆";
 "You may need to disable some conflicting system gestures" = "您或許需關閉一些衝突的系統手勢";
+"Show screen numbers" = "顯示螢幕編號";

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -87,6 +87,7 @@ class Preferences {
         "hideAppBadges": "false",
         "hideThumbnails": "false",
         "previewFocusedWindow": "false",
+        "showScreenNumbers": "false",
         "screenRecordingPermissionSkipped": "false",
     ]
 
@@ -123,6 +124,7 @@ class Preferences {
     static var startAtLogin: Bool { CachedUserDefaults.bool("startAtLogin") }
     static var blacklist: [BlacklistEntry] { CachedUserDefaults.json("blacklist", [BlacklistEntry].self) }
     static var previewFocusedWindow: Bool { CachedUserDefaults.bool("previewFocusedWindow") }
+    static var showScreenNumbers: Bool { CachedUserDefaults.bool("showScreenNumbers") }
     static var screenRecordingPermissionSkipped: Bool { CachedUserDefaults.bool("screenRecordingPermissionSkipped") }
 
     // macro values

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -27,6 +27,11 @@ class Windows {
 
     /// reordered list based on preferences, keeping the original index
     private static func sort() {
+        // Update display numbers for all windows
+        for window in list {
+            window.updateDisplayNumber()
+        }
+        
         list.sort {
             // separate buckets for these types of windows
             if Preferences.showWindowlessApps[App.app.shortcutIndex] == .showAtTheEnd && $0.isWindowlessApp != $1.isWindowlessApp {

--- a/src/ui/main-window/ThumbnailFontIconView.swift
+++ b/src/ui/main-window/ThumbnailFontIconView.swift
@@ -82,3 +82,62 @@ class ThumbnailFilledFontIconView: NSView {
         heightAnchor.constraint(equalTo: thumbnailFontIconView.heightAnchor).isActive = true
     }
 }
+
+class DisplayNumberIconView: NSView {
+    private let backgroundView = NSView()
+    private let numberLabel = NSTextField()
+    
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    private func setupView() {
+        translatesAutoresizingMaskIntoConstraints = false
+        wantsLayer = true
+        
+        // Setup background with darker blue color
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        backgroundView.wantsLayer = true
+        backgroundView.layer?.backgroundColor = NSColor(srgbRed: 0.1, green: 0.3, blue: 0.8, alpha: 0.9).cgColor // Darker blue
+        backgroundView.layer?.cornerRadius = 8 // Larger corner radius for bigger circle
+        addSubview(backgroundView)
+        
+        // Setup label
+        numberLabel.translatesAutoresizingMaskIntoConstraints = false
+        numberLabel.isEditable = false
+        numberLabel.isBordered = false
+        numberLabel.isBezeled = false
+        numberLabel.drawsBackground = false
+        numberLabel.isSelectable = false
+        numberLabel.textColor = NSColor.white
+        numberLabel.font = NSFont.systemFont(ofSize: 14, weight: .medium) // Larger font
+        numberLabel.alignment = .center
+        numberLabel.stringValue = "1"
+        addSubview(numberLabel)
+        
+        // Constraints for larger circle (24x24 instead of 16x16)
+        NSLayoutConstraint.activate([
+            backgroundView.topAnchor.constraint(equalTo: topAnchor),
+            backgroundView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            backgroundView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            backgroundView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            
+            numberLabel.topAnchor.constraint(equalTo: topAnchor, constant: 2),
+            numberLabel.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 2),
+            numberLabel.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -2),
+            numberLabel.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -2),
+            
+            widthAnchor.constraint(equalToConstant: 24), // Larger width
+            heightAnchor.constraint(equalToConstant: 24) // Larger height
+        ])
+    }
+    
+    func setDisplayNumber(_ number: Int) {
+        numberLabel.stringValue = "\(number)"
+    }
+}

--- a/src/ui/preferences-window/tabs/appearance/AppearanceTab.swift
+++ b/src/ui/preferences-window/tabs/appearance/AppearanceTab.swift
@@ -405,10 +405,11 @@ class AppearanceTab: NSObject {
     }
 
     private static func makeMultipleScreensView() -> NSView {
-        let table = TableGroupView(title: NSLocalizedString("Multiple screens", comment: ""), width: PreferencesWindow.width)
+        let table = TableGroupView(title: NSLocalizedString("Multiple screens", comment: ""),
+            width: PreferencesWindow.width)
         _ = table.addRow(leftText: NSLocalizedString("Show on", comment: ""),
             rightViews: LabelAndControl.makeDropdown("showOnScreen", ShowOnScreenPreference.allCases))
-        _ = table.addRow(leftText: NSLocalizedString("Show Screen Numbers", comment: ""),
+        _ = table.addRow(leftText: NSLocalizedString("Show screen numbers", comment: ""),
             rightViews: [LabelAndControl.makeSwitch("showScreenNumbers")])
         table.fit()
         return table

--- a/src/ui/preferences-window/tabs/appearance/AppearanceTab.swift
+++ b/src/ui/preferences-window/tabs/appearance/AppearanceTab.swift
@@ -408,6 +408,8 @@ class AppearanceTab: NSObject {
         let table = TableGroupView(title: NSLocalizedString("Multiple screens", comment: ""), width: PreferencesWindow.width)
         _ = table.addRow(leftText: NSLocalizedString("Show on", comment: ""),
             rightViews: LabelAndControl.makeDropdown("showOnScreen", ShowOnScreenPreference.allCases))
+        _ = table.addRow(leftText: NSLocalizedString("Show Screen Numbers", comment: ""),
+            rightViews: [LabelAndControl.makeSwitch("showScreenNumbers")])
         table.fit()
         return table
     }


### PR DESCRIPTION
Use case: I have terminal windows on multiple screens, most of them secondary.

When I press alt+tab, i would like to see if focus will be driven away out of my screen, in other words, which terminal will i tab to. I rarely need to switch to the different windows, but often accidentally do, and because windows are brought up the stack, this confuses long after that. I render numbers only when app is on different, from current, screen.

Anyway, this is just adding awareness. I'll attach the screenshot: 

<img width="300"  alt="image" src="https://github.com/user-attachments/assets/51624ae4-0fa5-4297-9ac4-4c0a074bff52" />

I would like this feature to be included in the main branch, but will not be offended if not. Please free to further modify as you wish, if you need.

Also I added the toggle in the settings to enable it (disabled by default): 
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/db34c3f4-a562-4f42-b742-f8c594d71c50" />


Cheers!
