### PR TITLE
feat: add Windows-style persistent taskbar

### DIFF
--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -69,6 +69,7 @@
 		5F21C9E22C6E94410091F72F /* AdditionalControlsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F21C9E12C6E94410091F72F /* AdditionalControlsSheet.swift */; };
 		5F21C9E42C6E94700091F72F /* CustomizeStyleSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F21C9E32C6E94700091F72F /* CustomizeStyleSheet.swift */; };
 		5F21C9E62C6E94920091F72F /* AnimationsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F21C9E52C6E94920091F72F /* AnimationsSheet.swift */; };
+		TASKBAR02SETTINGS02 /* TaskbarSettingsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = TASKBAR01SETTINGS01 /* TaskbarSettingsSheet.swift */; };
 		5F21C9E82C6E96A00091F72F /* SheetWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F21C9E72C6E96A00091F72F /* SheetWindow.swift */; };
 		5F4753072CEE5A2E002C6C5E /* AppearanceTestable.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C8D57C86AF492D43A576D /* AppearanceTestable.swift */; };
 		5F706EC02BA448B1004D542D /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5F706EBE2BA448B1004D542D /* Localizable.strings */; };
@@ -295,6 +296,11 @@
 		D04BAFB973C3D28718FAEB87 /* Windows.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BACD976030676FD0761D5 /* Windows.swift */; };
 		D04BAFBC862BA5FE0294EA7A /* AXUIElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA6F823BC0EDA9AA4B80A /* AXUIElement.swift */; };
 		D04BAFF30A98CF287F85DA1E /* BlacklistsTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA27695D9A5824720BD7B /* BlacklistsTab.swift */; };
+		8FE6E0B378B54C90A8301AC8 /* TaskbarPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A44A0D0B42640C487BEFF42 /* TaskbarPanel.swift */; };
+		C367289274764620BDD2160F /* TaskbarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEB00512369846288CC6ECDC /* TaskbarView.swift */; };
+		95875A597E804AD2B13E4C6C /* TaskbarItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B064811A1FE942A088D128DB /* TaskbarItemView.swift */; };
+		B2A1643914FE42FDB3B92A27 /* TaskbarManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7131D5CD57B4D3099E6BCA3 /* TaskbarManager.swift */; };
+		A1B2C3D4E5F647A8B9C0D1E2 /* TaskbarPreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E2D3C4B5A6978889706152 /* TaskbarPreviewPanel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -366,6 +372,7 @@
 		5F21C9E12C6E94410091F72F /* AdditionalControlsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdditionalControlsSheet.swift; sourceTree = "<group>"; };
 		5F21C9E32C6E94700091F72F /* CustomizeStyleSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomizeStyleSheet.swift; sourceTree = "<group>"; };
 		5F21C9E52C6E94920091F72F /* AnimationsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationsSheet.swift; sourceTree = "<group>"; };
+		TASKBAR01SETTINGS01 /* TaskbarSettingsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskbarSettingsSheet.swift; sourceTree = "<group>"; };
 		5F21C9E72C6E96A00091F72F /* SheetWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SheetWindow.swift; sourceTree = "<group>"; };
 		5F2218A92F156BC6005769F9 /* logo-github-sponsors.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "logo-github-sponsors.png"; sourceTree = "<group>"; };
 		5F2218AA2F156BC6005769F9 /* logo-patreon.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = "logo-patreon.svg"; sourceTree = "<group>"; };
@@ -726,6 +733,11 @@
 		D04BAFA20F13FB588F6CCB81 /* bug_report.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = bug_report.md; sourceTree = "<group>"; };
 		D04BAFDA9E2623E21CBD6CEF /* zh-TW */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = "zh-TW"; path = InfoPlist.strings; sourceTree = "<group>"; };
 		E20104DD2C3DE10E7CCC5B5A /* Pods-unit-tests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-unit-tests.release.xcconfig"; path = "Target Support Files/Pods-unit-tests/Pods-unit-tests.release.xcconfig"; sourceTree = "<group>"; };
+		1A44A0D0B42640C487BEFF42 /* TaskbarPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskbarPanel.swift; sourceTree = "<group>"; };
+		EEB00512369846288CC6ECDC /* TaskbarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskbarView.swift; sourceTree = "<group>"; };
+		B064811A1FE942A088D128DB /* TaskbarItemView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskbarItemView.swift; sourceTree = "<group>"; };
+		C7131D5CD57B4D3099E6BCA3 /* TaskbarManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskbarManager.swift; sourceTree = "<group>"; };
+		F1E2D3C4B5A6978889706152 /* TaskbarPreviewPanel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TaskbarPreviewPanel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -838,6 +850,7 @@
 				D04BA64F1F344007EA13BA05 /* AppearanceTab.swift */,
 				5F21C9E32C6E94700091F72F /* CustomizeStyleSheet.swift */,
 				5F21C9E52C6E94920091F72F /* AnimationsSheet.swift */,
+				TASKBAR01SETTINGS01 /* TaskbarSettingsSheet.swift */,
 			);
 			path = appearance;
 			sourceTree = "<group>";
@@ -1354,7 +1367,7 @@
 				BF0C8D57C86AF492D43A576D /* AppearanceTestable.swift */,
 				BF0C8998862E0E04D60CACBC /* MacroPreferences.swift */,
 				BF0C8F58B38F29B2662E6C2D /* PreferencesMigrations.swift */,
-			);
+				C7131D5CD57B4D3099E6BCA3 /* TaskbarManager.swift */,);
 			path = logic;
 			sourceTree = "<group>";
 		};
