### PR TITLE
feat: add configurable panel width for Titles style

### DIFF
--- a/src/logic/Appearance.swift
+++ b/src/logic/Appearance.swift
@@ -141,8 +141,10 @@ class Appearance {
         } else if aspectRatio >= 2.3 {
             // Regular ultrawide: Modest reduction for text readability
             maxWidthOnScreen = max(0.45, maxWidthOnScreen * 0.85)
+        } else {
+            // Normal screens: preserve original behavior
+            maxWidthOnScreen = isHorizontalScreen ? 0.6 : 0.8
         }
-        // else: use comfortableWidth value as-is for normal screens
         windowMinWidthInRow = 0.6
         windowMaxWidthInRow = 0.9
         rowsCount = 1


### PR DESCRIPTION
## Summary

Adds configurable panel width for the Titles appearance style to address the issue mentioned in #3882 where the UI becomes too wide on ultrawide monitors.

## Changes

  - Add automatic width optimization based on screen aspect ratio:
    - 30% for super ultrawide displays (32:9, e.g., 5120×1440)
    - 45% for regular ultrawide displays (21:9, e.g., 3440×1440)
    - 60% for standard displays (unchanged from current behavior)
    - 80% for vertical displays (unchanged)
  - Add user-configurable custom width option with slider (10-90%)
  - Add "Panel width" setting in "Customize Titles style" with Automatic/Custom modes
  - Add `isUltrawide()` and `isSuperUltrawide()` helper functions to NSScreen

 ## Testing

Tested on 5120×1440 (32:9) display where automatic mode correctly applies 30% width. Also verified on standard 16:9 display to ensure backwards compatibility. Custom slider works as expected and preferences persist correctly.

## Implementation Notes

The two-tier approach keeps absolute panel widths similar across screen types (~1500-1600px) while preventing the UI from being overwhelming on super ultrawide displays. Existing users on standard displays won't see any changes.

# Preview 
<img width="562" height="790" alt="SCR-20251022-msuf" src="https://github.com/user-attachments/assets/b7cc4a89-31ac-4942-a98e-48be3a754586" />

![SCR-20251021-pdaw](https://github.com/user-attachments/assets/d110aa76-2c04-4dff-ac08-ec5308bec2d5)
![SCR-20251021-pdfd](https://github.com/user-attachments/assets/4aa8cd88-24ce-423b-98be-29cdbf6539b0)

Edit: Forgot to include settings UI