### PR TITLE
feat: detect and filter invisible windows (zero-opacity ghost windows)

### DIFF
--- a/resources/l10n/en.lproj/Localizable.strings
+++ b/resources/l10n/en.lproj/Localizable.strings
@@ -191,6 +191,7 @@
 "Show apps with no open window" = "Show apps with no open window";
 "Show at the end" = "Show at the end";
 "Show fullscreen windows" = "Show fullscreen windows";
+"Show invisible windows" = "Show invisible windows";
 "Show hidden windows" = "Show hidden windows";
 "Show in switcher" = "Show in switcher";
 "Show minimized windows" = "Show minimized windows";
@@ -246,6 +247,9 @@
 "Visible Spaces" = "Visible Spaces";
 "When fullscreen" = "When fullscreen";
 "When no open window" = "When no open window";
+"When not visible on screen" = "When not visible on screen";
+"Window title contains" = "Window title contains";
+"Any" = "Any";
 "While open, press:" = "While open, press:";
 "Window app icon size:" = "Window app icon size:";
 "Window is fullscreen" = "Window is fullscreen";

--- a/resources/l10n/nb.lproj/Localizable.strings
+++ b/resources/l10n/nb.lproj/Localizable.strings
@@ -192,6 +192,7 @@
 "Show apps with no open window" = "Vis apper uten åpne vinduer";
 "Show at the end" = "Vis på slutten";
 "Show fullscreen windows" = "Vis fullskjermvinduer";
+"Show invisible windows" = "Vis usynlige vinduer";
 "Show hidden windows" = "Vis skjulte vinduer";
 "Show in switcher" = "Vis i switcher";
 "Show minimized windows" = "Vis minimerte vinduer";
@@ -250,6 +251,9 @@
 "Visible Spaces" = "Synlige områder";
 "When fullscreen" = "Når i fullskjerm";
 "When no open window" = "Når ingen åpne vinduer";
+"When not visible on screen" = "Når ikke synlig på skjermen";
+"Window title contains" = "Vindutittel inneholder";
+"Any" = "Alle";
 "While open, press:" = "Når åpen, trykk:";
 "Window app icon size:" = "Størrelse på vinduappikon:";
 "Window is fullscreen" = "Vinduet er i fullskjerm";

--- a/src/logic/MacroPreferences.swift
+++ b/src/logic/MacroPreferences.swift
@@ -519,12 +519,14 @@ enum BlacklistHidePreference: String/* required for jsonEncode */, CaseIterable,
     case none = "0"
     case always = "1"
     case whenNoOpenWindow = "2"
