### PR TITLE
feat: reduce app icon resolution to 256x256 for memory optimization

### DIFF
--- a/src/logic/Application.swift
+++ b/src/logic/Application.swift
@@ -45,7 +45,7 @@ class Application: NSObject {
     private static func appIconWithoutPadding(_ icon: NSImage?) -> CGImage? {
         guard let icon else { return nil }
         // we can render the icon quite big (e.g. windowless app icon), so we store it high-res
-        let iconWidth = CGFloat(1024)
+        let iconWidth = CGFloat(256)
         // NSRunningApplication.icon returns icons with padding; we remove it manually
 
         let croppedSize = iconWidth - appIconPadding * 2


### PR DESCRIPTION
Please read https://github.com/lwouis/alt-tab-macos/issues/5144 first

- Changed icon resolution from 1024x1024 to 256x256
- Reduces memory usage from ~4MB to ~256KB per app icon
- Expected total memory reduction: ~150MB with 30 apps
- Fixes excessive memory consumption when thumbnails disabled