### PR TITLE
Fix multi-window Unity/similar app focus failure (#4192), Zoom/similar race condition, improve notification dots

### DIFF
--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -153,13 +153,25 @@ class Window {
             NSSound.beep()
             return
         }
+        if let altTabWindow = altTabWindow() {
+            altTabWindow.close()
+            return
+        }
         BackgroundWork.accessibilityCommandsQueue.addOperation { [weak self] in
             guard let self else { return }
             if self.isFullscreen {
                 try? self.axUiElement!.setAttribute(kAXFullscreenAttribute, false)
-            }
-            if let closeButton_ = try? self.axUiElement!.closeButton() {
-                try? closeButton_.performAction(kAXPressAction)
+                // minimizing is ignored if sent immediatly; we wait for the de-fullscreen animation to be over
+                BackgroundWork.accessibilityCommandsQueue.addOperationAfter(deadline: .now() + .seconds(1)) { [weak self] in
+                    guard let self else { return }
+                    if let closeButton_ = try? self.axUiElement!.closeButton() {
+                        try? closeButton_.performAction(kAXPressAction)
+                    }
+                }
+            } else {
+                if let closeButton_ = try? self.axUiElement!.closeButton() {
+                    try? closeButton_.performAction(kAXPressAction)
+                }
             }
         }
     }

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -185,6 +185,10 @@ class Window {
             NSSound.beep()
             return
         }
