### PR TITLE
feat: add additional Window Title - Application Name appearance option

### DIFF
--- a/resources/l10n/Localizable.strings
+++ b/resources/l10n/Localizable.strings
@@ -612,6 +612,9 @@
 "Window Title" = "Window Title";
 
 /* No comment provided by engineer. */
+"Window Title - Application Name" = "Window Title - Application Name";
+
+/* No comment provided by engineer. */
 "Window title contains" = "Window title contains";
 
 /* No comment provided by engineer. */

--- a/resources/l10n/ar.lproj/Localizable.strings
+++ b/resources/l10n/ar.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "أصغر عرض للنافذة بالأعمدة:";
 "Window order:" = "ترتيب النوافذ:";
 "Window Title" = "عنوان النافذة";
+"Window Title - Application Name" = "عنوان النافذة - اسم التطبيق";
 "Window title font size:" = "حجم خط عنوان النافذة:";
 "Window title truncation:" = "اقتطاع عنوان النافذة:";
 "Windows" = "نوافذ";

--- a/resources/l10n/be.lproj/Localizable.strings
+++ b/resources/l10n/be.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "Мін. шырыня акна ў радку:";
 "Window order:" = "Парадак вокнаў:";
 "Window Title" = "Загаловак акна";
+"Window Title - Application Name" = "Загаловак акна — Назва праграмы";
 "Window title font size:" = "Памер шрыфту загалоўка вокна:";
 "Window title truncation:" = "Абрэзка загалоўка акна:";
 "Windows" = "Вокны";

--- a/resources/l10n/bg.lproj/Localizable.strings
+++ b/resources/l10n/bg.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "Минимална част от реда за един прозорец:";
 "Window order:" = "Подредба на прозорци:";
 "Window Title" = "Заглавие на прозореца";
+"Window Title - Application Name" = "заглавие на прозореца - Име на приложението";
 "Window title font size:" = "Размер на шрифта на заглавието:";
 "Window title truncation:" = "Съкрати заглавието на прозореца";
 "Windows" = "Windows";

--- a/resources/l10n/bn.lproj/Localizable.strings
+++ b/resources/l10n/bn.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "সারিতে উইন্ডোর মিনিমাম প্রস্থ:";
 "Window order:" = "উইন্ডোর ক্রম:";
 "Window Title" = "উইন্ডো শিরোনাম";
+"Window Title - Application Name" = "উইন্ডো শিরোনাম - আবেদনের নাম";
 "Window title font size:" = "উইন্ডো শিরোনামের ফন্ট সাইজ:";
 "Window title truncation:" = "উইন্ডো শিরোনাম ছেদন:";
 "Windows" = "উইন্ডোজ";

--- a/resources/l10n/ca.lproj/Localizable.strings
+++ b/resources/l10n/ca.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "Amplada mínima de finestra dins d'una fila:";
 "Window order:" = "Mostrar en ordre:";
 "Window Title" = "Títol de la finestra";
+"Window Title - Application Name" = "Títol de la finestra - Nom de l'aplicació";
 "Window title font size:" = "Mida dels títols:";
 "Window title truncation:" = "Escurçament dels títols:";
 "Windows" = "Finestres";

--- a/resources/l10n/cs.lproj/Localizable.strings
+++ b/resources/l10n/cs.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "Minimální šířka okna v řádku:";
 "Window order:" = "Pořadí oken:";
 "Window Title" = "Název okna";
+"Window Title - Application Name" = "název okna - Název aplikace";
 "Window title font size:" = "Velikost písma v titulku okna:";
 "Window title truncation:" = "Zkrácení názvu okna:";
 "Windows" = "Okna";

--- a/resources/l10n/da.lproj/Localizable.strings
+++ b/resources/l10n/da.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "Vindue min. bredde i række:";
 "Window order:" = "Vindue rækkefølge:";
 "Window Title" = "Vinduetitel";
+"Window Title - Application Name" = "Vinduetitel - Applikationsnavn";
 "Window title font size:" = "Vindue titel skriftstørrelse:";
 "Window title truncation:" = "Afkortning af vinduestitel:";
 "Windows" = "Windows";

--- a/resources/l10n/de.lproj/Localizable.strings
+++ b/resources/l10n/de.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "Minimale Fensterbreite in Zeile:";
 "Window order:" = "Reihenfolge der Fenster:";
 "Window Title" = "Fenstertitel";
