### PR TITLE
fix: mouse hover detection for hidden/windowless apps

### DIFF
--- a/src/ui/main-window/ThumbnailsView.swift
+++ b/src/ui/main-window/ThumbnailsView.swift
@@ -308,8 +308,7 @@ class ScrollView: NSScrollView {
     }
 
     private func findTarget(_ location: NSPoint) -> ThumbnailView? {
-        for i in 0..<Windows.list.count {
-            let view = ThumbnailsView.recycledViews[i]
+        for case let view as ThumbnailView in documentView!.subviews {
             let frame = view.frame
             let expandedFrame = CGRect(x: frame.minX - (App.shared.userInterfaceLayoutDirection == .leftToRight ? 0 : 1), y: frame.minY, width: frame.width + 1, height: frame.height + 1)
             if expandedFrame.contains(location) {


### PR DESCRIPTION
Mouse hover to select wasn't working for hidden apps or apps without windows. Hovering over these apps didn't show the blue highlight, so you couldn't hover and release the modifier key to focus them - clicking still worked. (Tested in App Icons and Titles modes, but likely affected all modes.)

The issue was that `findTarget` iterated `Windows.list.count` times over `recycledViews`, but the actual displayed subviews can be fewer due to the `shouldShowTheUser` filter in `layoutThumbnailViews`. This mismatch meant hover detection was checking views that weren't in the view hierarchy.

Fixed by iterating directly over `documentView.subviews` instead.