### PR TITLE
fix: prevent crash when using gestures via Universal Control

### DIFF
--- a/alt-tab-macos-Bridging-Header.h
+++ b/alt-tab-macos-Bridging-Header.h
@@ -1,1 +1,2 @@
 #import "AppCenterApplication.h"
+#import "ATTouchSafety.h"

--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -299,6 +299,7 @@
 		D04BAD2A7F2E8BF64EE982E9 /* TextArea.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA7C836A8CE8C0B8D128B /* TextArea.swift */; };
 		D04BAD451966B43720120D2E /* Menubar.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BAD905546AA93E5117B0A /* Menubar.swift */; };
 		D04BADA3F2DAB820D6FC6E75 /* AppCenterApplication.m in Sources */ = {isa = PBXBuildFile; fileRef = D04BA48BC82D3060C3A1AB11 /* AppCenterApplication.m */; };
+		AA0000000000000000000001 /* ATTouchSafety.m in Sources */ = {isa = PBXBuildFile; fileRef = AA0000000000000000000002 /* ATTouchSafety.m */; };
 		D04BADCDA9F9A6C3D6499877 /* SystemPermissions.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA7C6F2519091717F4B4E /* SystemPermissions.swift */; };
 		D04BADE4DDF7597749FB13BD /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA099FA155FB4D517D66B /* SettingsWindow.swift */; };
 		D04BAE8B16A06A10E2FA94DE /* AccessibilityEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA8FDCF137D892114F5F3 /* AccessibilityEvents.swift */; };
@@ -642,6 +643,8 @@
 		D04BA459034C1885CA43A807 /* LICENCE.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = LICENCE.md; sourceTree = "<group>"; };
 		D04BA484B11FEF4DBF08350A /* pt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = pt; path = Localizable.strings; sourceTree = "<group>"; };
 		D04BA48BC82D3060C3A1AB11 /* AppCenterApplication.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppCenterApplication.m; sourceTree = "<group>"; };
+		AA0000000000000000000002 /* ATTouchSafety.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ATTouchSafety.m; sourceTree = "<group>"; };
+		AA0000000000000000000003 /* ATTouchSafety.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ATTouchSafety.h; sourceTree = "<group>"; };
 		D04BA49E45BFFF3D9FC60E43 /* HyperlinkLabel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = HyperlinkLabel.swift; sourceTree = "<group>"; };
 		D04BA4A26987F67DD94C827F /* AboutTab.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutTab.swift; sourceTree = "<group>"; };
 		D04BA4A621A8A15660F973C1 /* KeyboardEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyboardEvents.swift; sourceTree = "<group>"; };
@@ -1678,6 +1681,8 @@
 				BF0C88D101728C6798C7FC07 /* private-apis */,
 				BF0C810FA0F6BC70E5886E11 /* HelperExtensionsTestable.swift */,
 				BF0C8363D45FECB8D6F8DCD5 /* LightweightTimer.swift */,
+				AA0000000000000000000002 /* ATTouchSafety.m */,
+				AA0000000000000000000003 /* ATTouchSafety.h */,
 			);
 			path = "api-wrappers";
 			sourceTree = "<group>";
@@ -2618,6 +2623,7 @@
 				D04BAFF30A98CF287F85DA1E /* ExceptionsTab.swift in Sources */,
 				D04BA56789A2AF52557A9BFF /* AppCenterCrashes.swift in Sources */,
 				D04BADA3F2DAB820D6FC6E75 /* AppCenterApplication.m in Sources */,
+				AA0000000000000000000001 /* ATTouchSafety.m in Sources */,
 				D04BAA16F21AC41A23DDA63D /* ControlsTab.swift in Sources */,
 				D04BADE4DDF7597749FB13BD /* SettingsWindow.swift in Sources */,
 				BF0C8CC5057406014FD612CC /* ATShortcut.swift in Sources */,

--- a/src/api-wrappers/ATTouchSafety.h
+++ b/src/api-wrappers/ATTouchSafety.h
@@ -1,0 +1,8 @@
+@import Cocoa;
+
+// NSTouch.normalizedPosition throws NSInternalInconsistencyException for touches
+// delivered via Universal Control. Swift cannot catch NSException, so this ObjC
+// wrapper provides a safe accessor that returns NO instead of crashing.
+@interface ATTouchSafety : NSObject
++ (BOOL)getNormalizedPosition:(NSTouch *)touch result:(NSPoint *)outPoint;
+@end

--- a/src/api-wrappers/ATTouchSafety.m
+++ b/src/api-wrappers/ATTouchSafety.m
@@ -1,0 +1,20 @@
+@import Cocoa;
+#import "ATTouchSafety.h"
+
+@implementation ATTouchSafety
+
++ (BOOL)getNormalizedPosition:(NSTouch *)touch result:(NSPoint *)outPoint {
+    @try {
+        *outPoint = touch.normalizedPosition;
+        return YES;
+    } @catch (NSException *exception) {
+        static BOOL logged = NO;
+        if (!logged) {
+            NSLog(@"ATTouchSafety: normalizedPosition threw %@: %@", exception.name, exception.reason);
+            logged = YES;
+        }
+        return NO;
+    }
+}
+
+@end

