### PR TITLE
fix(controls-tab): make enter key focus selected window

### DIFF
--- a/src/ui/preferences-window/tabs/controls/ControlsTab.swift
+++ b/src/ui/preferences-window/tabs/controls/ControlsTab.swift
@@ -10,6 +10,8 @@ class ControlsTab {
         "holdShortcut2": { App.app.focusTarget() },
         "holdShortcut3": { App.app.focusTarget() },
         "focusWindowShortcut": { App.app.focusTarget() },
+        "enterFocusShortcut": { App.app.focusTarget() },
+        "numpadEnterFocusShortcut": { App.app.focusTarget() },
         "nextWindowShortcut": { App.app.showUiOrCycleSelection(0, false) },
         "nextWindowShortcut2": { App.app.showUiOrCycleSelection(1, false) },
         "nextWindowShortcut3": { App.app.showUiOrCycleSelection(2, false) },
@@ -67,6 +69,7 @@ class ControlsTab {
         view.translatesAutoresizingMaskIntoConstraints = false
         shortcutsWhenActiveSheet = ShortcutsWhenActiveSheet()
         additionalControlsSheet = AdditionalControlsSheet()
+        registerEnterKeyShortcuts()
         ControlsTab.switchIndexTab(0)
         view.fit()
         return view
@@ -225,6 +228,14 @@ class ControlsTab {
         } else {
             keys.forEach { removeShortcutIfExists($0) }
         }
+    }
+
+    static func registerEnterKeyShortcuts() {
+        let enter = Shortcut(code: .return, modifierFlags: [], characters: nil, charactersIgnoringModifiers: nil)
+        let numpadEnter = Shortcut(code: .ansiKeypadEnter, modifierFlags: [], characters: nil,
+            charactersIgnoringModifiers: nil)
+        addShortcut(.down, .local, enter, "enterFocusShortcut", nil)
+        addShortcut(.down, .local, numpadEnter, "numpadEnterFocusShortcut", nil)
     }
 
     @objc static func vimKeysEnabledCallback(_ sender: NSControl) {

--- a/unit-tests/KeyboardEventsTests.swift
+++ b/unit-tests/KeyboardEventsTests.swift
@@ -111,6 +111,38 @@ final class KeyboardEventsUtilsTests: XCTestCase {
         XCTAssertEqual(ControlsTab.shortcutsActionsTriggered, ["nextWindowShortcut", "closeWindowShortcut", "holdShortcut"])
     }
 
+    // alt-down > tab-down > tab-up > enter-down
+    // Enter key should focus the selected window (like Space)
+    func testEnterKeyFocusesWindow() throws {
+        resetState()
+        ModifierFlags.current = [.option]
+        handleKeyboardEvent(nil, nil, nil, [.option], false)
+        XCTAssertEqual(ControlsTab.shortcutsActionsTriggered, [])
+        handleKeyboardEvent(KeyboardEventsTestable.globalShortcutsIds["nextWindowShortcut"], .down, nil, nil, false)
+        XCTAssertEqual(ControlsTab.shortcutsActionsTriggered, ["nextWindowShortcut"])
+        handleKeyboardEvent(KeyboardEventsTestable.globalShortcutsIds["nextWindowShortcut"], .up, nil, nil, false)
+        XCTAssertEqual(ControlsTab.shortcutsActionsTriggered, ["nextWindowShortcut"])
+        // Enter key should trigger focusWindowShortcut action
+        handleKeyboardEvent(nil, nil, enterKeyCode, [.option], false)
+        XCTAssertEqual(ControlsTab.shortcutsActionsTriggered, ["nextWindowShortcut", "enterFocusShortcut"])
+    }
+
+    // alt-down > tab-down > tab-up > numpad-enter-down
+    // Numpad Enter key should focus the selected window (like Space)
+    func testNumpadEnterKeyFocusesWindow() throws {
+        resetState()
+        ModifierFlags.current = [.option]
+        handleKeyboardEvent(nil, nil, nil, [.option], false)
+        XCTAssertEqual(ControlsTab.shortcutsActionsTriggered, [])
+        handleKeyboardEvent(KeyboardEventsTestable.globalShortcutsIds["nextWindowShortcut"], .down, nil, nil, false)
+        XCTAssertEqual(ControlsTab.shortcutsActionsTriggered, ["nextWindowShortcut"])
+        handleKeyboardEvent(KeyboardEventsTestable.globalShortcutsIds["nextWindowShortcut"], .up, nil, nil, false)
+        XCTAssertEqual(ControlsTab.shortcutsActionsTriggered, ["nextWindowShortcut"])
+        // Numpad Enter key should trigger focusWindowShortcut action
+        handleKeyboardEvent(nil, nil, numpadEnterKeyCode, [.option], false)
+        XCTAssertEqual(ControlsTab.shortcutsActionsTriggered, ["nextWindowShortcut", "numpadEnterFocusShortcut"])
+    }
+
     func testOnReleaseDoNothing() throws {
         resetState()
         Preferences.shortcutStyle[0] = .doNothingOnRelease
@@ -169,4 +201,7 @@ final class KeyboardEventsUtilsTests: XCTestCase {
         "\\": 0x2A, ",": 0x2B, "/": 0x2C, "n": 0x2D,
         "m": 0x2E, ".": 0x2F, "`": 0x32, " ": 0x31
     ]
+
+    private let enterKeyCode: UInt32 = 0x24        // main keyboard Enter/Return
+    private let numpadEnterKeyCode: UInt32 = 0x4C  // numpad Enter
 }

--- a/unit-tests/Mocks.swift
+++ b/unit-tests/Mocks.swift
@@ -25,6 +25,12 @@ class ControlsTab {
 //        "vimCycleUp": ATShortcut(Shortcut(keyEquivalent: "k")!, "vimCycleUp", .local, .down),
 //        "vimCycleDown": ATShortcut(Shortcut(keyEquivalent: "j")!, "vimCycleDown", .local, .down),
         "focusWindowShortcut": ATShortcut(Shortcut(keyEquivalent: " ")!, "focusWindowShortcut", .local, .down),
+        "enterFocusShortcut": ATShortcut(
+            Shortcut(code: .return, modifierFlags: [], characters: nil, charactersIgnoringModifiers: nil),
+            "enterFocusShortcut", .local, .down),
+        "numpadEnterFocusShortcut": ATShortcut(
+            Shortcut(code: .ansiKeypadEnter, modifierFlags: [], characters: nil, charactersIgnoringModifiers: nil),
+            "numpadEnterFocusShortcut", .local, .down),
         "previousWindowShortcut": ATShortcut(Shortcut(keyEquivalent: "⇧")!, "previousWindowShortcut", .local, .down),
         "cancelShortcut": ATShortcut(Shortcut(keyEquivalent: "⎋")!, "cancelShortcut", .local, .down),
         "closeWindowShortcut": ATShortcut(Shortcut(keyEquivalent: "w")!, "closeWindowShortcut", .local, .down),


### PR DESCRIPTION
This PR add Enter key (both main keyboard Return and numpad Enter) as additional shortcuts to focus the selected window when AltTab is active, matching the existing Space key behavior. re last bit of https://github.com/lwouis/alt-tab-macos/issues/210#issuecomment-3763096245

I verified that it works properly on my machine, as well as unit-tests.