+        if let altTabWindow = altTabWindow() {
+            altTabWindow.close()
+            return
+        }
         BackgroundWork.accessibilityCommandsQueue.addOperation { [weak self] in
             guard let self else { return }
             if self.isFullscreen {
@@ -203,6 +207,10 @@ class Window {
     func toggleFullscreen() {
         if !canBeMinDeminOrFullscreened() {
             NSSound.beep()
+            return
+        }
+        if let altTabWindow = altTabWindow() {
+            altTabWindow.close()
             return
         }
         BackgroundWork.accessibilityCommandsQueue.addOperation { [weak self] in

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -186,7 +186,7 @@ class Window {
             return
         }
         if let altTabWindow = altTabWindow() {
-            altTabWindow.close()
+            isMinimized ? altTabWindow.deminiaturize(nil) : altTabWindow.miniaturize(nil)
             return
         }
         BackgroundWork.accessibilityCommandsQueue.addOperation { [weak self] in
@@ -210,7 +210,7 @@ class Window {
             return
         }
         if let altTabWindow = altTabWindow() {
-            altTabWindow.close()
+            altTabWindow.toggleFullScreen(nil)
             return
         }
         BackgroundWork.accessibilityCommandsQueue.addOperation { [weak self] in

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -44,7 +44,7 @@ class Window {
             let currentPid = NSWorkspace.shared.frontmostApplication?.processIdentifier
             if currentPid != pid {
                 #if DEBUG
-                Logger.debug("finalAssert[\(label)]: re-activating pid \(pid) (frontmost was: \(String(describing: currentPid)))")
+                Logger.debug { "finalAssert[\(label)]: re-activating pid \(pid) (frontmost was: \(String(describing: currentPid)))" }
                 #endif
                 application.runningApplication.activate(options: .activateIgnoringOtherApps)
             }
@@ -101,17 +101,6 @@ class Window {
 
     deinit {
         Logger.debug { self.debugId() }
-    }
-
-    /// some apps will not trigger AXApplicationActivated, where we usually update application.focusedWindow
-    /// workaround: we check and possibly do it here
-    func checkIfFocused(_ application: Application, _ wid: CGWindowID) {
-        AXUIElement.retryAxCallUntilTimeout(context: debugId, pid: application.pid, callType: .updateWindow) {
-            let focusedWid = try application.axUiElement?.focusedWindow()?.cgWindowId()
-            if wid == focusedWid {
-                application.focusedWindow = self
-            }
-        }
     }
 
     func isEqualRobust(_ otherWindowAxUiElement: AXUIElement, _ otherWindowWid: CGWindowID?) -> Bool {
@@ -352,3 +341,4 @@ class Window {
         }
     }
 }
+

--- a/src/logic/events/AccessibilityEvents.swift
+++ b/src/logic/events/AccessibilityEvents.swift
@@ -48,6 +48,82 @@ class AccessibilityEvents {
             case kAXWindowResizedNotification,
                  kAXWindowMovedNotification: try windowResizedOrMoved(element, pid)
             default: return
+        }
+    }
+}
+
+private static func applicationActivated(_ element: AXUIElement, _ pid: pid_t) throws {
+    let initialFocusedWindow = try element.focusedWindow()
+    let initialWid = try initialFocusedWindow?.cgWindowId()
+
+    func applyFocusBump(_ axWindow: AXUIElement?, _ wid: CGWindowID?) {
+        DispatchQueue.main.async {
+            if let app = Applications.find(pid) {
+                if app.hasBeenActiveOnce != true {
+                    app.hasBeenActiveOnce = true
+                }
+                app.isHidden = false
+
+                var window: Window? = nil
+                if let axWindow, let wid {
+                    // Try to update recency immediately if we can identify the window
+                    window = Windows.updateLastFocus(axWindow, wid)?.first
+
+                    // If the window isn't tracked yet, mirror the focusedWindowChanged fallback to create it
+                    if window == nil {
+                        AXUIElement.retryAxCallUntilTimeout(context: "activation wid:\(wid) pid:\(pid)", pid: pid, callType: .updateWindow) {
+                            if let (title, role, subrole, isMinimized, isFullscreen) = try axWindow.windowAttributes() {
+                                let position = try axWindow.position()
+                                let size = try axWindow.size()
+                                let level = wid.level()
+                                DispatchQueue.main.async {
+                                    if let app2 = Applications.find(pid),
+                                       (!Windows.list.contains { $0.isEqualRobust(axWindow, wid) }),
+                                       AXUIElement.isActualWindow(app2, wid, level, title, subrole, role, size) {
+                                        let w = Window(axWindow, app2, wid, title, isFullscreen, isMinimized, position, size)
+                                        Windows.appendAndUpdateFocus(w)
+                                        App.app.refreshOpenUi([w], .refreshUiAfterExternalEvent)
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+
+                app.focusedWindow = window
+                App.app.checkIfShortcutsShouldBeDisabled(window, app.runningApplication)
+                App.app.refreshOpenUi(window != nil ? [window!] : [], .refreshUiAfterExternalEvent)
+            }
+        }
+    }
+
+    // First attempt: bump using whatever focused window we can get immediately
+    applyFocusBump(initialFocusedWindow, initialWid)
+
+    // If activation happened before a stable focused window exists, retry shortly after
+    if initialFocusedWindow == nil || initialWid == nil {
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(120)) {
+            AXUIElement.retryAxCallUntilTimeout(context: "activationRetry pid:\(pid)", pid: pid, callType: .updateWindow) {
+                let retryFocused = try element.focusedWindow()
+                let retryWid = try retryFocused?.cgWindowId()
+                applyFocusBump(retryFocused, retryWid)
+            }
+        }
+    }
+}
+
+fileprivate func applicationHiddenOrShown(_ pid: pid_t, _ type: String) throws {
+    DispatchQueue.main.async {
+        if let app = Applications.find(pid) {
+            app.isHidden = type == kAXApplicationHiddenNotification
+            let windows = Windows.list.filter {
+                // for AXUIElement of apps, CFEqual or == don't work; looks like a Cocoa bug
+                return $0.application.pid == pid
+            }
+            // if we process the "shown" event too fast, the window won't be listed by CGSCopyWindowsWithOptionsAndTags
+            // it will thus be detected as isTabbed. We add a delay to work around this scenario
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {
+                App.app.refreshOpenUi(windows, .refreshUiAfterExternalEvent)
             }
         }
     }
@@ -92,42 +168,28 @@ class AccessibilityEvents {
             let size = try element.size()
             let level = wid.level()
             DispatchQueue.main.async {
-                if let app = Applications.find(pid), NSRunningApplication(processIdentifier: pid) != nil {
-                    if (!Windows.list.contains { $0.isEqualRobust(element, wid) }) &&
-                           AXUIElement.isActualWindow(app, wid, level, title, subrole, role, size) {
-                        let window = Window(element, app, wid, title, isFullscreen, isMinimized, position, size)
-                        Windows.appendAndUpdateFocus(window)
-                        Windows.cycleFocusedWindowIndex(1)
-                        App.app.refreshOpenUi([window], .refreshUiAfterExternalEvent)
-                    }
-                }
-            }
-        }
-    }
 
-    private static func focusedWindowChanged(_ element: AXUIElement, _ pid: pid_t) throws {
-        let wid = try element.cgWindowId()
-        if let runningApp = NSRunningApplication(processIdentifier: pid) {
-            // photoshop will focus a window *after* you focus another app
-            // we check that a focused window happens within an active app
-            if runningApp.isActive {
-                DispatchQueue.main.async {
-                    guard let app = Applications.find(pid) else { return }
-                    // if the window is shown by alt-tab, we mark it as focused for this app
-                    // this avoids issues with dialogs, quicklook, etc (see scenarios from #1044 and #2003)
-                    if let w = (Windows.list.first { $0.isEqualRobust(element, wid) }) {
-                        app.focusedWindow = w
-                    }
-                    if let windows = Windows.updateLastFocus(element, wid) {
-                        App.app.refreshOpenUi(windows, .refreshUiAfterExternalEvent)
-                    } else {
-                        AXUIElement.retryAxCallUntilTimeout(context: "(wid:\(wid) pid:\(pid))", pid: pid, callType: .updateWindow) {
+                guard let app = Applications.find(pid) else { return }
+                app.isHidden = false
+                // if the window is shown by alt-tab, we mark it as focused for this app
+                // this avoids issues with dialogs, quicklook, etc (see scenarios from #1044 and #2003)
+                if let w = (Windows.list.first { $0.isEqualRobust(element, wid) }) {
+                    app.focusedWindow = w
+                }
+                Windows.updateLastFocusDebounced(element, wid, pid: pid, debounce: 60, requireFrontmost: false)
+
+                // Also schedule a fallback to create the window if it doesn't exist yet after a short delay
+                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(120)) {
+                    // If the window still isn't tracked, try to create it
+                    if (Windows.list.first { $0.isEqualRobust(element, wid) }) == nil {
+                        AXUIElement.retryAxCallUntilTimeout(context: "wid:\(wid) pid:\(pid)", pid: pid, callType: .updateWindow) {
                             if let (title, role, subrole, isMinimized, isFullscreen) = try element.windowAttributes() {
                                 let position = try element.position()
                                 let size = try element.size()
                                 let level = wid.level()
                                 DispatchQueue.main.async {
-                                    if (!Windows.list.contains { $0.isEqualRobust(element, wid) }),
+                                    if let app = Applications.find(pid),
+                                       (!Windows.list.contains { $0.isEqualRobust(element, wid) }),
                                        AXUIElement.isActualWindow(app, wid, level, title, subrole, role, size) {
                                         let window = Window(element, app, wid, title, isFullscreen, isMinimized, position, size)
                                         Windows.appendAndUpdateFocus(window)

--- a/src/logic/events/AccessibilityEvents.swift
+++ b/src/logic/events/AccessibilityEvents.swift
@@ -48,98 +48,66 @@ class AccessibilityEvents {
             case kAXWindowResizedNotification,
                  kAXWindowMovedNotification: try windowResizedOrMoved(element, pid)
             default: return
-        }
-    }
-}
-
-private static func applicationActivated(_ element: AXUIElement, _ pid: pid_t) throws {
-    let initialFocusedWindow = try element.focusedWindow()
-    let initialWid = try initialFocusedWindow?.cgWindowId()
-
-    func applyFocusBump(_ axWindow: AXUIElement?, _ wid: CGWindowID?) {
-        DispatchQueue.main.async {
-            if let app = Applications.find(pid) {
-                if app.hasBeenActiveOnce != true {
-                    app.hasBeenActiveOnce = true
-                }
-                app.isHidden = false
-
-                var window: Window? = nil
-                if let axWindow, let wid {
-                    // Try to update recency immediately if we can identify the window
-                    window = Windows.updateLastFocus(axWindow, wid)?.first
-
-                    // If the window isn't tracked yet, mirror the focusedWindowChanged fallback to create it
-                    if window == nil {
-                        AXUIElement.retryAxCallUntilTimeout(context: "activation wid:\(wid) pid:\(pid)", pid: pid, callType: .updateWindow) {
-                            if let (title, role, subrole, isMinimized, isFullscreen) = try axWindow.windowAttributes() {
-                                let position = try axWindow.position()
-                                let size = try axWindow.size()
-                                let level = wid.level()
-                                DispatchQueue.main.async {
-                                    if let app2 = Applications.find(pid),
-                                       (!Windows.list.contains { $0.isEqualRobust(axWindow, wid) }),
-                                       AXUIElement.isActualWindow(app2, wid, level, title, subrole, role, size) {
-                                        let w = Window(axWindow, app2, wid, title, isFullscreen, isMinimized, position, size)
-                                        Windows.appendAndUpdateFocus(w)
-                                        App.app.refreshOpenUi([w], .refreshUiAfterExternalEvent)
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-
-                app.focusedWindow = window
-                App.app.checkIfShortcutsShouldBeDisabled(window, app.runningApplication)
-                App.app.refreshOpenUi(window != nil ? [window!] : [], .refreshUiAfterExternalEvent)
-            }
-        }
-    }
-
-    // First attempt: bump using whatever focused window we can get immediately
-    applyFocusBump(initialFocusedWindow, initialWid)
-
-    // If activation happened before a stable focused window exists, retry shortly after
-    if initialFocusedWindow == nil || initialWid == nil {
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(120)) {
-            AXUIElement.retryAxCallUntilTimeout(context: "activationRetry pid:\(pid)", pid: pid, callType: .updateWindow) {
-                let retryFocused = try element.focusedWindow()
-                let retryWid = try retryFocused?.cgWindowId()
-                applyFocusBump(retryFocused, retryWid)
-            }
-        }
-    }
-}
-
-fileprivate func applicationHiddenOrShown(_ pid: pid_t, _ type: String) throws {
-    DispatchQueue.main.async {
-        if let app = Applications.find(pid) {
-            app.isHidden = type == kAXApplicationHiddenNotification
-            let windows = Windows.list.filter {
-                // for AXUIElement of apps, CFEqual or == don't work; looks like a Cocoa bug
-                return $0.application.pid == pid
-            }
-            // if we process the "shown" event too fast, the window won't be listed by CGSCopyWindowsWithOptionsAndTags
-            // it will thus be detected as isTabbed. We add a delay to work around this scenario
-            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(200)) {
-                App.app.refreshOpenUi(windows, .refreshUiAfterExternalEvent)
             }
         }
     }
 
     private static func applicationActivated(_ element: AXUIElement, _ pid: pid_t) throws {
-        let appFocusedWindow = try element.focusedWindow()
-        let wid = try appFocusedWindow?.cgWindowId()
-        DispatchQueue.main.async {
-            if let app = Applications.find(pid) {
-                if app.hasBeenActiveOnce != true {
-                    app.hasBeenActiveOnce = true
+        let initialFocusedWindow = try element.focusedWindow()
+        let initialWid = try initialFocusedWindow?.cgWindowId()
+
+        func applyFocusBump(_ axWindow: AXUIElement?, _ wid: CGWindowID?) {
+            DispatchQueue.main.async {
+                if let app = Applications.find(pid) {
+                    if app.hasBeenActiveOnce != true {
+                        app.hasBeenActiveOnce = true
+                    }
+                    app.isHidden = false
+
+                    var window: Window? = nil
+                    if let axWindow, let wid {
+                        // Try to update recency immediately if we can identify the window
+                        window = Windows.updateLastFocus(axWindow, wid)?.first
+
+                        // If the window isn't tracked yet, mirror the focusedWindowChanged fallback to create it
+                        if window == nil {
+                            AXUIElement.retryAxCallUntilTimeout(context: "activation wid:\(wid) pid:\(pid)", pid: pid, callType: .updateWindow) {
+                                if let (title, role, subrole, isMinimized, isFullscreen) = try axWindow.windowAttributes() {
+                                    let position = try axWindow.position()
+                                    let size = try axWindow.size()
+                                    let level = wid.level()
+                                    DispatchQueue.main.async {
+                                        if let app2 = Applications.find(pid),
+                                           (!Windows.list.contains { $0.isEqualRobust(axWindow, wid) }),
+                                           AXUIElement.isActualWindow(app2, wid, level, title, subrole, role, size) {
+                                            let w = Window(axWindow, app2, wid, title, isFullscreen, isMinimized, position, size)
+                                            Windows.appendAndUpdateFocus(w)
+                                            App.app.refreshOpenUi([w], .refreshUiAfterExternalEvent)
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    app.focusedWindow = window
+                    App.app.checkIfShortcutsShouldBeDisabled(window, app.runningApplication)
+                    App.app.refreshOpenUi(window != nil ? [window!] : [], .refreshUiAfterExternalEvent)
                 }
-                let window = (appFocusedWindow != nil && wid != nil) ? Windows.updateLastFocus(appFocusedWindow!, wid!)?.first : nil
-                app.focusedWindow = window
-                App.app.checkIfShortcutsShouldBeDisabled(window, app.runningApplication)
-                App.app.refreshOpenUi(window != nil ? [window!] : [], .refreshUiAfterExternalEvent)
+            }
+        }
+
+        // First attempt: bump using whatever focused window we can get immediately
+        applyFocusBump(initialFocusedWindow, initialWid)
+
+        // If activation happened before a stable focused window exists, retry shortly after
+        if initialFocusedWindow == nil || initialWid == nil {
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(120)) {
+                AXUIElement.retryAxCallUntilTimeout(context: "activationRetry pid:\(pid)", pid: pid, callType: .updateWindow) {
+                    let retryFocused = try element.focusedWindow()
+                    let retryWid = try retryFocused?.cgWindowId()
+                    applyFocusBump(retryFocused, retryWid)
+                }
             }
         }
     }
@@ -163,47 +131,37 @@ fileprivate func applicationHiddenOrShown(_ pid: pid_t, _ type: String) throws {
 
     private static func windowCreated(_ element: AXUIElement, _ pid: pid_t) throws {
         let wid = try element.cgWindowId()
-        if let (title, role, subrole, isMinimized, isFullscreen) = try element.windowAttributes() {
-            let position = try element.position()
-            let size = try element.size()
-            let level = wid.level()
-            DispatchQueue.main.async {
-
-                guard let app = Applications.find(pid) else { return }
-                app.isHidden = false
-                // if the window is shown by alt-tab, we mark it as focused for this app
-                // this avoids issues with dialogs, quicklook, etc (see scenarios from #1044 and #2003)
-                if let w = (Windows.list.first { $0.isEqualRobust(element, wid) }) {
-                    app.focusedWindow = w
-                }
-                Windows.updateLastFocusDebounced(element, wid, pid: pid, debounce: 60, requireFrontmost: false)
-
-                // Also schedule a fallback to create the window if it doesn't exist yet after a short delay
-                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(120)) {
-                    // If the window still isn't tracked, try to create it
-                    if (Windows.list.first { $0.isEqualRobust(element, wid) }) == nil {
-                        AXUIElement.retryAxCallUntilTimeout(context: "wid:\(wid) pid:\(pid)", pid: pid, callType: .updateWindow) {
-                            if let (title, role, subrole, isMinimized, isFullscreen) = try element.windowAttributes() {
-                                let position = try element.position()
-                                let size = try element.size()
-                                let level = wid.level()
-                                DispatchQueue.main.async {
-                                    if let app = Applications.find(pid),
-                                       (!Windows.list.contains { $0.isEqualRobust(element, wid) }),
-                                       AXUIElement.isActualWindow(app, wid, level, title, subrole, role, size) {
-                                        let window = Window(element, app, wid, title, isFullscreen, isMinimized, position, size)
-                                        Windows.appendAndUpdateFocus(window)
-                                        App.app.refreshOpenUi([window], .refreshUiAfterExternalEvent)
-                                    }
+        DispatchQueue.main.async {
+            guard let app = Applications.find(pid) else { return }
+            app.isHidden = false
+            // if the window is shown by alt-tab, we mark it as focused for this app
+            // this avoids issues with dialogs, quicklook, etc (see scenarios from #1044 and #2003)
+            if let w = (Windows.list.first { $0.isEqualRobust(element, wid) }) {
+                app.focusedWindow = w
+            }
+            Windows.updateLastFocusDebounced(element, wid, pid: pid, debounce: 60, requireFrontmost: false)
+            
+            // Also schedule a fallback to create the window if it doesn't exist yet after a short delay
+            DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(120)) {
+                // If the window still isn't tracked, try to create it
+                if (Windows.list.first { $0.isEqualRobust(element, wid) }) == nil {
+                    AXUIElement.retryAxCallUntilTimeout(context: "wid:\(wid) pid:\(pid)", pid: pid, callType: .updateWindow) {
+                        if let (title, role, subrole, isMinimized, isFullscreen) = try element.windowAttributes() {
+                            let position = try element.position()
+                            let size = try element.size()
+                            let level = wid.level()
+                            DispatchQueue.main.async {
+                                if let app = Applications.find(pid),
+                                   (!Windows.list.contains { $0.isEqualRobust(element, wid) }),
+                                   AXUIElement.isActualWindow(app, wid, level, title, subrole, role, size) {
+                                    let window = Window(element, app, wid, title, isFullscreen, isMinimized, position, size)
+                                    Windows.appendAndUpdateFocus(window)
+                                    App.app.refreshOpenUi([window], .refreshUiAfterExternalEvent)
                                 }
                             }
                         }
                     }
                 }
-            }
-        } else {
-            DispatchQueue.main.async {
-                Applications.find(pid)?.focusedWindow = nil
             }
         }
     }
@@ -247,6 +205,17 @@ fileprivate func applicationHiddenOrShown(_ pid: pid_t, _ type: String) throws {
         let wid = try element.cgWindowId()
         AXUIElement.retryAxCallUntilTimeout(context: "(wid:\(wid) pid:\(pid))", debounceType: .windowResizedOrMoved, pid: pid, wid: wid, callType: .updateWindow) {
             try updateWindowSizeAndPositionAndFullscreen(element, wid, nil)
+        }
+    }
+
+    private static func focusedWindowChanged(_ element: AXUIElement, _ pid: pid_t) throws {
+        let wid = try element.cgWindowId()
+        DispatchQueue.main.async {
+            if let window = Windows.updateLastFocus(element, wid)?.first, let app = Applications.find(pid) {
+                app.focusedWindow = window
+                App.app.checkIfShortcutsShouldBeDisabled(window, app.runningApplication)
+                App.app.refreshOpenUi([window], .refreshUiAfterExternalEvent)
+            }
         }
     }
 }

--- a/src/ui/main-window/ThumbnailFontIconView.swift
+++ b/src/ui/main-window/ThumbnailFontIconView.swift
@@ -7,6 +7,7 @@ enum Symbols: String {
     case circledNumber0 = "􀀸"
     case circledNumber10 = "􀓵"
     case circledStar = "􀕬"
+    case filledCircledDot = "􀢚"
     case filledCircledStar = "􀕭"
     case filledCircled = "􀀁"
     case filledCircledNumber0 = "􀀹"
@@ -24,6 +25,12 @@ class ThumbnailFontIconView: ThumbnailTitleView {
         return paragraphStyle
     }()
     var initialAttributedString: NSMutableAttributedString!
+    private var overlayLabel: NSTextField?
+    private var overlayCenterX: NSLayoutConstraint?
+    private var overlayCenterY: NSLayoutConstraint?
+    private var wakeObserver: Any?
+    private var appActiveObserver: Any?
+    private var overlayText: String?
 
     convenience init(symbol: Symbols, tooltip: String? = nil, size: CGFloat = Appearance.fontHeight, color: NSColor = Appearance.fontColor) {
         // This helps SF symbols display vertically centered and not clipped at the top
@@ -33,20 +40,197 @@ class ThumbnailFontIconView: ThumbnailTitleView {
         textColor = color
         toolTip = tooltip
         addOrUpdateConstraint(widthAnchor, cell!.cellSize.width)
+        wantsLayer = true
+        canDrawSubviewsIntoLayer = true
     }
 
-    // number should be in the interval [0-50]
+    private func ensureOverlayLabel() {
+        if overlayLabel != nil { return }
+        let label = NSTextField(labelWithString: "")
+        label.translatesAutoresizingMaskIntoConstraints = true
+        label.alignment = .center
+        label.isBezeled = false
+        label.drawsBackground = false
+        label.lineBreakMode = .byClipping
+        label.maximumNumberOfLines = 1
+        label.textColor = .white
+        label.wantsLayer = true
+        addSubview(label)
+        overlayLabel = label
+    }
+    
+    private func occupancy(for text: String) -> CGFloat {
+        // Slightly larger target occupancy for 1–2 digits; smaller for 3–4 digits
+        return (text.count <= 2) ? 0.78 : (text.count <= 3 ? 0.62 : 0.50)
+    }
+
+    private func fittedFont(for text: String) -> NSFont {
+        let baseFont = self.font ?? NSFont(name: "SF Pro Text", size: (Appearance.fontHeight * 0.85).rounded())!
+        let boundsW = (cell?.cellSize.width ?? bounds.width)
+        let boundsH = (cell?.cellSize.height ?? bounds.height)
+
+        let occupancy = occupancy(for: text)
+        let availableW = boundsW * occupancy
+        let availableH = boundsH * occupancy
+
+        let attrs: [NSAttributedString.Key: Any] = [.font: baseFont]
+        let measured = (text as NSString).size(withAttributes: attrs)
+
+        // Always compute a uniform scale so 2-digit numbers can scale UP a bit,
+        // and 3–4 digit numbers scale DOWN more than before.
+        let widthScale = availableW / max(measured.width, 1)
+        let heightScale = availableH / max(measured.height, 1)
+        let scale = min(widthScale, heightScale)
+
+        // Clamp to reasonable bounds and quantize to avoid jitter across repeated calls.
+        let clampedScale = max(0.4, min(scale, 1.25))
+        let newSize = max(6, floor(baseFont.pointSize * clampedScale))
+        return NSFont(name: baseFont.fontName, size: newSize) ?? baseFont
+    }
+
+    override func layout() {
+        super.layout()
+        if let label = overlayLabel, !label.isHidden {
+            let container = (self.cell?.titleRect(forBounds: self.bounds)) ?? self.bounds
+            let size: CGSize
+            if let cell = label.cell {
+                size = cell.cellSize
+            } else {
+                size = label.intrinsicContentSize
+            }
+            let x = container.midX - size.width / 2.0
+            let y = container.midY - size.height / 2.0
+            let dx: CGFloat = -1.75  // move slightly left
+            let occupancy = occupancy(for: label.stringValue)
+            let dy: CGFloat =  -1 - (5*occupancy - 2.5)  // move slightly up; -1.5 is about right for two digits
+            label.frame = CGRect(x: x + dx, y: y + dy, width: size.width, height: size.height)
+            label.needsDisplay = true
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard let text = overlayText, !text.isEmpty else { return }
+
+        let container = (self.cell?.titleRect(forBounds: self.bounds)) ?? self.bounds
+        let font = fittedFont(for: text)
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.white
+        ]
+        let size = (text as NSString).size(withAttributes: attrs)
+        let x = container.midX - size.width / 2.0
+        let y = container.midY - size.height / 2.0
+        let dx: CGFloat = -1.75
+        let occ = occupancy(for: text)
+        let dy: CGFloat = -1 - (5*occ - 2.5)
+        (text as NSString).draw(at: NSPoint(x: x + dx, y: y + dy), withAttributes: attrs)
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if let obs = wakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(obs)
+            wakeObserver = nil
+        }
+        if let obs = appActiveObserver {
+            NotificationCenter.default.removeObserver(obs)
+            appActiveObserver = nil
+        }
+        guard window != nil else { return }
+        wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.screensDidWakeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.forceRelayoutAndRedraw()
+        }
+        appActiveObserver = NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.forceRelayoutAndRedraw()
+        }
+    }
+
+    deinit {
+        if let obs = wakeObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(obs)
+        }
+        if let obs = appActiveObserver {
+            NotificationCenter.default.removeObserver(obs)
+        }
+    }
+
+    override func viewDidChangeBackingProperties() {
+        super.viewDidChangeBackingProperties()
+        forceRelayoutAndRedraw()
+    }
+
+    private func forceRelayoutAndRedraw()
+    {
+        // Keep label-based path alive if it's currently visible (<=30), but prefer our draw-based overlay for >30
+        if let label = overlayLabel, !label.isHidden {
+            let text = label.stringValue
+            let font = fittedFont(for: text)
+            let attrs: [NSAttributedString.Key: Any] = [ .font: font ]
+            label.attributedStringValue = NSAttributedString(string: text, attributes: attrs)
+            label.invalidateIntrinsicContentSize()
+            label.needsDisplay = true
+            label.displayIfNeeded()
+        }
+        // Always invalidate our own drawing; cheap and avoids stale overlays.
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+        needsDisplay = true
+        displayIfNeeded()
+    }
+
     func setNumber(_ number: Int, _ filled: Bool) {
-        let (baseCharacter, offset) = baseCharacterAndOffset(number, filled)
-        replaceCharIfNeeded(String(UnicodeScalar(Int(baseCharacter.unicodeScalars.first!.value) + offset)!))
+        // Preserve existing SF Symbols behavior for 0–30 exactly
+        if number <= 30 {
+            overlayText = nil
+            overlayLabel?.isHidden = true
+            let (baseCharacter, offset) = baseCharacterAndOffset(number, filled)
+            replaceCharIfNeeded(String(UnicodeScalar(Int(baseCharacter.unicodeScalars.first!.value) + offset)!))
+            return
+        }
+
+        // 5+ digits → fall back to filled star
+        if number >= 10000 {
+            overlayText = nil
+            overlayLabel?.isHidden = true
+            setFilledStar()
+            return
+        }
+
+        // Custom render for numbers > 30 and up to 4 digits:
+        // Draw the filled circle symbol, then overlay centered white text using the same SF font.
+        overlayText = String(number)
+        overlayLabel?.isHidden = true
+        replaceCharIfNeeded(Symbols.filledCircled.rawValue)
+        needsLayout = true
+        needsDisplay = true
+    }
+    
+    private func setSymbol(_ symbol: String) {
+        overlayText = nil
+        overlayLabel?.isHidden = true
+        needsDisplay = true
+        replaceCharIfNeeded(symbol)
     }
 
     func setStar() {
-        replaceCharIfNeeded(Symbols.circledStar.rawValue)
+        setSymbol(Symbols.circledStar.rawValue)
     }
 
     func setFilledStar() {
-        replaceCharIfNeeded(Symbols.filledCircledStar.rawValue)
+        setSymbol(Symbols.filledCircledStar.rawValue)
+    }
+
+    func setFilledDot() {
+        setSymbol(Symbols.filledCircledDot.rawValue)
     }
 
     private func replaceCharIfNeeded(_ newChar: String) {

--- a/src/ui/main-window/ThumbnailView.swift
+++ b/src/ui/main-window/ThumbnailView.swift
@@ -169,8 +169,8 @@ class ThumbnailView: FlippedView {
         if !dockLabelIcon.isHidden, let dockLabel {
             let view = dockLabelIcon.subviews[1] as! ThumbnailFontIconView
             let dockLabelInt = Int(dockLabel)
-            if dockLabelInt == nil || dockLabelInt! > 30 {
-                view.setFilledStar()
+            if dockLabelInt == nil {
+                view.setFilledDot()
             } else {
                 view.setNumber(dockLabelInt!, true)
             }


### PR DESCRIPTION
fix: Unity app focus (#4192 ), Zoom race condition, notification count cap

### Bug Fixes

* Swapping away from Unity/similar multi-window apps failed to change focus (should fix #4192 )
* Race condition during Zoom/Photoshop/similar apps with custom windows (revises previous fix)

### Features

* Improves notification dots (moves * cap up to >four digits)

Apologies that I have a very intense full time job and haven't had time to test under every circumstance
or match convention perfectly. I want to get this into circulation, though, since #4192 is breaking
for me, and the Zoom/Photoshop race condition has been a bear to track down. I've done extensive
testing on both of those prior to v7.39.0, which unfortunately stomped on several of the fixes.
I've done my best to re-test after a lot of merge conflicts, but I haven't had nearly as much time,
and I want to get this in over the holiday break before work takes over again. Apologies that I've
done my best, thanks for your work on this!