+"Window Title - Application Name" = "Fenstertitel - Anwendungsname";
 "Window title font size:" = "Schriftgröße des Fenstertitels:";
 "Window title truncation:" = "Fenstertitel kürzen:";
 "Windows" = "Fenster";

--- a/resources/l10n/el.lproj/Localizable.strings
+++ b/resources/l10n/el.lproj/Localizable.strings
@@ -260,6 +260,7 @@
 "Window min width in row:" = "Ελάχιστο πλάτος παραθύρου στη σειρά:";
 "Window order:" = "Σειρά παραθύρων:";
 "Window Title" = "Τίτλος παραθύρου";
+"Window Title - Application Name" = "Τίτλος παραθύρου - Όνομα εφαρμογής";
 "Window title font size:" = "Μέγεθος γραμματοσειράς τίτλου παραθύρου:";
 "Window title truncation:" = "Περικοπή τίτλου παραθύρου:";
 "Windows" = "Παράθυρα";

--- a/resources/l10n/en.lproj/Localizable.strings
+++ b/resources/l10n/en.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "Window min width in row:";
 "Window order:" = "Window order:";
 "Window Title" = "Window Title";
+"Window Title - Application Name" = "Window Title - Application Name";
 "Window title font size:" = "Window title font size:";
 "Window title truncation:" = "Window title truncation:";
 "Windows" = "Windows";

--- a/resources/l10n/es.lproj/Localizable.strings
+++ b/resources/l10n/es.lproj/Localizable.strings
@@ -260,6 +260,7 @@
 "Window min width in row:" = "Ancho mínimo de ventana en fila";
 "Window order:" = "Orden de la ventana:";
 "Window Title" = "Título de ventana";
+"Window Title - Application Name" = "Título de la ventana - Nombre de la aplicación";
 "Window title font size:" = "Tamaño de fuente del título de la ventana:";
 "Window title truncation:" = "Truncado de título de ventana:";
 "Windows" = "Windows";

--- a/resources/l10n/et.lproj/Localizable.strings
+++ b/resources/l10n/et.lproj/Localizable.strings
@@ -246,6 +246,7 @@
 "Window min width in row:" = "Akna minimaalne laius reas:";
 "Window order:" = "Akende järjestus:";
 "Window Title" = "Akna pealkiri";
+"Window Title - Application Name" = "akna pealkiri - Rakenduse nimi";
 "Window title font size:" = "Akna pealkirja fondi suurus:";
 "Window title truncation:" = "Akna pealkirja kärpimine:";
 "Windows" = "Aknad";

--- a/resources/l10n/fa.lproj/Localizable.strings
+++ b/resources/l10n/fa.lproj/Localizable.strings
@@ -174,6 +174,7 @@
 "Window is on every Space" = "پنجره در هر فضایی است";
 "Window is on Space %d" = "پنجره در فضا ٪ D است";
 "Window Title" = "عنوان پنجره";
+"Window Title - Application Name" = "عنوان پنجره - نام برنامه";
 "Windows" = "پنجره ها";
 "You can’t undo this action." = "شما نمی توانید این عمل را خنثیسازی کنید.";
 "You didn’t write your email, thus can’t receive any response." = "شما ایمیل خود را ننوشتید ، بنابراین نمی توانید پاسخی دریافت کنید.";

--- a/resources/l10n/fi.lproj/Localizable.strings
+++ b/resources/l10n/fi.lproj/Localizable.strings
@@ -244,6 +244,7 @@
 "Window min width in row:" = "Ikkunan minimileveys rivillä:";
 "Window order:" = "Ikkunoiden järjestys:";
 "Window Title" = "Ikkunan otsikko";
+"Window Title - Application Name" = "ikkunan otsikko - Apin nimi";
 "Window title font size:" = "Otsikkotekstin koko:";
 "Window title truncation:" = "Ikkunaotsikoiden lyhennys:";
 "Windows" = "Ikkunat";

--- a/resources/l10n/fr.lproj/Localizable.strings
+++ b/resources/l10n/fr.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "Largeur minimum des aperçus :";
 "Window order:" = "Affichage des fenêtres par ordre :";
 "Window Title" = "Titre de fenêtre";
+"Window Title - Application Name" = "Titre de la fenêtre - Nom de l'application";
 "Window title font size:" = "Taille du titre des fenêtres :";
 "Window title truncation:" = "Troncature du titre des fenêtres :";
 "Windows" = "les fenêtres";

