### PR TITLE
fix: run TrackpadEvents on main thread for toNSEvent() correctness

### DIFF
--- a/src/logic/events/TrackpadEvents.swift
+++ b/src/logic/events/TrackpadEvents.swift
@@ -39,7 +39,8 @@ class TrackpadEvents {
             userInfo: nil)
         if let eventTap {
             let runLoopSource = CFMachPortCreateRunLoopSource(nil, eventTap, 0)
-            CFRunLoopAddSource(BackgroundWork.keyboardAndMouseAndTrackpadEventsThread.runLoop, runLoopSource, .commonModes)
+            // we run on main-thread since toNSEvent() must be called on main-thread, and we need to synchronously decide if we absorb the event
+            CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
         } else {
             App.restart()
         }


### PR DESCRIPTION
`toNSEvent()` must be called on the main thread. Unlike `CursorEvents` (which was updated in #5336 to use `cgEvent.location` directly), `TrackpadEvents` still calls `toNSEvent()` and must synchronously decide whether to absorb events — so it cannot use a background thread or switch to `.listenOnly`.

This moves the trackpad run loop source to `CFRunLoopGetMain()` to fix the incorrect background-thread usage.