+    case whenNotOnScreen = "3"
 
     var localizedString: LocalizedString {
         switch self {
             case .none: return ""
             case .always: return NSLocalizedString("Always", comment: "")
             case .whenNoOpenWindow: return NSLocalizedString("When no open window", comment: "")
+            case .whenNotOnScreen: return NSLocalizedString("When not visible on screen", comment: "")
         }
     }
 }

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -40,6 +40,10 @@ class Preferences {
         "showWindowlessApps2": ShowHowPreference.showAtTheEnd.indexAsString,
         "showWindowlessApps3": ShowHowPreference.showAtTheEnd.indexAsString,
         "showWindowlessApps4": ShowHowPreference.showAtTheEnd.indexAsString,
+        "showTransparentWindows": ShowHowPreference.show.indexAsString,
+        "showTransparentWindows2": ShowHowPreference.show.indexAsString,
+        "showTransparentWindows3": ShowHowPreference.show.indexAsString,
+        "showTransparentWindows4": ShowHowPreference.show.indexAsString,
         "windowOrder": WindowOrderPreference.recentlyFocused.indexAsString,
         "windowOrder2": WindowOrderPreference.recentlyFocused.indexAsString,
         "windowOrder3": WindowOrderPreference.recentlyFocused.indexAsString,
@@ -146,6 +150,7 @@ class Preferences {
     static var showHiddenWindows: [ShowHowPreference] { ["showHiddenWindows", "showHiddenWindows2", "showHiddenWindows3", "showHiddenWindows4"].map { CachedUserDefaults.macroPref($0, ShowHowPreference.allCases) } }
     static var showFullscreenWindows: [ShowHowPreference] { ["showFullscreenWindows", "showFullscreenWindows2", "showFullscreenWindows3", "showFullscreenWindows4"].map { CachedUserDefaults.macroPref($0, ShowHowPreference.allCases) } }
     static var showWindowlessApps: [ShowHowPreference] { ["showWindowlessApps", "showWindowlessApps2", "showWindowlessApps3", "showWindowlessApps4"].map { CachedUserDefaults.macroPref($0, ShowHowPreference.allCases) } }
+    static var showTransparentWindows: [ShowHowPreference] { ["showTransparentWindows", "showTransparentWindows2", "showTransparentWindows3", "showTransparentWindows4"].map { CachedUserDefaults.macroPref($0, ShowHowPreference.allCases) } }
     static var windowOrder: [WindowOrderPreference] { ["windowOrder", "windowOrder2", "windowOrder3", "windowOrder4"].map { CachedUserDefaults.macroPref($0, WindowOrderPreference.allCases) } }
     static var shortcutStyle: [ShortcutStylePreference] { ["shortcutStyle", "shortcutStyle2", "shortcutStyle3", "shortcutStyle4"].map { CachedUserDefaults.macroPref($0, ShortcutStylePreference.allCases) } }
     static var menubarIcon: MenubarIconPreference { CachedUserDefaults.macroPref("menubarIcon", MenubarIconPreference.allCases) }
@@ -299,4 +304,5 @@ struct BlacklistEntry: Codable {
     var bundleIdentifier: String
     var hide: BlacklistHidePreference
     var ignore: BlacklistIgnorePreference
+    var windowTitle: String?
 }

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -24,6 +24,8 @@ class Window {
     var dockLabel: String? { get { application.dockLabel } }
     var isFullscreen = false
     var isMinimized = false
+    var isCurrentlyOnScreen = true
+    var isTransparent = false
     var isOnAllSpaces = false
     var isWindowlessApp: Bool { get { cgWindowId == nil } }
     var position: CGPoint?

--- a/src/ui/preferences-window/tabs/BlacklistsTab.swift
+++ b/src/ui/preferences-window/tabs/BlacklistsTab.swift
@@ -21,7 +21,7 @@ class BlacklistsTab {
                 tableView.removeSelectedRows()
             }
         }
-        let table = TableGroupView(width: PreferencesWindow.width)
+        let table = TableGroupView(width: 700)
         _ = table.addRow(leftViews: [blacklist], secondaryViews: [add])
         let view = TableGroupSetView(originalViews: [table])
         view.translatesAutoresizingMaskIntoConstraints = false

--- a/src/ui/preferences-window/tabs/controls/ControlsTab.swift
+++ b/src/ui/preferences-window/tabs/controls/ControlsTab.swift
@@ -107,6 +107,7 @@ class ControlsTab {
         let showHiddenWindows = LabelAndControl.makeDropdown(Preferences.indexToName("showHiddenWindows", index), ShowHowPreference.allCases)
         let showFullscreenWindows = LabelAndControl.makeDropdown(Preferences.indexToName("showFullscreenWindows", index), ShowHowPreference.allCases.filter { $0 != .showAtTheEnd }) // this filter is ok for serialization because the filtered value is last in the enum
         let showWindowlessApps = LabelAndControl.makeDropdown(Preferences.indexToName("showWindowlessApps", index), ShowHowPreference.allCases)
+        let showTransparentWindows = LabelAndControl.makeDropdown(Preferences.indexToName("showTransparentWindows", index), ShowHowPreference.allCases)
         let windowOrder = LabelAndControl.makeDropdown(Preferences.indexToName("windowOrder", index), WindowOrderPreference.allCases)
         let shortcutStyle = LabelAndControl.makeDropdown(Preferences.indexToName("shortcutStyle", index), ShortcutStylePreference.allCases)
         let table = TableGroupView(width: PreferencesWindow.width)
@@ -120,6 +121,7 @@ class ControlsTab {
         table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Show hidden windows", comment: ""), rightViews: [showHiddenWindows]))
         table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Show fullscreen windows", comment: ""), rightViews: [showFullscreenWindows]))
         table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Show apps with no open window", comment: ""), rightViews: [showWindowlessApps]))
+        table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Show invisible windows", comment: ""), rightViews: [showTransparentWindows]))
         table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Order windows by", comment: ""), rightViews: [windowOrder]))
         table.fit()
         return table


### PR DESCRIPTION
Some apps (e.g. Microsoft Outlook reminders) keep background windows with CGWindowAlpha=0 that appear in AltTab even though they are invisible to the user. This commit adds two complementary approaches to handle them:

## 1. Global preference: "Show invisible windows"
A new per-shortcut preference (Show / Hide / Show at the end) that filters windows with zero opacity across all apps — no configuration needed. Works just like the existing showMinimizedWindows, showHiddenWindows, and showFullscreenWindows preferences.

Files: Preferences.swift, ControlsTab.swift, Windows.swift (sort)

## 2. Enhanced blacklist: per-window title filtering The blacklist now supports an optional "Window title contains" column for case-insensitive substring matching, and a new hide option "When not visible on screen" that only hides matching windows when they are invisible (alpha=0). This allows precise control per app.

The existing "When no open window" option also hides transparent windows, since a zero-opacity window is effectively not visible.

Files: Preferences.swift (BlacklistEntry), MacroPreferences.swift,
       TableView.swift, BlacklistsTab.swift, Windows.swift

## Detection method
Uses CGWindowListCopyWindowInfo to check kCGWindowAlpha per window. Windows with alpha < 0.01 are marked as isTransparent=true and isCurrentlyOnScreen=false. This runs in updatesBeforeShowing() alongside existing space/tab detection.

Files: Window.swift (isTransparent, isCurrentlyOnScreen properties),
       Windows.swift (updateIsCurrentlyOnScreen method)

## Localization
English and Norwegian (nb) strings added for all new UI elements.

Default: "Show" (no behavior change for existing users).