--- a/resources/l10n/ga.lproj/Localizable.strings
+++ b/resources/l10n/ga.lproj/Localizable.strings
@@ -260,6 +260,7 @@
 "Window min width in row:" = "Leithead min fuinneoige i ndiaidh a chéile:";
 "Window order:" = "Ordú fuinneoige:";
 "Window Title" = "Teideal Fuinneog";
+"Window Title - Application Name" = "Teideal Fuinneog - Ainm Feidhmchláir";
 "Window title font size:" = "Méid cló teideal na fuinneoige:";
 "Window title truncation:" = "Teascadh teideal fuinneoige:";
 "Windows" = "Fuinneoga";

--- a/resources/l10n/gl.lproj/Localizable.strings
+++ b/resources/l10n/gl.lproj/Localizable.strings
@@ -210,6 +210,7 @@
 "Window max width in row:" = "Ancho maximo de ventá en fila";
 "Window min width in row:" = "Ancho mínimo de ventá en fila";
 "Window Title" = "Título da xanela";
+"Window Title - Application Name" = "Título da xanela - Nome da aplicación";
 "Window title font size:" = "Tamaño de fonte do título da ventá:";
 "Window title truncation:" = "Truncado de título de ventá:";
 "Windows" = "Windows";

--- a/resources/l10n/he.lproj/Localizable.strings
+++ b/resources/l10n/he.lproj/Localizable.strings
@@ -218,6 +218,7 @@
 "Window min width in row:" = "רוחב מינימלי של חלון בטור:";
 "Window order:" = "סדר חלונות:";
 "Window Title" = "כותרת חלון";
+"Window Title - Application Name" = "כותרת חלון - שם יישום";
 "Window title font size:" = "גודל כותרת חלון:";
 "Window title truncation:" = "כותרת חלון מקוצרת:";
 "Windows" = "חלונות";

--- a/resources/l10n/hi.lproj/Localizable.strings
+++ b/resources/l10n/hi.lproj/Localizable.strings
@@ -231,6 +231,7 @@
 "Window min width in row:" = "पंक्ति में खिड़की की न्यूनतम चौड़ाई:";
 "Window order:" = "विंडो और्डर";
 "Window Title" = "खिड़की का शीर्षक";
+"Window Title - Application Name" = "विंडो शीर्षक - आवेदन का नाम";
 "Window title font size:" = "खिड़की शीर्षक फ़ॉन्ट आकार:";
 "Window title truncation:" = "खिड़की शीर्षक काट-छाँट:";
 "Windows" = "खिड़कियाँ";

--- a/resources/l10n/hr.lproj/Localizable.strings
+++ b/resources/l10n/hr.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "Minimalna širina prozora u redu:";
 "Window order:" = "Redoslijed prozora:";
 "Window Title" = "Prozor";
+"Window Title - Application Name" = "Naslov prozora - Naziv aplikacije";
 "Window title font size:" = "Veličina fonta naslova prozora:";
 "Window title truncation:" = "Skraćivanje naslova prozora:";
 "Windows" = "Prozori";

--- a/resources/l10n/hu.lproj/Localizable.strings
+++ b/resources/l10n/hu.lproj/Localizable.strings
@@ -219,6 +219,7 @@
 "Window min width in row:" = "Ablak minimum szélessége a sorban:";
 "Window order:" = "Ablakok sorrendje:";
 "Window Title" = "Ablak címe";
+"Window Title - Application Name" = "Ablak címe - Alkalmazás neve";
 "Window title font size:" = "Ablak címének betű mérete:";
 "Window title truncation:" = "Ablak címsor rövidítése:";
 "Windows" = "Ablakok";

--- a/resources/l10n/id.lproj/Localizable.strings
+++ b/resources/l10n/id.lproj/Localizable.strings
@@ -212,6 +212,7 @@
 "Window max width in row:" = "Lebar maks jendela dalam baris:";
 "Window min width in row:" = "Lebar minimal jendela dalam baris:";
 "Window Title" = "Judul jendela";
+"Window Title - Application Name" = "Judul Jendela - Nama Aplikasi";
 "Window title font size:" = "Ukuran font judul jendela:";
 "Window title truncation:" = "Pemotongan judul jendela:";
 "Windows" = "Windows";

--- a/resources/l10n/is.lproj/Localizable.strings
+++ b/resources/l10n/is.lproj/Localizable.strings
@@ -191,6 +191,7 @@
 "Window is on Space %d" = "Gluggi er á Space %D";
 "Window order:" = "Gluggaröð:";
 "Window Title" = "Gluggatitill";
