### PR TITLE
complete mouse disabler

### DIFF
--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		1C961F9CF4F1BEDF04ACAEE0 /* Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C96189273B7482124C36F4C /* Switch.swift */; };
 		1C961FA2D2D99AE54EBECA67 /* titles_show_running_windows_light@2x.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 1C9610B2E76F1E429C8D3660 /* titles_show_running_windows_light@2x.jpg */; };
 		1C961FB59566B8314771F58E /* thumbnails_show_preview_focused_window_light@2x.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 1C961EF84B061A68FD9AEC46 /* thumbnails_show_preview_focused_window_light@2x.jpg */; };
+		264B2B822E533E7B00F9B869 /* MouseActionPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 264B2B812E533E7B00F9B869 /* MouseActionPreference.swift */; };
 		442E26DB1F7DA80AF794CCB6 /* Pods_unit_tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7E6F409CA442F83B7BE71AD /* Pods_unit_tests.framework */; };
 		4807A6C623A9CD190052A53E /* SkyLight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4807A6C523A9CD190052A53E /* SkyLight.framework */; };
 		48F3E16224EC0D8800A1C64B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D04BABDA79F8EF76E3ACDD5F /* Localizable.strings */; };
@@ -336,6 +337,7 @@
 		1C961F5740647DBFA0540789 /* thumbnails_show_tabs_as_windows_light@2x.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "thumbnails_show_tabs_as_windows_light@2x.jpg"; sourceTree = "<group>"; };
 		1C961F68C77AAE38E5A2E046 /* app_icons_show_running_applications_light@2x.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "app_icons_show_running_applications_light@2x.jpg"; sourceTree = "<group>"; };
 		1C961FB3DCF4906FEEF4A23D /* TableGroupView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableGroupView.swift; sourceTree = "<group>"; };
+		264B2B812E533E7B00F9B869 /* MouseActionPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseActionPreference.swift; sourceTree = "<group>"; };
 		4807A6C523A9CD190052A53E /* SkyLight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SkyLight.framework; path = ../../../../System/Library/PrivateFrameworks/SkyLight.framework; sourceTree = "<group>"; };
 		481FE54624D2D387001032F1 /* alt-tab-macos-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "alt-tab-macos-Bridging-Header.h"; sourceTree = "<group>"; };
 		5883F0A729A5182C0071DB65 /* TrackpadEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackpadEvents.swift; sourceTree = "<group>"; };
@@ -1238,6 +1240,7 @@
 		D04BA0D80B24E72B9B981A1D /* logic */ = {
 			isa = PBXGroup;
 			children = (
+				264B2B812E533E7B00F9B869 /* MouseActionPreference.swift */,
 				D04BACD976030676FD0761D5 /* Windows.swift */,
 				D04BA9B93823398A542FF7A0 /* Preferences.swift */,
 				D04BA68C2561D9EE4FD851B8 /* NSScreen.swift */,
@@ -2314,6 +2317,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D04BAFBC862BA5FE0294EA7A /* AXUIElement.swift in Sources */,
+				264B2B822E533E7B00F9B869 /* MouseActionPreference.swift in Sources */,
 				D04BA73E90EFEF8247A5105D /* CGWindow.swift in Sources */,
 				D04BA004884A273D4D2D3EF1 /* HelperExtensions.swift in Sources */,
 				D04BABED81800E18732912CC /* CGWindowID.swift in Sources */,

--- a/resources/l10n/Localizable.strings
+++ b/resources/l10n/Localizable.strings
@@ -368,7 +368,16 @@
 "Select previous window" = "Select previous window";
 
 /* No comment provided by engineer. */
+"Mouse action" = "Mouse action";
+
+/* No comment provided by engineer. */
 "Select windows on mouse hover" = "Select windows on mouse hover";
+
+/* No comment provided by engineer. */
+"Activate windows on mouse click" = "Activate windows on mouse click";
+
+/* No comment provided by engineer. */
+"Disable mouse interaction" = "Disable mouse interaction";
 
 /* No comment provided by engineer. */
 "Select windows using arrow keys" = "Select windows using arrow keys";

--- a/resources/l10n/de.lproj/Localizable.strings
+++ b/resources/l10n/de.lproj/Localizable.strings
@@ -154,7 +154,10 @@
 "Screen showing AltTab" = "Bildschirm mit AltTab";
 "Select next window" = "Nächstes Fenster auswählen";
 "Select previous window" = "Vorheriges Fenster auswählen";
+"Mouse action" = "Mausaktion";
 "Select windows on mouse hover" = "Fenster beim Überfahren mit der Maus wählen";
+"Activate windows on mouse click" = "Fenster beim Klicken mit der Maus aktivieren";
+"Disable mouse interaction" = "Mausinteraktion deaktivieren";
 "Select windows using arrow keys" = "Fenster mit Pfeiltasten auswählen";
 "Select windows using vim keys" = "Fenster mit VIM-Tasten auswählen";
 "Send" = "Senden";

--- a/resources/l10n/en.lproj/Localizable.strings
+++ b/resources/l10n/en.lproj/Localizable.strings
@@ -154,7 +154,10 @@
 "Screen showing AltTab" = "Screen showing AltTab";
 "Select next window" = "Select next window";
 "Select previous window" = "Select previous window";
+"Mouse action" = "Mouse action";
 "Select windows on mouse hover" = "Select windows on mouse hover";
+"Activate windows on mouse click" = "Activate windows on mouse click";
+"Disable mouse interaction" = "Disable mouse interaction";
 "Select windows using arrow keys" = "Select windows using arrow keys";
 "Select windows using vim keys" = "Select windows using vim keys";
 "Send" = "Send";

--- a/resources/l10n/fr.lproj/Localizable.strings
+++ b/resources/l10n/fr.lproj/Localizable.strings
@@ -157,7 +157,10 @@
 "Screen showing AltTab" = "Écran affichant AltTab";
 "Select next window" = "Sélectionner la fenêtre suivante";
 "Select previous window" = "Sélectionner la fenêtre précédente";
+"Mouse action" = "Action de la souris";
 "Select windows on mouse hover" = "Sélectionner au survol de la souris";
+"Activate windows on mouse click" = "Activer les fenêtres en cliquant avec la souris";
+"Disable mouse interaction" = "Désactiver l'interaction avec la souris";
 "Select windows using arrow keys" = "Sélectionner à l'aide de touches flèches";
 "Select windows using vim keys" = "Sélectionner à l'aide des touches VIM";
 "Send" = "Envoyer";

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -23,6 +23,7 @@ class Preferences {
         "arrowKeysEnabled": "true",
         "vimKeysEnabled": "false",
         "mouseHoverEnabled": "false",
+        "mouseAction": MouseActionPreference.selectOnHover.indexAsString,
         "cursorFollowFocusEnabled": "false",
         "showMinimizedWindows": ShowHowPreference.show.indexAsString,
         "showMinimizedWindows2": ShowHowPreference.show.indexAsString,
@@ -110,6 +111,18 @@ class Preferences {
     // periphery:ignore
     static var vimKeysEnabled: Bool { CachedUserDefaults.bool("vimKeysEnabled") }
     static var mouseHoverEnabled: Bool { CachedUserDefaults.bool("mouseHoverEnabled") }
+    static var mouseAction: MouseActionPreference { 
+        // For backward compatibility, we convert the old boolean value to the new enum
+        // If mouseHoverEnabled was true, it means "select on hover"
+        // If mouseHoverEnabled was false, it means "activate on click"
+        if UserDefaults.standard.string(forKey: "mouseAction") != nil {
+            // New preference exists, use it
+            return CachedUserDefaults.macroPref("mouseAction", MouseActionPreference.allCases)
+        } else {
+            // Backward compatibility: convert old boolean to new enum
+            return CachedUserDefaults.bool("mouseHoverEnabled") ? .selectOnHover : .activateOnClick
+        }
+    }
     static var cursorFollowFocusEnabled: Bool { CachedUserDefaults.bool("cursorFollowFocusEnabled") }
     static var showTabsAsWindows: Bool { CachedUserDefaults.bool("showTabsAsWindows") }
     static var hideColoredCircles: Bool { CachedUserDefaults.bool("hideColoredCircles") }

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -166,15 +166,21 @@ class Windows {
     static func updateFocusedAndHoveredWindowIndex(_ newIndex: Int, _ fromMouse: Bool = false) {
         var index: Int?
         if fromMouse && (newIndex != hoveredWindowIndex || lastWindowActivityType == .focus) {
-            let oldIndex = hoveredWindowIndex
-            hoveredWindowIndex = newIndex
-            if let oldIndex {
-                ThumbnailsView.highlight(oldIndex)
+            // For all mouse actions except "disable", we update the hovered window index
+            // This ensures the secondary selection (hovered window) is shown
+            if Preferences.mouseAction != .disable {
+                let oldIndex = hoveredWindowIndex
+                hoveredWindowIndex = newIndex
+                if let oldIndex {
+                    ThumbnailsView.highlight(oldIndex)
+                }
+                index = hoveredWindowIndex
+                lastWindowActivityType = .hover
             }
-            index = hoveredWindowIndex
-            lastWindowActivityType = .hover
         }
-        if (!fromMouse || Preferences.mouseHoverEnabled)
+        // For "select on hover", we immediately focus the window
+        // For "activate on click" and "disable", we don't focus the window on hover
+        if (!fromMouse || Preferences.mouseAction == .selectOnHover)
                && (newIndex != focusedWindowIndex || lastWindowActivityType == .hover) {
             let oldIndex = focusedWindowIndex
             focusedWindowIndex = newIndex

--- a/src/ui/main-window/ThumbnailView.swift
+++ b/src/ui/main-window/ThumbnailView.swift
@@ -101,7 +101,10 @@ class ThumbnailView: FlippedView {
 
     func mouseMoved() {
         showOrHideWindowControls(true)
-        mouseMovedCallback()
+        // If mouse action is "disable", we ignore the mouse move
+        if Preferences.mouseAction != .disable {
+            mouseMovedCallback()
+        }
     }
 
     convenience init() {
@@ -365,8 +368,18 @@ class ThumbnailView: FlippedView {
         }
         windowControlIcons.forEach { $0.window_ = element }
         showOrHideWindowControls(isShowingWindowControls)
-        mouseUpCallback = { () -> Void in App.app.focusSelectedWindow(element) }
-        mouseMovedCallback = { () -> Void in Windows.updateFocusedAndHoveredWindowIndex(index, true) }
+        mouseUpCallback = { () -> Void in 
+            // If mouse action is "disable", we ignore the mouse click
+            if Preferences.mouseAction != .disable {
+                App.app.focusSelectedWindow(element)
+            }
+        }
+        mouseMovedCallback = { () -> Void in 
+            // If mouse action is "disable", we ignore the mouse move
+            if Preferences.mouseAction != .disable {
+                Windows.updateFocusedAndHoveredWindowIndex(index, true)
+            }
+        }
     }
 
     private func updateSizes(_ newHeight: CGFloat) {

--- a/src/ui/main-window/ThumbnailsView.swift
+++ b/src/ui/main-window/ThumbnailsView.swift
@@ -288,6 +288,8 @@ class ScrollView: NSScrollView {
     override func mouseMoved(with event: NSEvent) {
         // disable mouse hover during scrolling as it creates jank during elastic bounces at the start/end of the scrollview
         if isCurrentlyScrolling { return }
+        // If mouse action is "disable", we ignore the mouse move
+        if Preferences.mouseAction == .disable { return }
         if let hit = hitTest(App.app.thumbnailsPanel.mouseLocationOutsideOfEventStream) {
             var target: NSView? = hit
             while !(target is ThumbnailView) && target != nil {
@@ -305,7 +307,9 @@ class ScrollView: NSScrollView {
                 }
             }
         } else {
-            resetHoveredWindow()
+            if !checkIfWithinInterPadding() {
+                resetHoveredWindow()
+            }
         }
     }
 

--- a/src/ui/preferences-window/tabs/controls/AdditionalControlsSheet.swift
+++ b/src/ui/preferences-window/tabs/controls/AdditionalControlsSheet.swift
@@ -6,8 +6,14 @@ class AdditionalControlsSheet: SheetWindow {
             rightViews: [LabelAndControl.makeSwitch("arrowKeysEnabled", extraAction: ControlsTab.arrowKeysEnabledCallback)])
         let enableVimKeys = TableGroupView.Row(leftTitle: NSLocalizedString("Select windows using vim keys", comment: ""),
             rightViews: [LabelAndControl.makeSwitch("vimKeysEnabled", extraAction: ControlsTab.vimKeysEnabledCallback)])
-        let enableMouse = TableGroupView.Row(leftTitle: NSLocalizedString("Select windows on mouse hover", comment: ""),
-            rightViews: [LabelAndControl.makeSwitch("mouseHoverEnabled")])
+        let enableMouse = TableGroupView.Row(leftTitle: NSLocalizedString("Mouse action", comment: ""),
+            rightViews: [LabelAndControl.makeDropdown("mouseAction", MouseActionPreference.allCases, extraAction: { control in
+                // Update the old mouseHoverEnabled preference for backward compatibility
+                if let popupButton = control as? NSPopUpButton {
+                    let mouseAction = MouseActionPreference.allCases[popupButton.indexOfSelectedItem]
+                    Preferences.set("mouseHoverEnabled", mouseAction == .selectOnHover ? "true" : "false")
+                }
+            })])
         let enableCursorFollowFocus = TableGroupView.Row(leftTitle: NSLocalizedString("Cursor follows focus", comment: ""),
             rightViews: [LabelAndControl.makeSwitch("cursorFollowFocusEnabled")])
         ControlsTab.arrowKeysCheckbox = enableArrows.rightViews[0] as? Switch


### PR DESCRIPTION
Use case: you pressed alt-tab with your left hand, aiming at certain app, and then you touched mouse with right hand.
Outcome: two focused applications with two similarly blue selection rectangles.
Reaction: WTF? which one?
Correct behavior: accessibility fix: disable mouse completely for people never using mouse when alt-tabbing.

I implemented it with the saved settings compatibility in mind, so it understands saved option. Option looks like this:

<img width="400" alt="image" src="https://github.com/user-attachments/assets/04768677-c67d-4617-82e0-c0d0a884cb52" />

Localization is added.

I will not be offended if you're not adding that to master, but plz drop me a note maybe I could better align with requirements. 

Thanks!