### PR TITLE
feat: add configurable macos-like app switcher mode

### DIFF
--- a/src/logic/MacroPreferences.swift
+++ b/src/logic/MacroPreferences.swift
@@ -1,3 +1,5 @@
+import Cocoa
+
 enum MenubarIconPreference: CaseIterable, MacroPreference {
     case outlined
     case filled
@@ -223,6 +225,37 @@ enum AppsToShowPreference: CaseIterable, MacroPreference {
             case .all: return NSLocalizedString("All apps", comment: "")
             case .active: return NSLocalizedString("Active app", comment: "")
             case .nonActive: return NSLocalizedString("Non-active apps", comment: "")
+        }
+    }
+}
+
+enum MaxWindowsPerAppPreference: CaseIterable, MacroPreference {
+    case noLimit
+    case one
+    case two
+    case three
+    case four
+    case five
+
+    var localizedString: LocalizedString {
+        switch self {
+            case .noLimit: return NSLocalizedString("No limit", comment: "")
+            case .one: return NSLocalizedString("1 window", comment: "")
+            case .two: return NSLocalizedString("2 windows", comment: "")
+            case .three: return NSLocalizedString("3 windows", comment: "")
+            case .four: return NSLocalizedString("4 windows", comment: "")
+            case .five: return NSLocalizedString("5 windows", comment: "")
+        }
+    }
+
+    var maxWindows: Int? {
+        switch self {
+            case .noLimit: return nil
+            case .one: return 1
+            case .two: return 2
+            case .three: return 3
+            case .four: return 4
+            case .five: return 5
         }
     }
 }

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -80,6 +80,7 @@ class Preferences {
         }
         (0...maxShortcutCount).forEach { index in
             values[indexToName("appsToShow", index)] = index == 1 ? AppsToShowPreference.active.indexAsString : (index == 2 ? AppsToShowPreference.nonActive.indexAsString : AppsToShowPreference.all.indexAsString)
+            values[indexToName("maxWindowsPerApp", index)] = MaxWindowsPerAppPreference.noLimit.indexAsString
             values[indexToName("spacesToShow", index)] = SpacesToShowPreference.all.indexAsString
             values[indexToName("screensToShow", index)] = ScreensToShowPreference.all.indexAsString
             values[indexToName("showMinimizedWindows", index)] = ShowHowPreference.show.indexAsString
@@ -145,6 +146,7 @@ class Preferences {
     static var updatePolicy: UpdatePolicyPreference { CachedUserDefaults.macroPref("updatePolicy", UpdatePolicyPreference.allCases) }
     static var crashPolicy: CrashPolicyPreference { CachedUserDefaults.macroPref("crashPolicy", CrashPolicyPreference.allCases) }
     static var appsToShow: [AppsToShowPreference] { (0...maxShortcutCount).map { CachedUserDefaults.macroPref(indexToName("appsToShow", $0), AppsToShowPreference.allCases) } }
+    static var maxWindowsPerApp: [MaxWindowsPerAppPreference] { (0...maxShortcutCount).map { CachedUserDefaults.macroPref(indexToName("maxWindowsPerApp", $0), MaxWindowsPerAppPreference.allCases) } }
     static var spacesToShow: [SpacesToShowPreference] { (0...maxShortcutCount).map { CachedUserDefaults.macroPref(indexToName("spacesToShow", $0), SpacesToShowPreference.allCases) } }
     static var screensToShow: [ScreensToShowPreference] { (0...maxShortcutCount).map { CachedUserDefaults.macroPref(indexToName("screensToShow", $0), ScreensToShowPreference.allCases) } }
     static var showMinimizedWindows: [ShowHowPreference] { (0...maxShortcutCount).map { CachedUserDefaults.macroPref(indexToName("showMinimizedWindows", $0), ShowHowPreference.allCases) } }
@@ -203,6 +205,15 @@ class Preferences {
 
     static func onlyShowApplications() -> Bool {
         return Preferences.showAppsOrWindows == .applications && Preferences.appearanceStyle != .thumbnails
+    }
+
+    static func maxWindowsPerAppInSwitcher(_ shortcutIndex: Int = App.shortcutIndex) -> Int? {
+        guard appsToShow[safe: shortcutIndex] == .all else { return nil }
+        return maxWindowsPerApp[safe: shortcutIndex]?.maxWindows
+    }
+
+    static func onlyShowApplicationsInSwitcher(_ shortcutIndex: Int = App.shortcutIndex) -> Bool {
+        return onlyShowApplications() || maxWindowsPerAppInSwitcher(shortcutIndex) == 1
     }
 
     /// key-above-tab is ` on US keyboard, but can be different on other keyboards

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -204,7 +204,7 @@ class Window {
             App.shared.activate(ignoringOtherApps: true)
             altTabWindow.makeKeyAndOrderFront(nil)
             Windows.previewSelectedWindowIfNeeded()
-        } else if isWindowlessApp || cgWindowId == nil || Preferences.onlyShowApplications() {
+        } else if isWindowlessApp || cgWindowId == nil || Preferences.onlyShowApplicationsInSwitcher() {
             if let bundleUrl = application.bundleURL, isWindowlessApp {
                 if (try? NSWorkspace.shared.launchApplication(at: bundleUrl, configuration: [:])) == nil {
                     application.runningApplication.activate(options: .activateAllWindows)

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -75,7 +75,7 @@ class Windows {
 
     static func previewSelectedWindowIfNeeded() {
         if App.appIsBeingUsed && ScreenRecordingPermission.status == .granted
-               && Preferences.previewSelectedWindow && !Preferences.onlyShowApplications()
+               && Preferences.previewSelectedWindow && !Preferences.onlyShowApplicationsInSwitcher()
                && TilesPanel.shared.isKeyWindow,
            let window = selectedWindow(),
            let id = window.cgWindowId,
@@ -129,7 +129,7 @@ class Windows {
     // dispatch screenshot requests off the main-thread, then wait for completion
     static func refreshThumbnailsAsync(_ windows: [Window], _ source: RefreshCausedBy, windowRemoved: Bool = false) {
         guard (!windows.isEmpty || windowRemoved) && ScreenRecordingPermission.status == .granted
-               && !Preferences.onlyShowApplications()
+               && !Preferences.onlyShowApplicationsInSwitcher()
                && (!Appearance.hideThumbnails || Preferences.previewSelectedWindow) else { return }
         var eligibleWindows = [Window]()
         for window in windows {
@@ -148,19 +148,34 @@ class Windows {
     }
 
     static func refreshWhichWindowsToShowTheUser() {
-        if Preferences.onlyShowApplications() {
-            // Group windows by application and select the optimal main window
-            let windowsGroupedByApp = Dictionary(grouping: list) { $0.application.pid }
-            windowsGroupedByApp.forEach { (app, windows) in
-                if windows.count > 1, let mainWindow = findMainWindow(windows) {
-                    windows.forEach { window in
-                        if window.cgWindowId != mainWindow.cgWindowId {
-                            window.shouldShowTheUser = false
-                        }
-                    }
+        guard let maxWindowsPerApp = maxWindowsPerAppInCurrentSwitcherMode() else { return }
+        let windowsGroupedByApp = Dictionary(grouping: list) { $0.application.pid }
+        windowsGroupedByApp.forEach { _, windows in
+            let prioritizedWindows = prioritizeWindowsWithinApp(windows).filter { $0.shouldShowTheUser }
+            if prioritizedWindows.count > maxWindowsPerApp {
+                prioritizedWindows.dropFirst(maxWindowsPerApp).forEach {
+                    $0.shouldShowTheUser = false
                 }
             }
         }
+    }
+
+    private static func maxWindowsPerAppInCurrentSwitcherMode() -> Int? {
+        if Preferences.onlyShowApplications() {
+            return 1
+        }
+        return Preferences.maxWindowsPerAppInSwitcher()
+    }
+
+    private static func prioritizeWindowsWithinApp(_ windows: [Window]) -> [Window] {
+        guard let mainWindow = findMainWindow(windows) else { return windows }
+        var prioritizedWindows = [mainWindow]
+        windows.forEach {
+            if $0.id != mainWindow.id {
+                prioritizedWindows.append($0)
+            }
+        }
+        return prioritizedWindows
     }
 
     private static func shouldHideWindow(_ window: Window, _ entry: ExceptionEntry) -> Bool {

--- a/src/ui/main-window/TileView.swift
+++ b/src/ui/main-window/TileView.swift
@@ -329,7 +329,7 @@ class TileView: FlippedView {
 
     private func searchSpanRanges() -> [NSRange] {
         var spanRanges = [NSRange]()
-        if Preferences.onlyShowApplications() || Preferences.showTitles == .appName {
+        if Preferences.onlyShowApplicationsInSwitcher() || Preferences.showTitles == .appName {
             for result in window_?.swAppResults ?? [] {
                 spanRanges.append(NSRange(location: result.span.lowerBound, length: result.span.count))
             }
@@ -531,7 +531,7 @@ class TileView: FlippedView {
     private func getAppOrAndWindowTitle() -> String {
         let appName = window_?.application.localizedName
         let windowTitle = window_?.title
-        if Preferences.onlyShowApplications() || Preferences.showTitles == .appName {
+        if Preferences.onlyShowApplicationsInSwitcher() || Preferences.showTitles == .appName {
             return appName ?? ""
         } else if Preferences.showTitles == .appNameAndWindowTitle {
             return [appName, windowTitle].compactMap { $0 }.joined(separator: " - ")

--- a/src/ui/settings-window/tabs/controls/ControlsTab.swift
+++ b/src/ui/settings-window/tabs/controls/ControlsTab.swift
@@ -161,7 +161,7 @@ class ControlsTab {
     ]
     private static let removableShortcutPreferences = [
         "holdShortcut", "nextWindowShortcut",
-        "appsToShow", "spacesToShow", "screensToShow",
+        "appsToShow", "maxWindowsPerApp", "spacesToShow", "screensToShow",
         "showMinimizedWindows", "showHiddenWindows", "showFullscreenWindows", "showWindowlessApps",
         "windowOrder", "shortcutStyle",
     ]
@@ -397,7 +397,11 @@ class ControlsTab {
     }
 
     private static func controlTab(_ index: Int, _ trigger: [NSView], _ width: CGFloat) -> TableGroupView {
-        let appsToShow = LabelAndControl.makeDropdown(Preferences.indexToName("appsToShow", index), AppsToShowPreference.allCases)
+        var maxWindowsPerAppRowInfo: TableGroupView.RowInfo?
+        let appsToShow = LabelAndControl.makeDropdown(Preferences.indexToName("appsToShow", index), AppsToShowPreference.allCases, extraAction: { _ in
+            toggleMaxWindowsPerAppRow(index, maxWindowsPerAppRowInfo)
+        })
+        let maxWindowsPerApp = LabelAndControl.makeDropdown(Preferences.indexToName("maxWindowsPerApp", index), MaxWindowsPerAppPreference.allCases)
         let spacesToShow = LabelAndControl.makeDropdown(Preferences.indexToName("spacesToShow", index), SpacesToShowPreference.allCases)
         let screensToShow = LabelAndControl.makeDropdown(Preferences.indexToName("screensToShow", index), ScreensToShowPreference.allCases)
         let showMinimizedWindows = LabelAndControl.makeDropdown(Preferences.indexToName("showMinimizedWindows", index), ShowHowPreference.allCases)
@@ -409,6 +413,7 @@ class ControlsTab {
         table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Trigger", comment: ""), rightViews: trigger))
         table.addNewTable()
         table.addRow(leftViews: [TableGroupView.makeText(NSLocalizedString("Show windows from applications", comment: ""))], rightViews: [appsToShow])
+        maxWindowsPerAppRowInfo = table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Show at most this many windows from one app", comment: ""), rightViews: [maxWindowsPerApp]))
         table.addRow(leftViews: [TableGroupView.makeText(NSLocalizedString("Show windows from Spaces", comment: ""))], rightViews: [spacesToShow])
         table.addRow(leftViews: [TableGroupView.makeText(NSLocalizedString("Show windows from screens", comment: ""))], rightViews: [screensToShow])
         table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Show minimized windows", comment: ""), rightViews: [showMinimizedWindows]))
@@ -416,7 +421,15 @@ class ControlsTab {
         table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Show fullscreen windows", comment: ""), rightViews: [showFullscreenWindows]))
         table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Show apps with no open window", comment: ""), rightViews: [showWindowlessApps]))
         table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Order windows by", comment: ""), rightViews: [windowOrder]))
+        toggleMaxWindowsPerAppRow(index, maxWindowsPerAppRowInfo)
         return table
+    }
+
+    private static func toggleMaxWindowsPerAppRow(_ index: Int, _ rowInfo: TableGroupView.RowInfo?) {
+        let isVisible = Preferences.appsToShow[safe: index] == .all
+        rowInfo?.view.isHidden = !isVisible
+        rowInfo?.previousSeparator?.isHidden = !isVisible
+        rowInfo?.nextSeparator?.isHidden = !isVisible
     }
 
     private static func refreshShortcutUi() {


### PR DESCRIPTION
This PR:

- replaces the per-shortcut apps-only toggle with a per-shortcut **max windows per app** setting (`No limit`, `1`..`5`)
- only shows the new control when **Show windows from applications** is set to **All apps**
- updates switcher filtering so each app can be capped to the configured number of windows, while keeping main-window-first behavior

### Reasoning

Users want an option closer to the native macOS app switcher behavior, while still keeping AltTab's richer controls. This feature provides that middle ground:

- setting the max to `1` gives native-like app switching (one entry per app)
- values above `1` keep multiple windows per app, but in a bounded and predictable way
- existing options like spaces/screens filters still apply, so users can customize scope beyond default macOS behavior

Validation:

- `xcodebuild -workspace alt-tab-macos.xcworkspace -scheme Debug -configuration Debug -derivedDataPath ~/git/alt-tab-macos/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""`
- `xcodebuild -workspace alt-tab-macos.xcworkspace -scheme Test -configuration Debug -derivedDataPath ~/git/alt-tab-macos/DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY="" test`