### PR TITLE
feat: implement lazy-loading icons with dynamic resolution

### DIFF
--- a/src/logic/Appearance.swift
+++ b/src/logic/Appearance.swift
@@ -52,8 +52,25 @@ class Appearance {
     }
 
     static func update() {
+        let previousStyle = currentStyle
+        let previousSize = currentSize
         updateSize()
         updateTheme()
+        // Manage icon resolution based on appearance changes
+        updateIconResolution(previousStyle: previousStyle, previousSize: previousSize)
+    }
+    
+    private static func updateIconResolution(previousStyle: AppearanceStylePreference, previousSize: AppearanceSizePreference) {
+        let needsHighRes = currentStyle == .appIcons && currentSize == .large
+        let previousNeedsHighRes = previousStyle == .appIcons && previousSize == .large
+        
+        if needsHighRes && !previousNeedsHighRes {
+            // Upgrade to high resolution
+            Applications.list.forEach { $0.upgradeIconIfNeeded() }
+        } else if !needsHighRes && previousNeedsHighRes {
+            // Downgrade to save memory
+            Applications.list.forEach { $0.downgradeIcon() }
+        }
     }
 
     private static func updateSize() {


### PR DESCRIPTION
Please read https://github.com/lwouis/alt-tab-macos/issues/5144 first

- Added IconSize enum with default (256x256) and large (512x512) options
- Icons start at 256x256 to minimize memory usage
- Automatically upgrade to 512x512 when app icons style + large size
- Automatically downgrade when switching away to save memory
- Added upgradeIconIfNeeded() and downgradeIcon() methods
- Integrated with Appearance.update() for automatic management

Benefits:
- Default memory usage: ~7.5MB for 30 apps (256x256)
- High-res when needed: ~30MB for 30 apps (512x512)
- Best of both worlds: low memory + good quality when needed

Closes #memory-usage-issue