### PR TITLE
fix: Always show windows for "Active app" shortcut type

### DIFF
--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -215,7 +215,13 @@ class Preferences {
     static var all: [String: Any] { UserDefaults.standard.persistentDomain(forName: App.bundleIdentifier)! }
 
     static func onlyShowApplications() -> Bool {
-        return Preferences.showAppsOrWindows == .applications && Preferences.appearanceStyle != .thumbnails
+        guard Preferences.showAppsOrWindows == .applications && Preferences.appearanceStyle != .thumbnails else {
+            return false
+        }
+        guard App.shortcutIndex < Preferences.appsToShow.count else {
+            return true
+        }
+        return Preferences.appsToShow[App.shortcutIndex] != .active
     }
 
     /// key-above-tab is ` on US keyboard, but can be different on other keyboards


### PR DESCRIPTION
This PR is updating the behaviour of appearance "Application Icons" with "Show in switcher: Applications" to be ignored by shortcuts with scope of "Active app".

Fixes https://github.com/lwouis/alt-tab-macos/issues/5511