--- a/src/logic/events/TrackpadEvents.swift
+++ b/src/logic/events/TrackpadEvents.swift
@@ -65,7 +65,6 @@ class TrackpadEvents {
     private static func touchEventHandler(_ cgEvent: CGEvent) -> Bool {
         guard let nsEvent = cgEvent.toNSEvent() else { return false } // don't absorb the touch event
         let touches = nsEvent.allTouches()
-        // Logger.error { (touches.count, touches.map { $0.phase.readable }) }
         // macOS often sends faulty events with no touches between valid events; we ignore these as they would break our gesture logic
         guard touches.count > 0 else  { return false }
         // isResting seems to always return false. It's not doing its job to detect resting thumb/palm/finger
@@ -153,6 +152,7 @@ class TriggerSwipeDetector {
         guard swipeStillPossible && !gestureTracker.isNewGesture(activeTouches) else { return false }
         maxFingersDownDuringTrigger = max(maxFingersDownDuringTrigger, fingersDown)
         let distances = gestureTracker.computeDistance(activeTouches)
+        guard !distances.isEmpty else { return false }
         for distance in distances {
             let (absX, absY) = (abs(distance.x), abs(distance.y))
             let horizontal = Preferences.nextWindowGesture.isHorizontal()
@@ -203,12 +203,19 @@ class NavigationSwipeDetector {
 class GestureTracker {
     var startPositions = [String: NSPoint]()
 
+    private static func safeNormalizedPosition(_ touch: NSTouch) -> NSPoint? {
+        var point = NSPoint.zero
+        return ATTouchSafety.getNormalizedPosition(touch, result: &point) ? point : nil
+    }
+
     @discardableResult
     func isNewGesture(_ activeTouches: Set<NSTouch>) -> Bool {
         // if touches are new, record their startPositions
         if (activeTouches.contains { startPositions["\($0.identity)"] == nil }) {
             for touch in activeTouches {
-                startPositions["\(touch.identity)"] = touch.normalizedPosition
+                if let pos = GestureTracker.safeNormalizedPosition(touch) {
+                    startPositions["\(touch.identity)"] = pos
+                }
             }
             return true
         }
@@ -217,16 +224,22 @@ class GestureTracker {
 
     func computeAverageDistance(_ activeTouches: Set<NSTouch>) -> NSPoint {
         var totalDelta = NSPoint(x: 0, y: 0)
+        var count = 0
         for touch in activeTouches {
-            totalDelta = totalDelta + (touch.normalizedPosition - startPositions["\(touch.identity)"]!)
+            guard let pos = GestureTracker.safeNormalizedPosition(touch),
+                  let start = startPositions["\(touch.identity)"] else { continue }
+            totalDelta = totalDelta + (pos - start)
+            count += 1
         }
-        return totalDelta / activeTouches.count
+        return count > 0 ? totalDelta / count : totalDelta
     }
 
     func computeDistance(_ activeTouches: Set<NSTouch>) -> Array<NSPoint> {
         var deltas: Array<NSPoint> = []
         for touch in activeTouches {
-            deltas.append(touch.normalizedPosition - startPositions["\(touch.identity)"]!)
+            guard let pos = GestureTracker.safeNormalizedPosition(touch),
+                  let start = startPositions["\(touch.identity)"] else { continue }
+            deltas.append(pos - start)
         }
         return deltas
     }
@@ -237,13 +250,15 @@ class GestureTracker {
 
     func resetX(_ activeTouches: Set<NSTouch>) {
         for touch in activeTouches {
-            startPositions["\(touch.identity)"]!.x = touch.normalizedPosition.x
+            guard let pos = GestureTracker.safeNormalizedPosition(touch) else { continue }
+            startPositions["\(touch.identity)"]?.x = pos.x
         }
     }
 
     func resetY(_ activeTouches: Set<NSTouch>) {
         for touch in activeTouches {
-            startPositions["\(touch.identity)"]!.y = touch.normalizedPosition.y
+            guard let pos = GestureTracker.safeNormalizedPosition(touch) else { continue }
+            startPositions["\(touch.identity)"]?.y = pos.y
         }
     }
 }


### PR DESCRIPTION
## Summary

- `NSTouch.normalizedPosition` throws `NSInternalInconsistencyException` for touches delivered via Universal Control (e.g. using another Mac's trackpad). Swift cannot catch `NSException`, so an ObjC wrapper (`ATTouchSafety`) safely returns `NO` instead of crashing.
- All force-unwraps of touch positions in `GestureTracker` replaced with safe optional access via `guard let ... else { continue }`.
- Added `guard !distances.isEmpty` in `TriggerSwipeDetector.hasDetected` to prevent the window switcher from incorrectly triggering when all touches fail position retrieval.

Closes #5499

## Test plan

- [x] Build and run with Universal Control active (two Macs sharing keyboard/trackpad)
- [x] Perform 3-finger and 4-finger swipe gestures via Universal Control — should no longer crash
- [x] Verify gestures still work normally on local trackpad
- [x] Verify navigation swipes (back/forward) work correctly