### PR TITLE
fix: window focus silently failing for apps under macOS focus-stealing prevention

### DIFF
--- a/src/api-wrappers/private-apis/SkyLight.framework.swift
+++ b/src/api-wrappers/private-apis/SkyLight.framework.swift
@@ -187,6 +187,7 @@ enum SLPSMode: UInt32 {
     case allWindows = 0x100
     case userGenerated = 0x200
     case noWindows = 0x400
+    case dontUnhide = 0x800
 }
 
 /// focuses the front process

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -229,6 +229,30 @@ class Window {
                 _SLPSSetFrontProcessWithOptions(&psn, self.cgWindowId!, SLPSMode.userGenerated.rawValue)
                 self.makeKeyWindow(&psn)
                 try? self.axUiElement!.focusWindow()
+                // Public-API safety net for apps where the private SLPS call above silently
+                // half-fails: it activates the app at the menu-bar level and the AX raise
+                // updates focus state, but the window never actually rises visually above
+                // other apps' windows. This bites apps like Slack, Telegram, Teams, ChatGPT,
+                // Notion, etc., especially after their window has been closed (red ✕) and
+                // reopened, or when switching very quickly to a newly-opened window.
+                //
+                // Since macOS Sonoma / Sequoia, the system applies focus-stealing prevention
+                // to window-raise requests that don't carry an activation token. Our private
+                // path doesn't carry one, so the system silently drops the visual raise.
+                // NSRunningApplication.activate does carry a proper token, so the system
+                // honours the raise.
+                //
+                // Because _SLPSSetFrontProcessWithOptions above has already designated our
+                // target cgWindowId as the app's frontmost window, calling activate() here
+                // only raises that one window — it does not bring all of the app's windows
+                // forward. See #3747, #4192.
+                //
+                // Must run on the main thread: NSRunningApplication.activate's internal
+                // yield step takes a fast path on main but blocks for up to a second when
+                // called off-main.
+                DispatchQueue.main.async { [weak self] in
+                    self?.application.runningApplication.activate(options: .activateIgnoringOtherApps)
+                }
                 DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
                     Windows.previewSelectedWindowIfNeeded()
                 }


### PR DESCRIPTION
Closes #3747 Refs #4192

Some apps (Slack, Telegram, Teams, ChatGPT, Notion, Spark, VSCode, IINA,
...) regularly fail to actually rise to the front when alt-tabbed to

The menu bar updates, AXApplicationActivated/AXFocusedWindowChanged
both fire for the target window, yet the window stays visually behind
whatever was in front. The bug is especially easy to hit right after the
app's window has been recreated (closed with red ✕ then reopened, or a
freshly-spawned window during fast alt-tab)

Since macOS Sonoma / Sequoia, the system applies focus-stealing
prevention to window-raise requests that don't carry an activation
token. Our existing private-API focus path doesn't carry one, so the
system silently drops the visual raise while still letting the cheaper
operations through (menu-bar activation, AX focus state).

Hence the "half-focused" symptom. The public
NSRunningApplication.activate path does carry a proper token, so the
system honours the raise

Fix: after the existing private SLPS + AX-raise sequence, also call
NSRunningApplication.activate(options: .activateIgnoringOtherApps).
Order matters: the SLPS call has already designated our target
cgWindowId as the app's frontmost window, so when activate() raises "the
app's frontmost window" only that one window comes forward

Not all of the app's windows. This avoids the side-effects that ruled
out earlier proposed fixes (PR #4581's AppleScript activate+reopen
spawned extra windows, and synthetic mouse-clicks broke fullscreen /
minimized / Stage Manager / hidden-app windows)

Threading note: NSRunningApplication.activate's internal yield
step takes a fast path on the main thread but blocks for up to
a second when called off-main, so the activate() call is hopped
to main with DispatchQueue.main.async, running it directly on
accessibilityCommandsQueue would stall a worker on every focus

The pre-existing private-API path is preserved, so the benefits it
brings (focusing minimized windows on other Spaces) still work. The
public activate() is purely a safety net for the apps where the private
path silently fails