+"Window Title - Application Name" = "gluggatitill - Nafn umsóknar";
 "Windows" = "Gluggar";
 "You can’t undo this action." = "Þú getur ekki afturkallað þessa aðgerð.";
 "You didn’t write your email, thus can’t receive any response." = "Þú gafst ekki upp netfang, því færðu ekki svar.";

--- a/resources/l10n/it.lproj/Localizable.strings
+++ b/resources/l10n/it.lproj/Localizable.strings
@@ -236,6 +236,7 @@
 "Window min width in row:" = "Larghezza minima finestra in riga:";
 "Window order:" = "Ordine delle finestre:";
 "Window Title" = "Titolo della finestra";
+"Window Title - Application Name" = "Titolo della finestra - Nome dell'applicazione";
 "Window title font size:" = "Dimensioni del titolo della finestra:";
 "Window title truncation:" = "Troncamento titolo:";
 "Windows" = "finestre";

--- a/resources/l10n/ja.lproj/Localizable.strings
+++ b/resources/l10n/ja.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "列に表示される最小ウィンドウ幅：";
 "Window order:" = "ウインドウの並び：";
 "Window Title" = "ウィンドウタイトル";
+"Window Title - Application Name" = "ウィンドウタイトル - アプリケーション名";
 "Window title font size:" = "ウィンドウに表示されるタイトルフォントサイズ：";
 "Window title truncation:" = "ウィンドウタイトル短縮：";
 "Windows" = "ウィンドウ";

--- a/resources/l10n/kn.lproj/Localizable.strings
+++ b/resources/l10n/kn.lproj/Localizable.strings
@@ -246,6 +246,7 @@
 "Window min width in row:" = "ಸಾಲಿನಲ್ಲಿ ವಿಂಡೋದ ಕನಿಷ್ಠ ಅಗಲ:";
 "Window order:" = "ವಿಂಡೋ ಕ್ರಮಾಂಕ";
 "Window Title" = "Window Title";
+"Window Title - Application Name" = "ವಿಂಡೋ ಶೀರ್ಷಿಕೆ - ಅಪ್ಲಿಕೇಶನ್ ಹೆಸರು";
 "Window title font size:" = "ವಿಂಡೋ ಶೀರ್ಷಿಕೆ ಅಕ್ಷರ ಗಾತ್ರ:";
 "Window title truncation:" = "ವಿಂಡೋ ಶೀರ್ಷಿಕೆ ಮೊಟಕುಗೊಳಿಸುವಿಕೆ:";
 "Windows" = "ವಿಂಡೋ ಗಳು";

--- a/resources/l10n/ko.lproj/Localizable.strings
+++ b/resources/l10n/ko.lproj/Localizable.strings
@@ -260,6 +260,7 @@
 "Window min width in row:" = "한 줄 내의 윈도우 최소 너비:";
 "Window order:" = "윈도우 정렬:";
 "Window Title" = "윈도우 제목";
+"Window Title - Application Name" = "윈도우 제목 - 앱 이름";
 "Window title font size:" = "윈도우 제목 서체 크기:";
 "Window title truncation:" = "윈도우 제목 생략 위치:";
 "Windows" = "윈도우";

--- a/resources/l10n/ku.lproj/Localizable.strings
+++ b/resources/l10n/ku.lproj/Localizable.strings
@@ -193,6 +193,7 @@
 "Window is on every Space" = "Pencere li her deverê ye";
 "Window is on Space %d" = "Pencere li ser cîhê% d e";
 "Window Title" = "Sernavê Windowê";
+"Window Title - Application Name" = "Sernavê Windowê - Navê Serlêdanê";
 "Window title font size:" = "Mezinahîya fontên sernav ên paceya";
 "Window title truncation:" = "Birîna sernavê pacê:";
 "Windows" = "Windows";

--- a/resources/l10n/lb.lproj/Localizable.strings
+++ b/resources/l10n/lb.lproj/Localizable.strings
@@ -178,6 +178,7 @@
 "Window is on every Space" = "Fënster ass op all Raum";
 "Window is on Space %d" = "Fënster ass op Raums% D";
 "Window Title" = "Fënster Testbetter";
+"Window Title - Application Name" = "Fenster Titel - Applikatioun Numm";
 "Windows" = "FënsterSenferenzen";
 "You can’t undo this action." = "Dir kënnt dës Aktioun net ofhalen.";
 "You didn’t write your email, thus can’t receive any response." = "Dir hutt Är E-Mail net geschriwwen, also kann also keng Äntwert kréien.";