@@ -1453,7 +1466,7 @@
 				D04BA48BC82D3060C3A1AB11 /* AppCenterApplication.m */,
 				BF0C8468DF35990A7731D86C /* MainMenu.swift */,
 				BF0C80F8FAA00FF3D9682F26 /* DebugMenu.swift */,
-			);
+				4F86565804E54D6CAE3AF104 /* taskbar */,);
 			path = ui;
 			sourceTree = "<group>";
 		};
@@ -1991,6 +2004,17 @@
 			path = docs;
 			sourceTree = "<group>";
 		};
+		4F86565804E54D6CAE3AF104 /* taskbar */ = {
+			isa = PBXGroup;
+			children = (
+				1A44A0D0B42640C487BEFF42 /* TaskbarPanel.swift */,
+				EEB00512369846288CC6ECDC /* TaskbarView.swift */,
+				B064811A1FE942A088D128DB /* TaskbarItemView.swift */,
+				F1E2D3C4B5A6978889706152 /* TaskbarPreviewPanel.swift */,
+			);
+			path = taskbar;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -2439,6 +2463,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8FE6E0B378B54C90A8301AC8 /* TaskbarPanel.swift in Sources */,
+				C367289274764620BDD2160F /* TaskbarView.swift in Sources */,
+				95875A597E804AD2B13E4C6C /* TaskbarItemView.swift in Sources */,
+				B2A1643914FE42FDB3B92A27 /* TaskbarManager.swift in Sources */,
+				A1B2C3D4E5F647A8B9C0D1E2 /* TaskbarPreviewPanel.swift in Sources */,
 				D04BAFBC862BA5FE0294EA7A /* AXUIElement.swift in Sources */,
 				D04BA73E90EFEF8247A5105D /* CGWindow.swift in Sources */,
 				D04BA004884A273D4D2D3EF1 /* HelperExtensions.swift in Sources */,
@@ -2490,6 +2519,7 @@
 				D04BA0AE9865276FF8EF5DEB /* UserDefaultsEvents.swift in Sources */,
 				D04BA4A11F821548EE3C5E95 /* Bash.swift in Sources */,
 				5F21C9E62C6E94920091F72F /* AnimationsSheet.swift in Sources */,
+				TASKBAR02SETTINGS02 /* TaskbarSettingsSheet.swift in Sources */,
 				D04BAFB90E00AA5D662EAF24 /* PermissionsWindow.swift in Sources */,
 				D04BA7E39FA539DD8316447A /* PermissionView.swift in Sources */,
 				D04BA446D702C5E252AF2319 /* TitleLabel.swift in Sources */,

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -88,6 +88,15 @@ class Preferences {
         "previewFocusedWindow": "false",
         "screenRecordingPermissionSkipped": "false",
         "trackpadHapticFeedbackEnabled": "true",
+        "taskbarEnabled": "true",
+        "taskbarHeight": "32",
+        "taskbarItemHeight": "26",
+        "taskbarIconSize": "18",
+        "taskbarFontSize": "11",
+        "taskbarSpacesToShow": SpacesToShowPreference.visible.indexAsString,
+        "taskbarShowMinimizedWindows": ShowHowPreference.show.indexAsString,
+        "taskbarShowHiddenWindows": ShowHowPreference.hide.indexAsString,
+        "taskbarShowFullscreenWindows": ShowHowPreference.show.indexAsString,
     ]
 
     // system preferences
@@ -125,6 +134,15 @@ class Preferences {
     static var blacklist: [BlacklistEntry] { CachedUserDefaults.json("blacklist", [BlacklistEntry].self) }
     static var previewSelectedWindow: Bool { CachedUserDefaults.bool("previewFocusedWindow") }
     static var screenRecordingPermissionSkipped: Bool { CachedUserDefaults.bool("screenRecordingPermissionSkipped") }
+    static var taskbarEnabled: Bool { CachedUserDefaults.bool("taskbarEnabled") }
+    static var taskbarHeight: CGFloat { CGFloat(CachedUserDefaults.int("taskbarHeight")) }
+    static var taskbarItemHeight: CGFloat { CGFloat(CachedUserDefaults.int("taskbarItemHeight")) }
+    static var taskbarIconSize: CGFloat { CGFloat(CachedUserDefaults.int("taskbarIconSize")) }
+    static var taskbarFontSize: CGFloat { CGFloat(CachedUserDefaults.int("taskbarFontSize")) }
+    static var taskbarSpacesToShow: SpacesToShowPreference { CachedUserDefaults.macroPref("taskbarSpacesToShow", SpacesToShowPreference.allCases) }
+    static var taskbarShowMinimizedWindows: ShowHowPreference { CachedUserDefaults.macroPref("taskbarShowMinimizedWindows", ShowHowPreference.allCases) }
+    static var taskbarShowHiddenWindows: ShowHowPreference { CachedUserDefaults.macroPref("taskbarShowHiddenWindows", ShowHowPreference.allCases) }
+    static var taskbarShowFullscreenWindows: ShowHowPreference { CachedUserDefaults.macroPref("taskbarShowFullscreenWindows", ShowHowPreference.allCases) }
 
     // macro values
     static var appearanceStyle: AppearanceStylePreference { CachedUserDefaults.macroPref("appearanceStyle", AppearanceStylePreference.allCases) }

--- a/src/logic/TaskbarManager.swift
+++ b/src/logic/TaskbarManager.swift
@@ -1,0 +1,181 @@
+import Cocoa
+
+class TaskbarManager {
+    static var shared = TaskbarManager()
+    var taskbarPanels = [ScreenUuid: TaskbarPanel]()
+    var isEnabled = false
+
+    func enable() {
+        guard !isEnabled else { return }
+        isEnabled = true
+        createPanelsForAllScreens()
+        updateContents()
+        // adjust any already-maximized windows to leave room for taskbar
+        adjustAllMaximizedWindows()
+    }
+
+    func disable() {
+        guard isEnabled else { return }
+        isEnabled = false
+        for (_, panel) in taskbarPanels {
+            panel.orderOut(nil)
+        }
+        taskbarPanels.removeAll()
+    }
+
+    private func createPanelsForAllScreens() {
+        for screen in NSScreen.screens {
+            if let uuid = screen.uuid(), taskbarPanels[uuid] == nil {
+                let panel = TaskbarPanel(screenUuid: uuid)
+                panel.positionAtScreenBottom(screen)
+                panel.orderFront(nil)
+                taskbarPanels[uuid] = panel
+            }
+        }
+    }
+
+    func repositionAll() {
+        guard isEnabled else { return }
+
+        let currentUuids = Set(NSScreen.screens.compactMap { $0.uuid() })
+        let existingUuids = Set(taskbarPanels.keys)
+
+        // remove panels for disconnected screens
+        for uuid in existingUuids.subtracting(currentUuids) {
+            taskbarPanels[uuid]?.orderOut(nil)
+            taskbarPanels.removeValue(forKey: uuid)
+        }
+
+        // add panels for new screens and reposition existing
+        for screen in NSScreen.screens {
+            if let uuid = screen.uuid() {
+                if let panel = taskbarPanels[uuid] {
+                    panel.positionAtScreenBottom(screen)
+                } else {
+                    let panel = TaskbarPanel(screenUuid: uuid)
+                    panel.positionAtScreenBottom(screen)
+                    panel.orderFront(nil)
+                    taskbarPanels[uuid] = panel
+                }
+            }
+        }
+
+        updateContents()
+    }
+
+    func updateContents() {
+        guard isEnabled else { return }
+        for (screenUuid, panel) in taskbarPanels {
+            let filteredWindows = filterWindowsForTaskbar(screenUuid: screenUuid)
+            panel.updateContents(filteredWindows)
+        }
+    }
+
+    private func filterWindowsForTaskbar(screenUuid: ScreenUuid) -> [Window] {
+        let screenSpaces = Spaces.screenSpacesMap[screenUuid] ?? []
+        let visibleSpacesForScreen = Spaces.visibleSpaces.filter { screenSpaces.contains($0) }
+
+        return Windows.list.filter { window in
+            // basic filter: should show to user and not a windowless app
+            guard !window.isWindowlessApp else { return false }
+
+            // filter by screen
+            guard window.screenId == screenUuid else { return false }
+
+            // filter by space
+            let spacesToShow = Preferences.taskbarSpacesToShow
+            if spacesToShow == .visible {
+                // only show windows on visible space for this screen
+                guard visibleSpacesForScreen.contains(where: { visibleSpace in window.spaceIds.contains { $0 == visibleSpace } }) else { return false }
+            }
+            // .all shows windows from all spaces
+
+            // filter minimized windows
+            if Preferences.taskbarShowMinimizedWindows == .hide && window.isMinimized {
+                return false
+            }
+
+            // filter hidden windows
+            if Preferences.taskbarShowHiddenWindows == .hide && window.isHidden {
+                return false
+            }
+
+            // filter fullscreen windows
+            if Preferences.taskbarShowFullscreenWindows == .hide && window.isFullscreen {
+                return false
+            }
+
+            return true
+        }
+    }
+
+    func updateAppearance() {
+        for (_, panel) in taskbarPanels {
+            panel.updateAppearance()
+        }
+    }
+
+    /// Adjusts all existing maximized windows to leave room for the taskbar
+    /// Called when taskbar is enabled or taskbar height changes
+    func adjustAllMaximizedWindows() {
+        guard isEnabled else { return }
+        for window in Windows.list {
+            adjustWindowIfMaximized(window)
+        }
+    }
+
+    /// Adjusts a window if it's maximized to leave room for the taskbar
+    /// Called when a window is resized or moved
+    func adjustWindowIfMaximized(_ window: Window) {
+        guard isEnabled else { return }
+        guard !window.isWindowlessApp else { return }
+        guard !window.isFullscreen else { return } // don't adjust actual fullscreen windows
+        guard let axUiElement = window.axUiElement else { return }
+        guard let position = window.position, let size = window.size else { return }
+        guard let screenId = window.screenId else { return }
+
+        // find the screen for this window
+        guard let screen = NSScreen.screens.first(where: { $0.uuid() == screenId }) else { return }
+
+        let visibleFrame = screen.visibleFrame
+        let taskbarHeight = Preferences.taskbarHeight
+
+        // convert screen coordinates (origin at bottom-left) to window coordinates (origin at top-left)
+        let screenTopLeftY = NSMaxY(NSScreen.screens[0].frame) - NSMaxY(visibleFrame)
+        let expectedWindowY = screenTopLeftY
+        let expectedWindowHeight = visibleFrame.height
+
+        // check if window fills the visible frame (is "maximized")
+        // allow small tolerance for rounding
+        let tolerance: CGFloat = 2
+        let isMaximizedWidth = abs(position.x - visibleFrame.minX) < tolerance && abs(size.width - visibleFrame.width) < tolerance
+        let isMaximizedHeight = abs(position.y - expectedWindowY) < tolerance && abs(size.height - expectedWindowHeight) < tolerance
+
+        // also check if window is already adjusted for taskbar (to avoid unnecessary operations)
+        let adjustedHeight = expectedWindowHeight - taskbarHeight
+        let isAlreadyAdjusted = abs(size.height - adjustedHeight) < tolerance
+
+        if isMaximizedWidth && isMaximizedHeight && !isAlreadyAdjusted {
+            // window is maximized - adjust to leave room for taskbar
+            let newHeight = expectedWindowHeight - taskbarHeight
+            let newY = expectedWindowY // keep top position the same
+
+            // only adjust if the new size is different
+            if abs(size.height - newHeight) > tolerance {
+                BackgroundWork.accessibilityCommandsQueue.addOperation {
+                    // set new size
+                    var newSize = CGSize(width: size.width, height: newHeight)
+                    if let sizeValue = AXValueCreate(.cgSize, &newSize) {
+                        try? axUiElement.setAttribute(kAXSizeAttribute, sizeValue)
+                    }
+
+                    // set position (in case it shifted)
+                    var newPosition = CGPoint(x: position.x, y: newY)
+                    if let posValue = AXValueCreate(.cgPoint, &newPosition) {
+                        try? axUiElement.setAttribute(kAXPositionAttribute, posValue)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/logic/events/AccessibilityEvents.swift
+++ b/src/logic/events/AccessibilityEvents.swift
@@ -128,6 +128,8 @@ class AccessibilityEvents {
 
     private static func windowResizedOrMoved(_ window: Window) {
         window.updateSpacesAndScreen()
+        // adjust window if it's maximized to leave room for taskbar
+        TaskbarManager.shared.adjustWindowIfMaximized(window)
         App.app.refreshOpenUi([window], .refreshUiAfterExternalEvent)
     }
 }

--- a/src/logic/events/ScreensEvents.swift
+++ b/src/logic/events/ScreensEvents.swift
@@ -16,6 +16,8 @@ class ScreensEvents {
             Screens.refresh()
             // a screen added or removed, or screen resolution change can mess up layout; we reset components
             App.app.resetPreferencesDependentComponents()
+            // reposition taskbars for screen changes
+            TaskbarManager.shared.repositionAll()
         }
     }
 }

--- a/src/logic/events/SpacesEvents.swift
+++ b/src/logic/events/SpacesEvents.swift
@@ -8,6 +8,8 @@ class SpacesEvents {
     @objc private static func handleEvent(_ notification: Notification) {
         ScreensEvents.debouncerScreenAndSpace.debounce(.spaceEvent) {
             Logger.debug { notification.name.rawValue }
+            // refresh space data so taskbar can filter by current space
+            Spaces.refresh()
             // Workaround for Safari full-screen videos
             // when full-screening a video, Safari spawns a second full-screen window called "Safari"
             // this window doesn't emit resize/move events. It doesn't pass isActualWindow on creation. It's added on focusedWindowChanged

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -201,6 +201,8 @@ class App: AppCenterApplication {
 
     func refreshOpenUi(_ windowsToScreenshot: [Window], _ source: RefreshCausedBy, windowRemoved: Bool = false) {
         Windows.refreshThumbnailsAsync(windowsToScreenshot, source, windowRemoved: windowRemoved)
+        // update taskbar regardless of Alt-Tab UI state
+        TaskbarManager.shared.updateContents()
         guard appIsBeingUsed else { return }
         if source == .refreshUiAfterExternalEvent {
             if !Windows.updatesBeforeShowing() { hideUi(); return }
@@ -319,6 +321,8 @@ extension App: NSApplicationDelegate {
         CursorEvents.observe()
         TrackpadEvents.observe()
         CliEvents.observe()
+        // enable taskbar
+        TaskbarManager.shared.enable()
         // login item and plist updates can be done a bit later, to accelerate launch
         DispatchQueue.main.asyncAfter(deadline: .now() + 2) { GeneralTab.startAtLoginCallback() }
         Logger.info { "Finished launching AltTab" }

--- a/src/ui/preferences-window/tabs/appearance/AppearanceTab.swift
+++ b/src/ui/preferences-window/tabs/appearance/AppearanceTab.swift
@@ -366,21 +366,26 @@ extension Popover: NSPopoverDelegate {
 class AppearanceTab: NSObject {
     static var customizeStyleButton: NSButton!
     static var animationsButton: NSButton!
+    static var taskbarSettingsButton: NSButton!
     static var customizeStyleSheet: CustomizeStyleSheet!
     static var animationsSheet: AnimationsSheet!
+    static var taskbarSettingsSheet: TaskbarSettingsSheet!
 
     static func initTab() -> NSView {
         customizeStyleButton = NSButton(title: getCustomizeStyleButtonTitle(), target: self, action: #selector(showCustomizeStyleSheet))
         animationsButton = NSButton(title: NSLocalizedString("Animations…", comment: ""), target: self, action: #selector(showAnimationsSheet))
+        taskbarSettingsButton = NSButton(title: NSLocalizedString("Taskbar settings…", comment: ""), target: self, action: #selector(showTaskbarSettingsSheet))
         customizeStyleSheet = CustomizeStyleSheet()
         animationsSheet = AnimationsSheet()
+        taskbarSettingsSheet = TaskbarSettingsSheet()
         return makeView()
     }
 
     private static func makeView() -> NSStackView {
         let appearanceView = makeAppearanceView()
         let multipleScreensView = makeMultipleScreensView()
-        let view = TableGroupSetView(originalViews: [appearanceView, multipleScreensView, animationsButton])
+        let taskbarView = makeTaskbarView()
+        let view = TableGroupSetView(originalViews: [appearanceView, multipleScreensView, taskbarView, animationsButton])
         view.translatesAutoresizingMaskIntoConstraints = false
         view.widthAnchor.constraint(equalToConstant: view.fittingSize.width).isActive = true
         return view
@@ -410,6 +415,21 @@ class AppearanceTab: NSObject {
         return table
     }
 
+    private static func makeTaskbarView() -> NSView {
+        let table = TableGroupView(title: NSLocalizedString("Taskbar", comment: ""), width: PreferencesWindow.width)
+        table.addRow(leftText: NSLocalizedString("Enable taskbar", comment: ""),
+            rightViews: LabelAndControl.makeSwitch("taskbarEnabled", extraAction: { _ in
+                if Preferences.taskbarEnabled {
+                    TaskbarManager.shared.enable()
+                } else {
+                    TaskbarManager.shared.disable()
+                }
+            }))
+        table.addRow(rightViews: taskbarSettingsButton)
+        table.fit()
+        return table
+    }
+
     private static func getCustomizeStyleButtonTitle() -> String {
         if Preferences.appearanceStyle == .thumbnails {
             return NSLocalizedString("Customize Thumbnails style…", comment: "")
@@ -435,5 +455,9 @@ class AppearanceTab: NSObject {
 
     @objc static func showAnimationsSheet() {
         App.app.preferencesWindow.beginSheet(animationsSheet)
+    }
+
+    @objc static func showTaskbarSettingsSheet() {
+        App.app.preferencesWindow.beginSheet(taskbarSettingsSheet)
     }
 }

--- a/src/ui/preferences-window/tabs/appearance/TaskbarSettingsSheet.swift
+++ b/src/ui/preferences-window/tabs/appearance/TaskbarSettingsSheet.swift
@@ -1,0 +1,76 @@
+import Cocoa
+
+class TaskbarSettingsSheet: SheetWindow {
+    override func makeContentView() -> NSView {
+        let table = TableGroupView(title: NSLocalizedString("Taskbar", comment: ""), width: SheetWindow.width)
+
+        // Size settings
+        let heightSlider = LabelAndControl.makeLabelWithSlider("", "taskbarHeight", 24, 64, 9, true, "px", width: 180, extraAction: { _ in
+            TaskbarManager.shared.repositionAll()
+            // re-adjust maximized windows when taskbar height changes
+            TaskbarManager.shared.adjustAllMaximizedWindows()
+        })
+        let heightIndicator = heightSlider[2] as! NSTextField
+        heightIndicator.alignment = .right
+        heightIndicator.fit(56, heightIndicator.fittingSize.height)
+        table.addRow(leftText: NSLocalizedString("Taskbar height", comment: ""),
+            rightViews: [heightSlider[1], heightIndicator])
+
+        let itemHeightSlider = LabelAndControl.makeLabelWithSlider("", "taskbarItemHeight", 18, 48, 7, true, "px", width: 180, extraAction: { _ in
+            TaskbarManager.shared.updateContents()
+        })
+        let itemHeightIndicator = itemHeightSlider[2] as! NSTextField
+        itemHeightIndicator.alignment = .right
+        itemHeightIndicator.fit(56, itemHeightIndicator.fittingSize.height)
+        table.addRow(leftText: NSLocalizedString("Item height", comment: ""),
+            rightViews: [itemHeightSlider[1], itemHeightIndicator])
+
+        let iconSizeSlider = LabelAndControl.makeLabelWithSlider("", "taskbarIconSize", 12, 32, 5, true, "px", width: 180, extraAction: { _ in
+            TaskbarManager.shared.updateContents()
+        })
+        let iconSizeIndicator = iconSizeSlider[2] as! NSTextField
+        iconSizeIndicator.alignment = .right
+        iconSizeIndicator.fit(56, iconSizeIndicator.fittingSize.height)
+        table.addRow(leftText: NSLocalizedString("Icon size", comment: ""),
+            rightViews: [iconSizeSlider[1], iconSizeIndicator])
+
+        let fontSizeSlider = LabelAndControl.makeLabelWithSlider("", "taskbarFontSize", 9, 16, 8, true, "pt", width: 180, extraAction: { _ in
+            TaskbarManager.shared.updateContents()
+        })
+        let fontSizeIndicator = fontSizeSlider[2] as! NSTextField
+        fontSizeIndicator.alignment = .right
+        fontSizeIndicator.fit(56, fontSizeIndicator.fittingSize.height)
+        table.addRow(leftText: NSLocalizedString("Font size", comment: ""),
+            rightViews: [fontSizeSlider[1], fontSizeIndicator])
+
+        // Filter settings
+        table.addNewTable()
+
+        let spacesToShow = LabelAndControl.makeDropdown("taskbarSpacesToShow", SpacesToShowPreference.allCases, extraAction: { _ in
+            TaskbarManager.shared.updateContents()
+        })
+        table.addRow(leftText: NSLocalizedString("Show windows from Spaces", comment: ""),
+            rightViews: [spacesToShow])
+
+        let showMinimizedWindows = LabelAndControl.makeDropdown("taskbarShowMinimizedWindows", ShowHowPreference.allCases.filter { $0 != .showAtTheEnd }, extraAction: { _ in
+            TaskbarManager.shared.updateContents()
+        })
+        table.addRow(leftText: NSLocalizedString("Show minimized windows", comment: ""),
+            rightViews: [showMinimizedWindows])
+
+        let showHiddenWindows = LabelAndControl.makeDropdown("taskbarShowHiddenWindows", ShowHowPreference.allCases.filter { $0 != .showAtTheEnd }, extraAction: { _ in
+            TaskbarManager.shared.updateContents()
+        })
+        table.addRow(leftText: NSLocalizedString("Show hidden windows", comment: ""),
+            rightViews: [showHiddenWindows])
+
+        let showFullscreenWindows = LabelAndControl.makeDropdown("taskbarShowFullscreenWindows", ShowHowPreference.allCases.filter { $0 != .showAtTheEnd }, extraAction: { _ in
+            TaskbarManager.shared.updateContents()
+        })
+        table.addRow(leftText: NSLocalizedString("Show fullscreen windows", comment: ""),
+            rightViews: [showFullscreenWindows])
+
+        table.fit()
+        return table
+    }
+}

--- a/src/ui/taskbar/TaskbarItemView.swift
+++ b/src/ui/taskbar/TaskbarItemView.swift
@@ -1,0 +1,158 @@
+import Cocoa
+
+class TaskbarItemView: NSView {
+    var window_: Window?
+    private var appIcon: NSImageView!
+    private var titleLabel: NSTextField!
+    private var trackingArea: NSTrackingArea?
+    private var isHovered = false
+    private var showPreviewTimer: Timer?
+    private var iconSize: CGFloat { Preferences.taskbarIconSize }
+    private let iconPadding: CGFloat = 6
+    private let titlePadding: CGFloat = 4
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("Class only supports programmatic initialization")
+    }
+
+    private func setupView() {
+        wantsLayer = true
+        layer!.cornerRadius = 4
+        layer!.masksToBounds = true
+
+        // app icon
+        appIcon = NSImageView()
+        appIcon.imageScaling = .scaleProportionallyUpOrDown
+        appIcon.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(appIcon)
+
+        // title label
+        titleLabel = NSTextField(labelWithString: "")
+        titleLabel.font = NSFont.systemFont(ofSize: Preferences.taskbarFontSize)
+        titleLabel.textColor = .labelColor
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(titleLabel)
+
+        updateBackgroundColor()
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea = trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+        trackingArea = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea!)
+    }
+
+    override var acceptsFirstResponder: Bool { true }
+
+    // Accept first mouse click even when window is not key
+    // This prevents needing to double-click to activate a window
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        return true
+    }
+
+    // Ensure tracking areas are set up when the view is added to window
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if window != nil {
+            updateTrackingAreas()
+        }
+    }
+
+    override func layout() {
+        super.layout()
+
+        let iconX = iconPadding
+        let iconY = (bounds.height - iconSize) / 2
+        appIcon.frame = NSRect(x: iconX, y: iconY, width: iconSize, height: iconSize)
+
+        let labelX = iconX + iconSize + titlePadding
+        let labelWidth = bounds.width - labelX - titlePadding
+        let labelHeight: CGFloat = 16
+        let labelY = (bounds.height - labelHeight) / 2
+        titleLabel.frame = NSRect(x: labelX, y: labelY, width: max(0, labelWidth), height: labelHeight)
+    }
+
+    func updateContent(_ window: Window) {
+        window_ = window
+
+        // update icon
+        if let icon = window.icon {
+            appIcon.image = NSImage(cgImage: icon, size: NSSize(width: iconSize, height: iconSize))
+        } else {
+            appIcon.image = nil
+        }
+
+        // update font size (in case preference changed)
+        titleLabel.font = NSFont.systemFont(ofSize: Preferences.taskbarFontSize)
+
+        // update title - show window title or app name
+        let title: String
+        if window.title.isEmpty {
+            title = window.application.localizedName ?? ""
+        } else {
+            title = window.title
+        }
+        titleLabel.stringValue = title
+        titleLabel.toolTip = title
+    }
+
+    func preferredWidth() -> CGFloat {
+        let titleWidth = titleLabel.attributedStringValue.size().width
+        return iconPadding + iconSize + titlePadding + titleWidth + titlePadding
+    }
+
+    private func updateBackgroundColor() {
+        if isHovered {
+            layer!.backgroundColor = NSColor.white.withAlphaComponent(0.25).cgColor
+            layer!.borderWidth = 1
+            layer!.borderColor = NSColor.white.withAlphaComponent(0.4).cgColor
+        } else {
+            layer!.backgroundColor = NSColor.clear.cgColor
+            layer!.borderWidth = 0
+            layer!.borderColor = nil
+        }
+    }
+
+    // MARK: - Mouse Events
+
+    override func mouseEntered(with event: NSEvent) {
+        isHovered = true
+        updateBackgroundColor()
+        // show thumbnail preview after a short delay
+        if let window = window_ {
+            showPreviewTimer?.invalidate()
+            showPreviewTimer = Timer.scheduledTimer(withTimeInterval: 0.3, repeats: false) { [weak self] _ in
+                guard let self, self.isHovered else { return }
+                TaskbarPreviewPanel.shared.show(for: window, relativeTo: self)
+            }
+        }
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isHovered = false
+        updateBackgroundColor()
+        // hide thumbnail preview
+        showPreviewTimer?.invalidate()
+        showPreviewTimer = nil
+        TaskbarPreviewPanel.shared.hide()
+    }
+
+    override func mouseUp(with event: NSEvent) {
+        guard bounds.contains(convert(event.locationInWindow, from: nil)) else { return }
+        window_?.focus()
+    }
+}

--- a/src/ui/taskbar/TaskbarPanel.swift
+++ b/src/ui/taskbar/TaskbarPanel.swift
@@ -1,0 +1,55 @@
+import Cocoa
+
+class TaskbarPanel: NSPanel {
+    var taskbarView: TaskbarView!
+    var screenUuid: ScreenUuid
+
+    init(screenUuid: ScreenUuid) {
+        self.screenUuid = screenUuid
+        super.init(contentRect: .zero, styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false)
+        isFloatingPanel = true
+        // Use dock window level (20) so taskbar stays above maximized windows
+        // This is the same level macOS Dock uses
+        level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.dockWindow)))
+        collectionBehavior = [.canJoinAllSpaces, .stationary]
+        hidesOnDeactivate = false
+        titleVisibility = .hidden
+        backgroundColor = .clear
+        animationBehavior = .none
+        // Accept mouse events even when not key window
+        acceptsMouseMovedEvents = true
+
+        taskbarView = TaskbarView()
+        contentView = taskbarView
+
+        // helps filter out this window from the thumbnails
+        setAccessibilitySubrole(.unknown)
+        setAccessibilityLabel("Taskbar")
+
+        updateAppearance()
+    }
+
+    func updateAppearance() {
+        hasShadow = true
+        appearance = NSAppearance(named: Appearance.currentTheme == .dark ? .vibrantDark : .vibrantLight)
+    }
+
+    func positionAtScreenBottom(_ screen: NSScreen) {
+        let screenFrame = screen.visibleFrame
+        let panelHeight = Preferences.taskbarHeight
+        let frame = NSRect(
+            x: screenFrame.minX,
+            y: screenFrame.minY,
+            width: screenFrame.width,
+            height: panelHeight
+        )
+        setFrame(frame, display: true)
+    }
+
+    func updateContents(_ windows: [Window]) {
+        taskbarView.updateItems(windows)
+    }
+
+    // Allow the panel to receive mouse events without becoming key
+    override var canBecomeKey: Bool { true }
+}

--- a/src/ui/taskbar/TaskbarPreviewPanel.swift
+++ b/src/ui/taskbar/TaskbarPreviewPanel.swift
@@ -1,0 +1,149 @@
+import Cocoa
+
+class TaskbarPreviewPanel: NSPanel {
+    static let shared = TaskbarPreviewPanel()
+
+    private let previewView = LightImageView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let containerView = NSVisualEffectView()
+    private var currentWindowId: CGWindowID?
+    private let maxPreviewWidth: CGFloat = 240
+    private let maxPreviewHeight: CGFloat = 160
+    private let padding: CGFloat = 8
+    private let titleHeight: CGFloat = 20
+
+    override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        frameRect
+    }
+
+    private init() {
+        super.init(contentRect: .zero, styleMask: [.nonactivatingPanel, .fullSizeContentView], backing: .buffered, defer: false)
+        isFloatingPanel = true
+        animationBehavior = .none
+        hidesOnDeactivate = false
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
+        backgroundColor = .clear
+        // same level as taskbar, but slightly above
+        level = NSWindow.Level(rawValue: Int(CGWindowLevelForKey(.dockWindow)) + 1)
+        collectionBehavior = .canJoinAllSpaces
+        setAccessibilitySubrole(.unknown)
+
+        setupContainerView()
+        setupPreviewView()
+        setupTitleLabel()
+    }
+
+    private func setupContainerView() {
+        if #available(macOS 10.14, *) {
+            containerView.material = .hudWindow
+        } else {
+            containerView.material = .dark
+        }
+        containerView.state = .active
+        containerView.wantsLayer = true
+        containerView.layer!.cornerRadius = 8
+        containerView.layer!.masksToBounds = true
+        contentView = containerView
+    }
+
+    private func setupPreviewView() {
+        previewView.wantsLayer = true
+        previewView.layer!.cornerRadius = 4
+        previewView.layer!.masksToBounds = true
+        containerView.addSubview(previewView)
+    }
+
+    private func setupTitleLabel() {
+        titleLabel.font = NSFont.systemFont(ofSize: 11)
+        titleLabel.textColor = .labelColor
+        titleLabel.alignment = .center
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.maximumNumberOfLines = 1
+        containerView.addSubview(titleLabel)
+    }
+
+    func show(for window: Window, relativeTo itemView: NSView) {
+        guard let cgWindowId = window.cgWindowId else { return }
+        guard let thumbnail = window.thumbnail else {
+            // no thumbnail available, try to capture one
+            hide()
+            return
+        }
+
+        currentWindowId = cgWindowId
+
+        // calculate preview size maintaining aspect ratio
+        guard let thumbnailSize = thumbnail.size() else {
+            hide()
+            return
+        }
+
+        let aspectRatio = thumbnailSize.width / thumbnailSize.height
+        var previewWidth = min(maxPreviewWidth, thumbnailSize.width)
+        var previewHeight = previewWidth / aspectRatio
+
+        if previewHeight > maxPreviewHeight {
+            previewHeight = maxPreviewHeight
+            previewWidth = previewHeight * aspectRatio
+        }
+
+        // update preview content
+        previewView.updateContents(thumbnail, NSSize(width: previewWidth, height: previewHeight))
+        previewView.frame = NSRect(x: padding, y: padding + titleHeight, width: previewWidth, height: previewHeight)
+
+        // update title
+        let windowTitle = window.title ?? ""
+        let title = windowTitle.isEmpty ? (window.application.localizedName ?? "") : windowTitle
+        titleLabel.stringValue = title
+        titleLabel.frame = NSRect(x: padding, y: padding, width: previewWidth, height: titleHeight - 4)
+
+        // calculate panel size and position
+        let panelWidth = previewWidth + padding * 2
+        let panelHeight = previewHeight + titleHeight + padding * 2
+
+        // position above the taskbar item
+        guard let itemWindow = itemView.window else { return }
+        let itemFrameInScreen = itemWindow.convertToScreen(itemView.convert(itemView.bounds, to: nil))
+
+        var panelX = itemFrameInScreen.midX - panelWidth / 2
+        let panelY = itemFrameInScreen.maxY + 8 // 8px gap above the taskbar
+
+        // ensure panel stays within screen bounds
+        if let screen = itemWindow.screen {
+            let screenFrame = screen.visibleFrame
+            if panelX < screenFrame.minX {
+                panelX = screenFrame.minX
+            } else if panelX + panelWidth > screenFrame.maxX {
+                panelX = screenFrame.maxX - panelWidth
+            }
+        }
+
+        let panelFrame = NSRect(x: panelX, y: panelY, width: panelWidth, height: panelHeight)
+        setFrame(panelFrame, display: true)
+
+        if !isVisible {
+            alphaValue = 0
+            orderFront(nil)
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.15
+                animator().alphaValue = 1
+            }
+        }
+    }
+
+    func hide() {
+        guard isVisible else { return }
+        currentWindowId = nil
+        NSAnimationContext.runAnimationGroup({ context in
+            context.duration = 0.1
+            animator().alphaValue = 0
+        }, completionHandler: {
+            self.orderOut(nil)
+        })
+    }
+
+    func isShowingWindow(_ windowId: CGWindowID?) -> Bool {
+        return isVisible && currentWindowId == windowId
+    }
+}

--- a/src/ui/taskbar/TaskbarView.swift
+++ b/src/ui/taskbar/TaskbarView.swift
@@ -1,0 +1,111 @@
+import Cocoa
+
+class TaskbarView: NSView {
+    private var effectView: NSVisualEffectView!
+    private var scrollView: NSScrollView!
+    private var documentView: NSView!
+    private var itemViews = [TaskbarItemView]()
+    private var itemHeight: CGFloat { Preferences.taskbarItemHeight }
+    private let itemSpacing: CGFloat = 4
+    private let horizontalPadding: CGFloat = 8
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("Class only supports programmatic initialization")
+    }
+
+    private func setupView() {
+        wantsLayer = true
+
+        // background blur effect
+        effectView = NSVisualEffectView()
+        effectView.blendingMode = .behindWindow
+        effectView.state = .active
+        if #available(macOS 10.14, *) {
+            effectView.material = .hudWindow
+        } else {
+            effectView.material = .dark
+        }
+        effectView.wantsLayer = true
+        addSubview(effectView)
+
+        // scroll view for horizontal scrolling
+        scrollView = NSScrollView()
+        scrollView.hasHorizontalScroller = true
+        scrollView.hasVerticalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.horizontalScrollElasticity = .allowed
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        addSubview(scrollView)
+
+        // document view holds the items
+        documentView = NSView()
+        documentView.wantsLayer = true
+        scrollView.documentView = documentView
+
+        // pre-allocate some item views
+        for _ in 0..<20 {
+            let itemView = TaskbarItemView()
+            itemView.isHidden = true
+            documentView.addSubview(itemView)
+            itemViews.append(itemView)
+        }
+    }
+
+    override func layout() {
+        super.layout()
+        effectView.frame = bounds
+        scrollView.frame = bounds
+    }
+
+    func updateItems(_ windows: [Window]) {
+        // ensure we have enough item views
+        while itemViews.count < windows.count {
+            let itemView = TaskbarItemView()
+            itemView.isHidden = true
+            documentView.addSubview(itemView)
+            itemViews.append(itemView)
+        }
+
+        // calculate item width
+        let maxItemWidth: CGFloat = 160
+        let minItemWidth: CGFloat = 48
+
+        var currentX = horizontalPadding
+        let itemY = (bounds.height - itemHeight) / 2
+
+        for (index, itemView) in itemViews.enumerated() {
+            if index < windows.count {
+                let window = windows[index]
+                itemView.updateContent(window)
+
+                // calculate width based on title
+                let titleWidth = itemView.preferredWidth()
+                let itemWidth = min(maxItemWidth, max(minItemWidth, titleWidth))
+
+                let newFrame = NSRect(x: currentX, y: itemY, width: itemWidth, height: itemHeight)
+                let frameChanged = itemView.frame != newFrame
+                itemView.frame = newFrame
+                itemView.isHidden = false
+
+                // ensure tracking areas are updated when frame changes or view becomes visible
+                if frameChanged {
+                    itemView.updateTrackingAreas()
+                }
+
+                currentX += itemWidth + itemSpacing
+            } else {
+                itemView.isHidden = true
+            }
+        }
+
+        // update document view size
+        let totalWidth = max(currentX + horizontalPadding - itemSpacing, bounds.width)
+        documentView.frame = NSRect(x: 0, y: 0, width: totalWidth, height: bounds.height)
+    }
+}


### PR DESCRIPTION
Add a persistent Windows-style taskbar at the bottom of the screen that displays all open windows with app icons and titles.
This is to partially resolve #529.
Features:
- Click to focus any window instantly
- Hover to preview window thumbnails (with 0.3s delay)
- Per-screen taskbar for multi-monitor setups
- Filter by current Space or show all windows
- Automatically adjusts maximized windows to leave room for taskbar
- Customizable settings: height, icon size, font size
- Show/hide minimized, hidden, and fullscreen windows

<img width="760" height="68" alt="image" src="https://github.com/user-attachments/assets/2b9ef196-9a85-48d8-b06b-ffd76fe99d8d" />

<img width="1080" height="928" alt="image" src="https://github.com/user-attachments/assets/9310bb53-2a65-4048-aaac-a4f5a5982c41" />

<img width="872" height="336" alt="image" src="https://github.com/user-attachments/assets/a5a91154-1f5a-424f-a143-9b14f2cfecaf" />

