### PR TITLE
feat: highlight selected window on desktop with accent-colored border

### DIFF
--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		76D02BB22BFE7C9E0056008D /* Pods_alt_tab_macos.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C0712B3BEA2B3780398C0999 /* Pods_alt_tab_macos.framework */; };
 		AA0C8A100000000000000001 /* AXCallScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0C8A000000000000000001 /* AXCallScheduler.swift */; };
 		AA974BA929B7D84C0099A29E /* PreviewPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA974BA829B7D84C0099A29E /* PreviewPanel.swift */; };
+		CC0000000000000000000002 /* WindowHighlightPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC0000000000000000000001 /* WindowHighlightPanel.swift */; };
 		BB0000000000000000000002 /* TabGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB0000000000000000000001 /* TabGroup.swift */; };
 		BF0C803A13C409E7F01FBCAB /* SkyLight.framework.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C8B94D7994AB9007F6391 /* SkyLight.framework.swift */; };
 		BF0C80484AA63306D0DB4DB2 /* SpacesEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C8DF008F1EB5F23291A13 /* SpacesEvents.swift */; };
@@ -423,6 +424,7 @@
 		7451B8433E47C444A6F489FF /* Pods-unit-tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-unit-tests.debug.xcconfig"; path = "Target Support Files/Pods-unit-tests/Pods-unit-tests.debug.xcconfig"; sourceTree = "<group>"; };
 		AA0C8A000000000000000001 /* AXCallScheduler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AXCallScheduler.swift; sourceTree = "<group>"; };
 		AA974BA829B7D84C0099A29E /* PreviewPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewPanel.swift; sourceTree = "<group>"; };
+		CC0000000000000000000001 /* WindowHighlightPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowHighlightPanel.swift; sourceTree = "<group>"; };
 		BB0000000000000000000001 /* TabGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabGroup.swift; sourceTree = "<group>"; };
 		BF0C800363086A5ED019FE11 /* google_translate_all_terms_locally.py */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.script.python; path = google_translate_all_terms_locally.py; sourceTree = "<group>"; };
 		BF0C804765D0E6A92C6646CC /* gu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = gu; path = InfoPlist.strings; sourceTree = "<group>"; };
@@ -1540,6 +1542,7 @@
 				BF0C8468DF35990A7731D86C /* MainMenu.swift */,
 				BF0C80F8FAA00FF3D9682F26 /* DebugMenu.swift */,
 				AA974BA829B7D84C0099A29E /* PreviewPanel.swift */,
+				CC0000000000000000000001 /* WindowHighlightPanel.swift */,
 			);
 			path = ui;
 			sourceTree = "<group>";
@@ -2571,6 +2574,7 @@
 				D04BA2A6FF9DDDC5A1A68E36 /* Applications.swift in Sources */,
 				BB0000000000000000000002 /* TabGroup.swift in Sources */,
 				AA974BA929B7D84C0099A29E /* PreviewPanel.swift in Sources */,
+				CC0000000000000000000002 /* WindowHighlightPanel.swift in Sources */,
 				D04BA3CF766857381519B892 /* BackgroundWork.swift in Sources */,
 				D04BA48B00B4211A465C7337 /* DebugProfile.swift in Sources */,
 				D04BAB68B7B8D1B548BC3AD5 /* App.swift in Sources */,

--- a/resources/l10n/Localizable.strings
+++ b/resources/l10n/Localizable.strings
@@ -353,6 +353,9 @@
 "Please fill in the form" = "Please fill in the form";
 
 /* No comment provided by engineer. */