--- a/resources/l10n/ml.lproj/Localizable.strings
+++ b/resources/l10n/ml.lproj/Localizable.strings
@@ -173,6 +173,7 @@
 "Window is on every Space" = "Window is on every Space";
 "Window is on Space %d" = "Window is on Space %d";
 "Window Title" = "Window Title";
+"Window Title - Application Name" = "Window Title - Application Name";
 "Windows" = "Windows";
 "You can’t undo this action." = "You can’t undo this action.";
 "You didn’t write your email, thus can’t receive any response." = "You didn’t write your email, thus can’t receive any response.";

--- a/resources/l10n/my.lproj/Localizable.strings
+++ b/resources/l10n/my.lproj/Localizable.strings
@@ -205,6 +205,7 @@
 "Visibility" = "မြင်သာမှု";
 "Window app icon size:" = "Window အက်ပ်အိုင်ကွန် အရွယ်အစား-";
 "Window Title" = "ဝင်းဒိုး ခေါင်းစဉ်";
+"Window Title - Application Name" = "ဝင်းဒိုး ခေါင်းစဉ် - အပလီကေးရှင်း အမည်";
 "Window title font size:" = "Window ခေါင်းစဉ် စာလုံးအရွယ်အစား-";
 "Window title truncation:" = "ဝင်းဒိုးခေါင်းစဉ် ဖြတ်တောက်ခြင်း-";
 "Windows" = "ဝင်းဒိုးစ်";

--- a/resources/l10n/nb.lproj/Localizable.strings
+++ b/resources/l10n/nb.lproj/Localizable.strings
@@ -260,6 +260,7 @@
 "Window min width in row:" = "Minimum vindusbredde på rad:";
 "Window order:" = "Vindusrekkefølge:";
 "Window Title" = "Vindustittel";
+"Window Title - Application Name" = "Vindustittel - Applikasjonsnavn";
 "Window title font size:" = "Skriftstørrelse på vindutittel:";
 "Window title truncation:" = "Forkortelse av vindustittel:";
 "Windows" = "Vinduer";

--- a/resources/l10n/nl.lproj/Localizable.strings
+++ b/resources/l10n/nl.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "Minimale vensterbreedte in rij:";
 "Window order:" = "Scherm volgorde:";
 "Window Title" = "Raamtitel";
+"Window Title - Application Name" = "Window -titel - Applicatienaam";
 "Window title font size:" = "Tekstgrootte venstertitel:";
 "Window title truncation:" = "Afkappen venstertitel:";
 "Windows" = "ramen";

--- a/resources/l10n/nn.lproj/Localizable.strings
+++ b/resources/l10n/nn.lproj/Localizable.strings
@@ -219,6 +219,7 @@
 "Window min width in row:" = "Minimum vindaugsbreidde på rad:";
 "Window order:" = "Vindaugsrekkjefylgje:";
 "Window Title" = "Window Title";
+"Window Title - Application Name" = "Window Title - Application Name";
 "Window title font size:" = "Skriftstorleik på vindaugstittel:";
 "Window title truncation:" = "Avstytting av vindaugstittel:";
 "Windows" = "Windows";

--- a/resources/l10n/pl.lproj/Localizable.strings
+++ b/resources/l10n/pl.lproj/Localizable.strings
@@ -260,6 +260,7 @@
 "Window min width in row:" = "Minimalna szerokość okna w rzędzie:";
 "Window order:" = "Porządek okien:";
 "Window Title" = "Tytuł okna";
+"Window Title - Application Name" = "tytuł okna - Nazwa aplikacji";
 "Window title font size:" = "Rozmiar czcionki tytułu okna:";
 "Window title truncation:" = "Obcięcie tytułu okna:";
 "Windows" = "Okna";

--- a/resources/l10n/pt-BR.lproj/Localizable.strings
+++ b/resources/l10n/pt-BR.lproj/Localizable.strings
@@ -260,6 +260,7 @@
 "Window min width in row:" = "Largura mínima da janela na linha:";
 "Window order:" = "Ordem das janelas:";
 "Window Title" = "Título da janela";
+"Window Title - Application Name" = "Título da janela - Nome do aplicativo";
 "Window title font size:" = "Tamanho da fonte do título da aplicação:";
 "Window title truncation:" = "Truncar título da janela:";
 "Windows" = "Janelas";

