### PR TITLE
feat(cli): expose screen, space, and app metadata in --detailed-list

### DIFF
--- a/src/logic/events/CliEvents.swift
+++ b/src/logic/events/CliEvents.swift
@@ -51,6 +51,11 @@ class CliServer {
             )
         }
         if rawValue == "--detailed-list" {
+            // refresh space/screen assignments so CLI returns fresh data
+            Spaces.refresh()
+            for window in Windows.list {
+                window.updateSpacesAndScreen()
+            }
             let windows = Windows.list
                 .filter { !$0.isWindowlessApp }
                 .map {


### PR DESCRIPTION
Closes #5319

---

## Summary

Enrich the `--detailed-list` CLI response with fields needed for programmatic window management:

**Per-window additions:**
- `screenId` — which physical monitor the window belongs to
- `appPid` — application process ID
- `dockLabel` — dock item label

**Top-level metadata (new fields alongside `windows`):**
- `screens` — array of screen UUIDs with Quartz-coordinate frames
- `currentSpaceIndex` — which space is currently active
- `visibleSpaceIndexes` — one active space per monitor
- `screenSpacesMap` — which spaces belong to which screen
- `frontmostAppPid` — currently focused application PID
- `mouseScreenId` — UUID of the screen the mouse cursor is currently on (uses existing `NSScreen.withMouse()` logic)
- `blacklist` — the user's configured blacklist entries (bundleId + hide/ignore settings)

## Motivation

External tools that cycle windows by monitor (e.g., skhd scripts) currently have to reverse-engineer screen membership from `position` coordinates + monitor bounds — which is unreliable across Spaces. Exposing `screenId` and the screen/space topology from a single `--detailed-list` call eliminates the need for separate helper binaries and position-based heuristics.

`mouseScreenId` enables tools to match AltTab's own "Screen including mouse" behavior — cycling windows on the hovered monitor rather than the focused window's monitor — without requiring external mouse-tracking utilities.

**My use case:** I use the mouse back/forward buttons (remapped to keyboard shortcuts via mouse software, picked up by skhd) to cycle through windows on the screen the mouse is hovering over. Each press advances to the next/previous window in creation order, wrapping around. A jq script filters `--detailed-list` by `mouseScreenId` to stay on one monitor. This needs `screenId`, `mouseScreenId`, and fresh space data to work reliably — without them, the cycle either targets the wrong screen or silently drops visible windows.

The latest commit also adds a `Spaces.refresh()` + per-window `updateSpacesAndScreen()` call before serializing `--detailed-list`, matching what the keyboard-triggered UI already does. Without this, the CLI could return stale `screenId` (null) and stale `visibleSpaceIndexes` for recently created or moved windows.

## Test plan

Code from this PR already works 100% on my 'dev' branch in my fork.

- [x] Build and run AltTab
- [x] Run `AltTab --detailed-list | jq .` and verify new fields are present
- [x] Verify `screenId` matches expected monitor for windows on different screens (5 screens detected, UUIDs map to distinct monitors)
- [x] Verify `visibleSpaceIndexes` updates when switching Spaces (currently reports [1,2,4,5,7] — one per monitor)
- [x] Verify `blacklist` reflects current AltTab preferences (13 entries including user-added wispr-flow)
- [x] Verify `mouseScreenId` returns the correct screen UUID when mouse is on different monitors
- [x] Verify `mouseScreenId` differs from focused window's `screenId` when mouse and focus are on different screens
- [x] Verify space/screen data is fresh after creating a new window (no stale null `screenId`)