### PR TITLE
feat: cursorFollowFocus additional behavior customization

### DIFF
--- a/src/logic/MacroPreferences.swift
+++ b/src/logic/MacroPreferences.swift
@@ -435,6 +435,18 @@ enum ShowAppsOrWindowsPreference: CaseIterable, MacroPreference {
     }
 }
 
+enum CursorFollowFocusBehavior: CaseIterable, MacroPreference {
+    case always
+    case differentScreen
+
+    var localizedString: LocalizedString {
+        switch self {
+            case .always: return NSLocalizedString("Always", comment: "")
+            case .differentScreen: return NSLocalizedString("Only on different screen", comment: "")
+        }
+    }
+}
+
 enum ShowTitlesPreference: CaseIterable, MacroPreference {
     case windowTitle
     case appName

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -24,6 +24,7 @@ class Preferences {
         "vimKeysEnabled": "false",
         "mouseHoverEnabled": "false",
         "cursorFollowFocusEnabled": "false",
+        "cursorFollowFocusBehavior": CursorFollowFocusBehavior.always.indexAsString,
         "showMinimizedWindows": ShowHowPreference.show.indexAsString,
         "showMinimizedWindows2": ShowHowPreference.show.indexAsString,
         "showMinimizedWindows3": ShowHowPreference.show.indexAsString,
@@ -111,6 +112,7 @@ class Preferences {
     static var vimKeysEnabled: Bool { CachedUserDefaults.bool("vimKeysEnabled") }
     static var mouseHoverEnabled: Bool { CachedUserDefaults.bool("mouseHoverEnabled") }
     static var cursorFollowFocusEnabled: Bool { CachedUserDefaults.bool("cursorFollowFocusEnabled") }
+    static var cursorFollowFocusBehavior: CursorFollowFocusBehavior { CachedUserDefaults.macroPref("cursorFollowFocusBehavior", CursorFollowFocusBehavior.allCases) }
     static var showTabsAsWindows: Bool { CachedUserDefaults.bool("showTabsAsWindows") }
     static var hideColoredCircles: Bool { CachedUserDefaults.bool("hideColoredCircles") }
     static var windowDisplayDelay: DispatchTimeInterval { DispatchTimeInterval.milliseconds(CachedUserDefaults.int("windowDisplayDelay")) }

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -190,6 +190,11 @@ class App: AppCenterApplication {
         if let window = selectedWindow, MissionControl.state() == .inactive || MissionControl.state() == .showDesktop {
             window.focus()
             if Preferences.cursorFollowFocusEnabled {
+                if Preferences.cursorFollowFocusBehavior == .differentScreen && window.isOnScreen(NSScreen.preferred) {
+                    // skip if we only want cursor to move to a different screen,
+                    // and the screen preference stays unchanged (selected window is on same screen)
+                    return
+                }
                 moveCursorToSelectedWindow(window)
             }
         } else {

--- a/src/ui/preferences-window/tabs/controls/AdditionalControlsSheet.swift
+++ b/src/ui/preferences-window/tabs/controls/AdditionalControlsSheet.swift
@@ -1,6 +1,8 @@
 import Cocoa
 
 class AdditionalControlsSheet: SheetWindow {
+    private var cursorFollowFocusBehaviorDropdown: NSPopUpButton?
+
     override func makeContentView() -> NSView {
         let enableArrows = TableGroupView.Row(leftTitle: NSLocalizedString("Select windows using arrow keys", comment: ""),
             rightViews: [LabelAndControl.makeSwitch("arrowKeysEnabled", extraAction: ControlsTab.arrowKeysEnabledCallback)])
@@ -8,8 +10,17 @@ class AdditionalControlsSheet: SheetWindow {
             rightViews: [LabelAndControl.makeSwitch("vimKeysEnabled", extraAction: ControlsTab.vimKeysEnabledCallback)])
         let enableMouse = TableGroupView.Row(leftTitle: NSLocalizedString("Select windows on mouse hover", comment: ""),
             rightViews: [LabelAndControl.makeSwitch("mouseHoverEnabled")])
-        let enableCursorFollowFocus = TableGroupView.Row(leftTitle: NSLocalizedString("Cursor follows focus", comment: ""),
-            rightViews: [LabelAndControl.makeSwitch("cursorFollowFocusEnabled")])
+        cursorFollowFocusBehaviorDropdown = LabelAndControl.makeDropdown(
+            "cursorFollowFocusBehavior", CursorFollowFocusBehavior.allCases
+        )
+        cursorFollowFocusBehaviorDropdown?.isEnabled = Preferences.cursorFollowFocusEnabled
+        let enableCursorFollowFocus = TableGroupView.Row(
+            leftTitle: NSLocalizedString("Cursor follows focus", comment: ""),
+            rightViews: [
+                cursorFollowFocusBehaviorDropdown!,
+                LabelAndControl.makeSwitch("cursorFollowFocusEnabled", extraAction: cursorFollowFocusBehaviorDidChange)
+            ]
+        )
         ControlsTab.arrowKeysCheckbox = enableArrows.rightViews[0] as? Switch
         ControlsTab.vimKeysCheckbox = enableVimKeys.rightViews[0] as? Switch
         ControlsTab.arrowKeysEnabledCallback(ControlsTab.arrowKeysCheckbox)
@@ -24,5 +35,9 @@ class AdditionalControlsSheet: SheetWindow {
         _ = table2.addRow(enableCursorFollowFocus)
         let view = TableGroupSetView(originalViews: [table1, table2], padding: 0)
         return view
+    }
+
+    func cursorFollowFocusBehaviorDidChange(_: NSControl?) {
+        cursorFollowFocusBehaviorDropdown?.isEnabled = Preferences.cursorFollowFocusEnabled
     }
 }


### PR DESCRIPTION
The existing “Cursor follows focus” is already nifty for me when working with multiple, large screens connected to my machine. When I switch focus between different screens, I often need my mouse to be there as well, such as switching spaces (since macOS switches spaces for the screen your cursor is at, not the currently-focused window).

However, switching windows on the same screen with this option on can be jarring in my opinion. So, **I've added a layer of customization for this setting, most notably to change cursor position only if the new window to be focused is on a different screen of the current**.