--- a/resources/l10n/pt.lproj/Localizable.strings
+++ b/resources/l10n/pt.lproj/Localizable.strings
@@ -260,6 +260,7 @@
 "Window min width in row:" = "Largura mínima da janela na linha:";
 "Window order:" = "Ordem das janelas:";
 "Window Title" = "Título da janela";
+"Window Title - Application Name" = "Título da janela - Nome da aplicação";
 "Window title font size:" = "Tamanho da fonte do título da aplicação:";
 "Window title truncation:" = "Truncamento do título da janela:";
 "Windows" = "Janelas";

--- a/resources/l10n/ro.lproj/Localizable.strings
+++ b/resources/l10n/ro.lproj/Localizable.strings
@@ -244,6 +244,7 @@
 "Window min width in row:" = "Lățime minimă a ferestrei pe rând:";
 "Window order:" = "Ordonare ferestre:";
 "Window Title" = "Titlu fereastră";
+"Window Title - Application Name" = "titlul ferestrei - Numele aplicației";
 "Window title font size:" = "Dimensiunea fontului titlului ferestrei:";
 "Window title truncation:" = "Trunchierea titlului din fereastră:";
 "Windows" = "Ferestre";

--- a/resources/l10n/ru.lproj/Localizable.strings
+++ b/resources/l10n/ru.lproj/Localizable.strings
@@ -260,6 +260,7 @@
 "Window min width in row:" = "Минимальная ширина эскиза в ряду:";
 "Window order:" = "Порядок окон:";
 "Window Title" = "Заголовок окна";
+"Window Title - Application Name" = "заголовок окна - Имя приложения";
 "Window title font size:" = "Размер заголовка:";
 "Window title truncation:" = "Обрезка заголовка окна:";
 "Windows" = "Окна";

--- a/resources/l10n/sk.lproj/Localizable.strings
+++ b/resources/l10n/sk.lproj/Localizable.strings
@@ -209,6 +209,7 @@
 "Window max width in row:" = "Maximálna šírka okna v rade:";
 "Window min width in row:" = "Minimálna šírka okna v rade:";
 "Window Title" = "Názov okna";
+"Window Title - Application Name" = "Názov okna - Názov aplikácie";
 "Window title font size:" = "Veľkosť písma názvu okna:";
 "Window title truncation:" = "Skrátenie názvu okna:";
 "Windows" = "Okná";

--- a/resources/l10n/sl.lproj/Localizable.strings
+++ b/resources/l10n/sl.lproj/Localizable.strings
@@ -181,6 +181,7 @@
 "Window is on every Space" = "Okno je na vsakem prostoru";
 "Window is on Space %d" = "Okno je na prostoru %d";
 "Window Title" = "Naslov okna";
+"Window Title - Application Name" = "naslov okna - Ime aplikacije";
 "Window title font size:" = "Velikost črk v nazivu okna:";
 "Windows" = "Okna";
 "You can’t undo this action." = "Tega dejanja ne morete razveljaviti.";

--- a/resources/l10n/sq.lproj/Localizable.strings
+++ b/resources/l10n/sq.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "Gjerësia minimale e dritares në rresht";
 "Window order:" = "Renditja e dritareve:";
 "Window Title" = "Titull dritaresh";
+"Window Title - Application Name" = "Titulli i dritares - Emri i Aplikimit";
 "Window title font size:" = "Madhësia e fontit të titullit të dritares:";
 "Window title truncation:" = "Titulli i kthesës së dritares:";
 "Windows" = "Dritare";

--- a/resources/l10n/sr.lproj/Localizable.strings
+++ b/resources/l10n/sr.lproj/Localizable.strings
@@ -212,6 +212,7 @@
 "Window max width in row:" = "Maksimalna širina prozora u redu:";
 "Window min width in row:" = "Minimalna širina prozora u redu:";
 "Window Title" = "Назив прозора";
+"Window Title - Application Name" = "Назив прозора - Назив апликације";
 "Window title font size:" = "Veličina naslova u prozoru:";
 "Window title truncation:" = "Odsecanje naslova prozora:";
 "Windows" = "Прозори";

--- a/resources/l10n/sv.lproj/Localizable.strings
+++ b/resources/l10n/sv.lproj/Localizable.strings
@@ -219,6 +219,7 @@
 "Window min width in row:" = "Maxbredd för fönster i rad:";
 "Window order:" = "Sortera fönster:";
 "Window Title" = "Fönstertitel";
+"Window Title - Application Name" = "fönstertitel - Applikationsnamn";
 "Window title font size:" = "Storlek för fönstertitel:";
 "Window title truncation:" = "Förkortning av fönstertitel:";
 "Windows" = "Fönster";