+"Highlight selected window on desktop" = "Highlight selected window on desktop";
+
+/* No comment provided by engineer. */
 "Preview selected window" = "Preview selected window";
 
 /* %@ is AltTab

--- a/resources/l10n/en.lproj/Localizable.strings
+++ b/resources/l10n/en.lproj/Localizable.strings
@@ -165,6 +165,7 @@
 "Please fill in the form" = "Please fill in the form";
 "Policies" = "Policies";
 "Preferences…" = "Preferences…";
+"Highlight selected window on desktop" = "Highlight selected window on desktop";
 "Preview selected window" = "Preview selected window";
 "Preview selected window:" = "Preview selected window:";
 "Preview the selected window." = "Preview the selected window.";

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -47,6 +47,7 @@ class Preferences {
             "hideSpaceNumberLabels": "false",
             "hideStatusIcons": "false",
             "previewFocusedWindow": "false",
+            "highlightSelectedWindow": "false",
             "captureWindowsInBackground": "true",
             "screenRecordingPermissionSkipped": "false",
             "trackpadHapticFeedbackEnabled": "true",
@@ -116,6 +117,7 @@ class Preferences {
     static var startAtLogin: Bool { CachedUserDefaults.bool("startAtLogin") }
     static var exceptions: [ExceptionEntry] { CachedUserDefaults.json("exceptions", [ExceptionEntry].self) }
     static var previewSelectedWindow: Bool { CachedUserDefaults.bool("previewFocusedWindow") }
+    static var highlightSelectedWindow: Bool { CachedUserDefaults.bool("highlightSelectedWindow") }
     static var captureWindowsInBackground: Bool { CachedUserDefaults.bool("captureWindowsInBackground") }
     static var screenRecordingPermissionSkipped: Bool { CachedUserDefaults.bool("screenRecordingPermissionSkipped") }
     static var settingsWindowShownOnFirstLaunch: Bool { CachedUserDefaults.bool("settingsWindowShownOnFirstLaunch") }

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -86,6 +86,7 @@ class Windows {
         } else {
             PreviewPanel.shared.orderOut(nil)
         }
+        WindowHighlightPanel.updateHighlightIfNeeded()
     }
 
     static func updatesBeforeShowing() -> Bool {

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -67,6 +67,7 @@ class App: AppCenterApplication {
         if !keepPreview {
             PreviewPanel.shared.orderOut(nil)
         }
+        WindowHighlightPanel.shared?.orderOut(nil)
         hideAllTooltips()
         MainMenu.toggle(true)
     }
@@ -371,6 +372,7 @@ class App: AppCenterApplication {
         MainMenu.create()
         _ = TilesPanel()
         _ = PreviewPanel()
+        _ = WindowHighlightPanel()
         Spaces.refresh()
         Screens.refresh()
         SpacesEvents.observe()

--- a/src/ui/WindowHighlightPanel.swift
+++ b/src/ui/WindowHighlightPanel.swift
@@ -1,0 +1,63 @@
+import Cocoa
+
+class WindowHighlightPanel: NSPanel {
+    static var shared: WindowHighlightPanel!
+    static let borderWidth = CGFloat(4)
+    static let cornerRadius = CGFloat(10)
+
+    override func constrainFrameRect(_ frameRect: NSRect, to screen: NSScreen?) -> NSRect {
+        frameRect
+    }
+
+    convenience init() {
+        self.init(contentRect: .zero, styleMask: [.nonactivatingPanel, .titled, .fullSizeContentView], backing: .buffered, defer: false)
+        isFloatingPanel = true
+        animationBehavior = .none
+        hidesOnDeactivate = false
+        titleVisibility = .hidden
+        titlebarAppearsTransparent = true
+        backgroundColor = .clear
+        isOpaque = false
+        hasShadow = false
+        ignoresMouseEvents = true
+        contentView = HighlightBorderView()
+        collectionBehavior = .canJoinAllSpaces
+        setAccessibilitySubrole(.unknown)
+        Self.shared = self
+    }
+
+    static func show(_ position: CGPoint, _ size: CGSize) {
+        var frame = NSRect(origin: position, size: size)
+        frame.origin.y = NSScreen.screens.first!.frame.maxY - frame.maxY
+        Self.shared.setFrame(frame, display: true)
+        Self.shared.order(.below, relativeTo: TilesPanel.shared.windowNumber)
+        Self.shared.level = NSWindow.Level(rawValue: TilesPanel.shared.level.rawValue - 1)
+    }
+
+    static func updateHighlightIfNeeded() {
+        guard App.appIsBeingUsed && Preferences.highlightSelectedWindow && TilesPanel.shared.isKeyWindow,
+              let window = Windows.selectedWindow(),
+              !window.isWindowlessApp,
+              let position = window.position,
+              let size = window.size,
+              !window.isMinimized else {
+            Self.shared?.orderOut(nil)
+            return
+        }
+        show(position, size)
+    }
+}
+
+private class HighlightBorderView: NSView {
+    override func draw(_ dirtyRect: NSRect) {
+        guard let context = NSGraphicsContext.current?.cgContext else { return }
+        context.clear(bounds)
+        let borderWidth = WindowHighlightPanel.borderWidth
+        let cornerRadius = WindowHighlightPanel.cornerRadius
+        let insetRect = bounds.insetBy(dx: borderWidth / 2, dy: borderWidth / 2)
+        let path = NSBezierPath(roundedRect: insetRect, xRadius: cornerRadius, yRadius: cornerRadius)
+        path.lineWidth = borderWidth
+        NSColor.systemAccentColor.setStroke()
+        path.stroke()
+    }
+}

--- a/src/ui/settings-window/tabs/appearance/AppearanceTab.swift
+++ b/src/ui/settings-window/tabs/appearance/AppearanceTab.swift
@@ -424,6 +424,7 @@ class AppearanceTab: NSObject {
             rightViews: [LabelAndControl.makeSegmentedControl("appearanceTheme", AppearanceThemePreference.allCases, segmentWidth: 100)])
         addAfterKeysReleasedRow(table)
         addPreviewSelectedWindowRow(table)
+        addHighlightSelectedWindowRow(table)
         table.addRow(rightViews: customizeStyleButton)
         return table
     }
@@ -431,6 +432,11 @@ class AppearanceTab: NSObject {
     private static func addAfterKeysReleasedRow(_ table: TableGroupView) {
         table.addRow(leftText: NSLocalizedString("After keys are released", comment: ""),
             rightViews: [LabelAndControl.makeDropdown("shortcutStyle", ShortcutStylePreference.allCases)])
+    }
+
+    private static func addHighlightSelectedWindowRow(_ table: TableGroupView) {
+        table.addRow(leftText: NSLocalizedString("Highlight selected window on desktop", comment: ""),
+            rightViews: [LabelAndControl.makeSwitch("highlightSelectedWindow")])
     }
 
     private static func addPreviewSelectedWindowRow(_ table: TableGroupView) {


### PR DESCRIPTION
## Summary

- Adds an option to show a border outline around the actual window on the desktop that is currently selected in the AltTab switcher, making it easier to identify which window is selected among overlapping windows
- Uses a lightweight transparent `NSPanel` overlay positioned at the selected window's coordinates, styled with the system accent color to match the existing tile selection highlight
- The setting is off by default and can be toggled in **Settings > Appearance > "Highlight selected window on desktop"**
- Does **not** require Screen Recording permission — only uses window position and size from the Accessibility API

## Test plan

- [ ] Enable the setting in Settings > Appearance > "Highlight selected window on desktop"
- [ ] Trigger AltTab and verify a blue accent border appears around the selected window on the desktop
- [ ] Navigate between windows with arrow keys and verify the border follows the selection
- [ ] Verify the border disappears when AltTab is dismissed
- [ ] Verify minimized and windowless apps do not show a border
- [ ] Verify the border appears below the AltTab panel (doesn't overlap the switcher UI)
- [ ] Verify the feature works across multiple screens
- [ ] Verify the border color matches the system accent color (change it in System Settings to confirm)
- [ ] Verify the setting is off by default on a fresh install
- [ ] Verify the app works normally with the setting disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)