### PR TITLE
feat: Add live window preview using ScreenCaptureKit

### DIFF
--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -59,6 +59,7 @@
 		1C961F9CF4F1BEDF04ACAEE0 /* Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C96189273B7482124C36F4C /* Switch.swift */; };
 		1C961FA2D2D99AE54EBECA67 /* titles_show_running_windows_light@2x.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 1C9610B2E76F1E429C8D3660 /* titles_show_running_windows_light@2x.jpg */; };
 		1C961FB59566B8314771F58E /* thumbnails_show_preview_focused_window_light@2x.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 1C961EF84B061A68FD9AEC46 /* thumbnails_show_preview_focused_window_light@2x.jpg */; };
+		346D342C2EEA72A4009590BE /* LiveWindowCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346D342B2EEA72A4009590BE /* LiveWindowCapture.swift */; };
 		442E26DB1F7DA80AF794CCB6 /* Pods_unit_tests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C7E6F409CA442F83B7BE71AD /* Pods_unit_tests.framework */; };
 		4807A6C623A9CD190052A53E /* SkyLight.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4807A6C523A9CD190052A53E /* SkyLight.framework */; };
 		48F3E16224EC0D8800A1C64B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D04BABDA79F8EF76E3ACDD5F /* Localizable.strings */; };
@@ -349,6 +350,7 @@
 		1C961F5740647DBFA0540789 /* thumbnails_show_tabs_as_windows_light@2x.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "thumbnails_show_tabs_as_windows_light@2x.jpg"; sourceTree = "<group>"; };
 		1C961F68C77AAE38E5A2E046 /* app_icons_show_running_applications_light@2x.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "app_icons_show_running_applications_light@2x.jpg"; sourceTree = "<group>"; };
 		1C961FB3DCF4906FEEF4A23D /* TableGroupView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TableGroupView.swift; sourceTree = "<group>"; };
+		346D342B2EEA72A4009590BE /* LiveWindowCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveWindowCapture.swift; sourceTree = "<group>"; };
 		4807A6C523A9CD190052A53E /* SkyLight.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SkyLight.framework; path = ../../../../System/Library/PrivateFrameworks/SkyLight.framework; sourceTree = "<group>"; };
 		481FE54624D2D387001032F1 /* alt-tab-macos-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "alt-tab-macos-Bridging-Header.h"; sourceTree = "<group>"; };
 		5883F0A729A5182C0071DB65 /* TrackpadEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackpadEvents.swift; sourceTree = "<group>"; };
@@ -1285,6 +1287,7 @@
 		D04BA0D80B24E72B9B981A1D /* logic */ = {
 			isa = PBXGroup;
 			children = (
+				346D342B2EEA72A4009590BE /* LiveWindowCapture.swift */,
 				D04BACD976030676FD0761D5 /* Windows.swift */,
 				D04BA9B93823398A542FF7A0 /* Preferences.swift */,
 				D04BA68C2561D9EE4FD851B8 /* NSScreen.swift */,
@@ -2432,6 +2435,7 @@
 				D04BA446D702C5E252AF2319 /* TitleLabel.swift in Sources */,
 				D04BAD43C122A1C7E88B0362 /* MouseEvents.swift in Sources */,
 				D04BAFF30A98CF287F85DA1E /* BlacklistsTab.swift in Sources */,
+				346D342C2EEA72A4009590BE /* LiveWindowCapture.swift in Sources */,
 				D04BA56789A2AF52557A9BFF /* AppCenterCrashes.swift in Sources */,
 				D04BADA3F2DAB820D6FC6E75 /* AppCenterApplication.m in Sources */,
 				D04BAA16F21AC41A23DDA63D /* ControlsTab.swift in Sources */,

--- a/src/logic/LiveWindowCapture.swift
+++ b/src/logic/LiveWindowCapture.swift
@@ -1,0 +1,213 @@
+import Cocoa
+import ScreenCaptureKit
+
+/// LiveWindowCapture provides real-time video capture of windows using ScreenCaptureKit.
+/// Singleton pattern for AppKit integration - manages SCStream instances per window.
+@available(macOS 12.3, *)
+@MainActor
+class LiveWindowCapture: NSObject {
+    static let shared = LiveWindowCapture()
+
+    /// Active streams for each window
+    private var streams: [CGWindowID: SCStream] = [:]
+
+    /// Stream output handlers for each window
+    private var streamOutputs: [CGWindowID: StreamOutput] = [:]
+
+    /// Callback to notify when a new frame is available
+    var onFrameUpdate: ((CGWindowID, CGImage) -> Void)?
+
+    /// Flag to cancel pending stop operation
+    private var stopCancelled = false
+
+    override private init() {
+        super.init()
+    }
+
+    /// Start capturing multiple windows at once (incremental - only starts/stops what's needed)
+    func startCapture(windowIDs: [CGWindowID]) async {
+        guard Preferences.enableLivePreview else { return }
+        
+        // Cancel any pending stop operation
+        stopCancelled = true
+
+        let newWindowIDsSet = Set(windowIDs)
+        let existingWindowIDsSet = Set(streams.keys)
+
+        // Stop streams for windows no longer needed
+        let windowsToStop = existingWindowIDsSet.subtracting(newWindowIDsSet)
+        for windowID in windowsToStop {
+            await stopCapture(windowID: windowID)
+        }
+
+        // Start streams for new windows only
+        let windowsToStart = newWindowIDsSet.subtracting(existingWindowIDsSet)
+        guard !windowsToStart.isEmpty else { return }
+
+        do {
+            let content = try await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: false)
+
+            // Start all streams in parallel using TaskGroup
+            await withTaskGroup(of: Void.self) { group in
+                for windowID in windowsToStart {
+                    guard let scWindow = content.windows.first(where: { $0.windowID == windowID }) else {
+                        continue
+                    }
+                    group.addTask {
+                        await self.startStream(for: scWindow)
+                    }
+                }
+            }
+        } catch {}
+    }
+
+    /// Start capturing a single window
+    func startCapture(windowID: CGWindowID) async {
+        guard Preferences.enableLivePreview else { return }
+        guard streams[windowID] == nil else { return }
+
+        do {
+            let content = try await SCShareableContent.excludingDesktopWindows(true, onScreenWindowsOnly: false)
+            guard let scWindow = content.windows.first(where: { $0.windowID == windowID }) else {
+                return
+            }
+            await startStream(for: scWindow)
+        } catch {}
+    }
+
+    /// Internal method to start a stream for a specific window
+    private func startStream(for window: SCWindow) async {
+        let windowID = window.windowID
+        let filter = SCContentFilter(desktopIndependentWindow: window)
+
+        let quality = Preferences.livePreviewQuality
+        let frameRate = Preferences.livePreviewFrameRate
+
+        let config = SCStreamConfiguration()
+
+        let backingScaleFactor = Int(NSScreen.main?.backingScaleFactor ?? 2.0)
+        let windowWidth = Int(window.frame.width)
+        let windowHeight = Int(window.frame.height)
+        let maxDim = quality.maxDimension
+
+        if quality.useFullResolution {
+            let effectiveScale = quality.scaleFactor == 2 ? 2 : backingScaleFactor
+            var targetWidth = windowWidth * effectiveScale
+            var targetHeight = windowHeight * effectiveScale
+
+            if maxDim > 0 {
+                let aspectRatio = Double(targetWidth) / Double(targetHeight)
+                if targetWidth > targetHeight {
+                    targetWidth = min(targetWidth, maxDim * effectiveScale)
+                    targetHeight = Int(Double(targetWidth) / aspectRatio)
+                } else {
+                    targetHeight = min(targetHeight, maxDim * effectiveScale)
+                    targetWidth = Int(Double(targetHeight) * aspectRatio)
+                }
+            }
+
+            config.width = targetWidth
+            config.height = targetHeight
+        } else {
+            let aspectRatio = Double(windowWidth) / Double(windowHeight)
+            let limitDim = maxDim > 0 ? maxDim : 640
+            if aspectRatio > 1 {
+                config.width = min(limitDim, windowWidth * backingScaleFactor)
+                config.height = Int(Double(config.width) / aspectRatio)
+            } else {
+                config.height = min(limitDim, windowHeight * backingScaleFactor)
+                config.width = Int(Double(config.height) * aspectRatio)
+            }
+        }
+
+        config.minimumFrameInterval = CMTime(value: 1, timescale: CMTimeScale(frameRate.frameRate))
+        config.pixelFormat = kCVPixelFormatType_32BGRA
+        config.showsCursor = false
+        config.queueDepth = 8
+        config.scalesToFit = true
+
+        do {
+            let stream = SCStream(filter: filter, configuration: config, delegate: nil)
+
+            let output = StreamOutput { [weak self] (image: CGImage) in
+                Task { @MainActor in
+                    self?.onFrameUpdate?(windowID, image)
+                }
+            }
+
+            try stream.addStreamOutput(output, type: .screen, sampleHandlerQueue: .global(qos: .userInteractive))
+            try await stream.startCapture()
+
+            streams[windowID] = stream
+            streamOutputs[windowID] = output
+        } catch {}
+    }
+
+    /// Stop capturing a specific window
+    func stopCapture(windowID: CGWindowID) async {
+        if let stream = streams[windowID] {
+            try? await stream.stopCapture()
+            streams.removeValue(forKey: windowID)
+            streamOutputs.removeValue(forKey: windowID)
+        }
+    }
+
+    func stopAllCaptures() async {
+        let keepAlive = Preferences.livePreviewStreamKeepAlive
+
+        if keepAlive == 0 {
+            let streamsToStop = streams
+            streams.removeAll()
+            streamOutputs.removeAll()
+            for (_, stream) in streamsToStop {
+                try? await stream.stopCapture()
+            }
+            return
+        }
+
+        if keepAlive < 0 {
+            return
+        }
+
+        stopCancelled = false
+        try? await Task.sleep(nanoseconds: UInt64(keepAlive) * 1_000_000_000)
+
+        guard !stopCancelled else { return }
+
+        let streamsToStop = streams
+        streams.removeAll()
+        streamOutputs.removeAll()
+
+        for (_, stream) in streamsToStop {
+            try? await stream.stopCapture()
+        }
+    }
+}
+
+/// StreamOutput handles the incoming video frames from SCStream
+/// Reuses CIContext for performance
+@available(macOS 12.3, *)
+private class StreamOutput: NSObject, SCStreamOutput {
+    private let context = CIContext()
+    private let onFrame: (CGImage) -> Void
+
+    init(onFrame: @escaping (CGImage) -> Void) {
+        self.onFrame = onFrame
+        super.init()
+    }
+
+    func stream(_ stream: SCStream, didOutputSampleBuffer sampleBuffer: CMSampleBuffer, of type: SCStreamOutputType) {
+        guard type == .screen else { return }
+        guard let imageBuffer = CMSampleBufferGetImageBuffer(sampleBuffer) else { return }
+
+        let ciImage = CIImage(cvPixelBuffer: imageBuffer)
+        let width = CVPixelBufferGetWidth(imageBuffer)
+        let height = CVPixelBufferGetHeight(imageBuffer)
+
+        guard let cgImage = context.createCGImage(ciImage, from: CGRect(x: 0, y: 0, width: width, height: height)) else {
+            return
+        }
+
+        onFrame(cgImage)
+    }
+}

--- a/src/logic/MacroPreferences.swift
+++ b/src/logic/MacroPreferences.swift
@@ -574,3 +574,98 @@ struct ThemeParameters {
 }
 
 typealias LocalizedString = String
+
+// MARK: - Live Preview Preferences
+
+enum LivePreviewQualityPreference: CaseIterable, MacroPreference {
+    case thumbnail
+    case low
+    case standard
+    case high
+    case retina
+    case native
+
+    var localizedString: LocalizedString {
+        switch self {
+            case .thumbnail: return NSLocalizedString("Thumbnail (320px)", comment: "")
+            case .low: return NSLocalizedString("Low (480px)", comment: "")
+            case .standard: return NSLocalizedString("Standard (640px)", comment: "")
+            case .high: return NSLocalizedString("High (960px)", comment: "")
+            case .retina: return NSLocalizedString("Retina (1280px)", comment: "")
+            case .native: return NSLocalizedString("Native (Best)", comment: "")
+        }
+    }
+
+    var scaleFactor: Int {
+        switch self {
+            case .thumbnail, .low, .standard, .high: return 1
+            case .retina, .native: return 2
+        }
+    }
+
+    var useFullResolution: Bool {
+        switch self {
+            case .thumbnail, .low: return false
+            case .standard, .high, .retina, .native: return true
+        }
+    }
+
+    var maxDimension: Int {
+        switch self {
+            case .thumbnail: return 320
+            case .low: return 480
+            case .standard: return 640
+            case .high: return 960
+            case .retina: return 1280
+            case .native: return 0 // No limit
+        }
+    }
+}
+
+enum LivePreviewFrameRatePreference: CaseIterable, MacroPreference {
+    case fps5
+    case fps10
+    case fps15
+    case fps24
+    case fps30
+    case fps60
+    case fps120
+
+    var localizedString: LocalizedString {
+        switch self {
+            case .fps5: return NSLocalizedString("5 FPS", comment: "")
+            case .fps10: return NSLocalizedString("10 FPS", comment: "")
+            case .fps15: return NSLocalizedString("15 FPS", comment: "")
+            case .fps24: return NSLocalizedString("24 FPS", comment: "")
+            case .fps30: return NSLocalizedString("30 FPS", comment: "")
+            case .fps60: return NSLocalizedString("60 FPS", comment: "")
+            case .fps120: return NSLocalizedString("120 FPS (ProMotion)", comment: "")
+        }
+    }
+
+    var frameRate: Int32 {
+        switch self {
+            case .fps5: return 5
+            case .fps10: return 10
+            case .fps15: return 15
+            case .fps24: return 24
+            case .fps30: return 30
+            case .fps60: return 60
+            case .fps120: return 120
+        }
+    }
+}
+
+enum LivePreviewScopePreference: CaseIterable, MacroPreference {
+    case selectedWindowOnly
+    case selectedAppWindows
+    case allWindows
+
+    var localizedString: LocalizedString {
+        switch self {
+            case .selectedWindowOnly: return NSLocalizedString("Selected Window Only", comment: "")
+            case .selectedAppWindows: return NSLocalizedString("Selected App's Windows", comment: "")
+            case .allWindows: return NSLocalizedString("All Windows", comment: "")
+        }
+    }
+}

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -88,6 +88,11 @@ class Preferences {
         "previewFocusedWindow": "false",
         "screenRecordingPermissionSkipped": "false",
         "trackpadHapticFeedbackEnabled": "true",
+        "enableLivePreview": "false",
+        "livePreviewQuality": LivePreviewQualityPreference.native.indexAsString,
+        "livePreviewFrameRate": LivePreviewFrameRatePreference.fps15.indexAsString,
+        "livePreviewScope": LivePreviewScopePreference.allWindows.indexAsString,
+        "livePreviewStreamKeepAlive": "0",
     ]
 
     // system preferences
@@ -125,6 +130,13 @@ class Preferences {
     static var blacklist: [BlacklistEntry] { CachedUserDefaults.json("blacklist", [BlacklistEntry].self) }
     static var previewFocusedWindow: Bool { CachedUserDefaults.bool("previewFocusedWindow") }
     static var screenRecordingPermissionSkipped: Bool { CachedUserDefaults.bool("screenRecordingPermissionSkipped") }
+
+    // Live preview settings
+    static var enableLivePreview: Bool { CachedUserDefaults.bool("enableLivePreview") }
+    static var livePreviewQuality: LivePreviewQualityPreference { CachedUserDefaults.macroPref("livePreviewQuality", LivePreviewQualityPreference.allCases) }
+    static var livePreviewFrameRate: LivePreviewFrameRatePreference { CachedUserDefaults.macroPref("livePreviewFrameRate", LivePreviewFrameRatePreference.allCases) }
+    static var livePreviewScope: LivePreviewScopePreference { CachedUserDefaults.macroPref("livePreviewScope", LivePreviewScopePreference.allCases) }
+    static var livePreviewStreamKeepAlive: Int { CachedUserDefaults.int("livePreviewStreamKeepAlive") } // seconds (-1 = forever, 0 = immediate)
 
     // macro values
     static var appearanceStyle: AppearanceStylePreference { CachedUserDefaults.macroPref("appearanceStyle", AppearanceStylePreference.allCases) }

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -69,6 +69,8 @@ class App: AppCenterApplication {
         }
         hideAllTooltips()
         MainMenu.toggle(enabled: true)
+        // Stop live capture when UI is hidden
+        Windows.stopLiveCapture()
     }
 
     /// some tooltips may not be hidden when the main window is hidden; we force it through a private API


### PR DESCRIPTION
## Background

I've read through #122 (Display video of the windows instead of static screenshots) and related issues (#2407, #2694, #967). The request for live window previews has been a long-standing feature request since 2019.

In your March 2022 comment on #122, you mentioned experimenting with ScreenCaptureKit and documented your findings in #447. I took that as a starting point and built upon it to create a working implementation.

## What This PR Does

This PR adds an **optional** live video preview feature that shows real-time window content instead of static thumbnails. The feature is:

- **Disabled by default** - Users must explicitly enable it in Preferences → Appearance → Live Preview
- **Fully configurable** - Quality, frame rate, and scope can be adjusted based on user preferences and system capabilities
- **Backwards compatible** - Gracefully disabled on macOS versions older than 12.3

## Implementation Details

### ScreenCaptureKit Approach

After reviewing the constraints discussed in #122 (private APIs being patched in Catalina, etc.), I focused on using the public `ScreenCaptureKit` framework introduced in macOS 12.3. This provides:

- Official Apple API with long-term support
- Per-window video capture via `SCStream`
- Configurable resolution and frame rate via `SCStreamConfiguration`

### Architecture

**LiveWindowCapture.swift** - Core capture manager
- Singleton pattern for AppKit integration
- Manages multiple `SCStream` instances (one per window)
- Incremental stream management - only starts/stops streams as needed, avoiding unnecessary overhead
- `CIContext` reuse in `StreamOutput` for efficient frame processing

**Preference Enums**
- `LivePreviewQualityPreference`: Thumbnail (320px) → Native (full resolution)
- `LivePreviewFrameRatePreference`: 5 FPS → 120 FPS (ProMotion support)
- `LivePreviewScopePreference`: Selected Window Only / Selected App's Windows / All Windows
- `LivePreviewStreamKeepAlivePreference`: Immediately close (0) / Keep forever (-1) / Custom duration (seconds)

**Scope Filtering**
- Capture streams run for all visible windows
- Filtering happens at the display level (in `onFrameUpdate` callback)
- This prevents video freezing when hovering between windows

### Performance Considerations

- **Quality settings** affect `SCStreamConfiguration.width/height` - lower quality = less GPU usage
- **Frame rate** controls `minimumFrameInterval` - lower FPS = less CPU usage
- **Scope** determines how many thumbnails get updated - "Selected Window Only" is the lightest option
- Users are warned in the UI: *"Higher quality and frame rate use more CPU/GPU resources. Use lower settings if you experience lag."*

## Default Settings

- **Enable Live Preview**: Off (opt-in)
- **Quality**: Native (Best)
- **Frame Rate**: 15 FPS
- **Scope**: All Windows

## Notes

This is my proposed solution for the live preview feature. I understand this is a significant addition, and I'm happy to make any adjustments based on your feedback. The implementation tries to stay consistent with the existing codebase patterns and coding style.

@lwouis - Would love to hear your thoughts on this implementation