--- a/resources/l10n/ta.lproj/Localizable.strings
+++ b/resources/l10n/ta.lproj/Localizable.strings
@@ -192,6 +192,7 @@
 "Window is on every Space" = "சாளரம் ஒவ்வொரு இடத்திலும் உள்ளது";
 "Window is on Space %d" = "சாளரம் விண்வெளி %d இல் உள்ளது";
 "Window Title" = "சாளர தலைப்பு";
+"Window Title - Application Name" = "சாளர தலைப்பு - பயன்பாட்டு பெயர்";
 "Windows" = "விண்டோஸ்";
 "You can’t undo this action." = "இந்த செயலை நீங்கள் செயல்தவிர்க்க முடியாது.";
 "You didn’t write your email, thus can’t receive any response." = "உங்கள் மின்னஞ்சலை நீங்கள் எழுதவில்லை, இதனால் எந்த பதிலும் பெற முடியாது.";

--- a/resources/l10n/th.lproj/Localizable.strings
+++ b/resources/l10n/th.lproj/Localizable.strings
@@ -244,6 +244,7 @@
 "Window min width in row:" = "ความกว้างต่ำสุดของหน้าต่างในแถว:";
 "Window order:" = "ลำดับหน้าต่าง:";
 "Window Title" = "ชื่อหน้าต่าง";
+"Window Title - Application Name" = "ชื่อหน้าต่าง - ชื่อแอปพลิเคชัน";
 "Window title font size:" = "ขนาดชื่อของหน้าต่าง:";
 "Window title truncation:" = "ตัดทอนชื่อหน้าต่าง:";
 "Windows" = "หน้าต่าง";

--- a/resources/l10n/tr.lproj/Localizable.strings
+++ b/resources/l10n/tr.lproj/Localizable.strings
@@ -260,6 +260,7 @@
 "Window min width in row:" = "Asgari pencere genişliği:";
 "Window order:" = "Pencere sırası:";
 "Window Title" = "Pencere başlığı";
+"Window Title - Application Name" = "Pencere Başlığı - Uygulama Adı";
 "Window title font size:" = "Pencere başlığı yazı boyutu:";
 "Window title truncation:" = "Pencere başlığını kısaltma:";
 "Windows" = "Pencereler";

--- a/resources/l10n/uk.lproj/Localizable.strings
+++ b/resources/l10n/uk.lproj/Localizable.strings
@@ -259,6 +259,7 @@
 "Window min width in row:" = "Мінімальна ширина вікна в рядку:";
 "Window order:" = "Порядок вікон:";
 "Window Title" = "Заголовок вікна";
+"Window Title - Application Name" = "Назва вікна - Назва програми";
 "Window title font size:" = "Розмір шрифту заголовку вікна:";
 "Window title truncation:" = "Скорочення заголовку вікна:";
 "Windows" = "Вікна";

--- a/resources/l10n/uz.lproj/Localizable.strings
+++ b/resources/l10n/uz.lproj/Localizable.strings
@@ -173,6 +173,7 @@
 "Window is on every Space" = "Oyna har bir joyda";
 "Window is on Space %d" = "Deraza kosmosda% d";
 "Window Title" = "Oyna nomi";
+"Window Title - Application Name" = "oyna nomi - Ilova nomi";
 "Windows" = "Derazalar";
 "You can’t undo this action." = "Siz ushbu harakatni bekor qila olmaysiz.";
 "You didn’t write your email, thus can’t receive any response." = "Siz elektron pochtangizni yozmadingiz, shuning uchun hech qanday javob ololmaysiz.";

--- a/resources/l10n/vi.lproj/Localizable.strings
+++ b/resources/l10n/vi.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "Độ rộng cửa sổ tối thiểu trong dòng:";
 "Window order:" = "Thứ tự cửa sổ:";
 "Window Title" = "Tiêu đề cửa sổ";
+"Window Title - Application Name" = "Tiêu đề cửa sổ - Tên ứng dụng";
 "Window title font size:" = "Kích cỡ tiêu đề cửa sổ:";
 "Window title truncation:" = "Ẩn bớt tiêu đề cửa sổ:";
 "Windows" = "các cửa sổ";

--- a/resources/l10n/zh-CN.lproj/Localizable.strings
+++ b/resources/l10n/zh-CN.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "每行窗口最小宽度：";
 "Window order:" = "窗口顺序：";
 "Window Title" = "窗口标题";
+"Window Title - Application Name" = "窗口标题 - 应用名称";
 "Window title font size:" = "窗口标题字号：";
 "Window title truncation:" = "窗口标题删节：";
 "Windows" = "窗口";

--- a/resources/l10n/zh-TW.lproj/Localizable.strings
+++ b/resources/l10n/zh-TW.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "每列視窗最小寬度：";
 "Window order:" = "視窗排序方式：";
 "Window Title" = "視窗標題";
+"Window Title - Application Name" = "視窗標題 - 應用程式名稱";
 "Window title font size:" = "視窗標題的字體大小：";
 "Window title truncation:" = "視窗標題截斷：";
 "Windows" = "視窗";

--- a/resources/l10n/zh-hk.lproj/Localizable.strings
+++ b/resources/l10n/zh-hk.lproj/Localizable.strings
@@ -279,6 +279,7 @@
 "Window min width in row:" = "每列視窗的最小寬度：";
 "Window order:" = "視窗順序：";
 "Window Title" = "視窗標題";
+"Window Title - Application Name" = "視窗標題 - 應用程式名稱";
 "Window title font size:" = "視窗標題字體大小：";
 "Window title truncation:" = "視窗標題截斷：";
 "Windows" = "視窗";

--- a/src/logic/MacroPreferences.swift
+++ b/src/logic/MacroPreferences.swift
@@ -362,12 +362,14 @@ enum ShowTitlesPreference: CaseIterable, MacroPreference {
     case windowTitle
     case appName
     case appNameAndWindowTitle
+    case windowTitleAndAppName
 
     var localizedString: LocalizedString {
         switch self {
             case .windowTitle: return NSLocalizedString("Window Title", comment: "")
             case .appName: return NSLocalizedString("Application Name", comment: "")
             case .appNameAndWindowTitle: return NSLocalizedString("Application Name - Window Title", comment: "")
+            case .windowTitleAndAppName: return NSLocalizedString("Window Title  - Application Name", comment: "")
         }
     }
 
@@ -376,6 +378,7 @@ enum ShowTitlesPreference: CaseIterable, MacroPreference {
             case .windowTitle: return WidthHeightImage(name: "show_running_windows")
             case .appName: return WidthHeightImage(name: "show_running_applications")
             case .appNameAndWindowTitle: return WidthHeightImage(name: "show_running_applications_windows")
+            case .windowTitleAndAppName: return WidthHeightImage(name: "show_running_applications_windows")
         }
     }
 }

--- a/src/ui/main-window/TileView.swift
+++ b/src/ui/main-window/TileView.swift
@@ -346,6 +346,17 @@ class TileView: FlippedView {
             }
             return spanRanges
         }
+        if Preferences.showTitles == .windowTitleAndAppName {
+            let windowTitle = window_?.title ?? ""
+            let offset = windowTitle.isEmpty ? 0 : (windowTitle + " - ").count
+            for result in window_?.swTitleResults ?? [] {
+                spanRanges.append(NSRange(location: result.span.lowerBound, length: result.span.count))
+            }
+            for result in window_?.swAppResults ?? [] {
+                spanRanges.append(NSRange(location: offset + result.span.lowerBound, length: result.span.count))
+            }
+            return spanRanges
+        }
         for result in window_?.swTitleResults ?? [] {
             spanRanges.append(NSRange(location: result.span.lowerBound, length: result.span.count))
         }
@@ -535,6 +546,8 @@ class TileView: FlippedView {
             return appName ?? ""
         } else if Preferences.showTitles == .appNameAndWindowTitle {
             return [appName, windowTitle].compactMap { $0 }.joined(separator: " - ")
+        } else if Preferences.showTitles == .windowTitleAndAppName {
+            return [windowTitle, appName].compactMap { $0 }.joined(separator: " - ")
         }
         return windowTitle ?? ""
     }


### PR DESCRIPTION
Adds an additional option for the "Show titles" appearance setting (under Appearance > Customize Titles style...") to show the window title followed by the application name.

<img width="1030" height="793" alt="Screenshot 2026-02-21 at 10 37 39 PM" src="https://github.com/user-attachments/assets/ab19d904-cfd5-4e2b-9347-aa48fe9e082d" />

Note that each setting has a corresponding image https://github.com/lwouis/alt-tab-macos/blob/master/resources/illustrations/titles_show_running_applications_windows_light%402x.jpg but I'm not sure how to generate a new image to show this new setting, so the preview image is out of sync with this new option (as seen in the screenshot above).