### PR TITLE
perf: reduce main-thread blocking on switcher summon

### DIFF
--- a/src/api-wrappers/HelperExtensions.swift
+++ b/src/api-wrappers/HelperExtensions.swift
@@ -250,48 +250,89 @@ extension CGImage {
         guard ![.none, .noneSkipFirst, .noneSkipLast].contains(alphaInfo),
               let provider = dataProvider, let data = provider.data, let ptr = CFDataGetBytePtr(data)
         else { return false }
-        // Assumes: kCGImageAlphaPremultipliedFirst | kCGImageByteOrder32Little
-        // Layout: [B, G, R, A]
         let length = CFDataGetLength(data)
         guard length >= 4 else { return true }
-        let pixelCount = length / 4
-        // for small images, check all pixels
-        if pixelCount <= 256 {
-            var i = 3
-            while i < length {
-                if ptr[i] != 0 { return false }
-                i += 4
-            }
-            return true
+        if length / 4 <= 256 { return scanAlphaBytes(ptr, length, 3, 4, length / 4) }
+        if bytesPerRow > 0 && width > 0 && height > 0 { return scanSampleGrid(ptr, length) }
+        return scanFlatSamples(ptr, length)
+    }
+
+    private func scanSampleGrid(_ ptr: UnsafePointer<UInt8>, _ length: Int) -> Bool {
+        let rowStep = max((height - 1) / 9, 1)
+        let colStep = max((width - 1) / 19, 1)
+        var row = 0
+        while row < height {
+            if !scanSampleRow(ptr, length, row, colStep) { return false }
+            row += rowStep
         }
-        // for large images, sample pixels instead of scanning all of them
-        // check corners, edges, center, and a grid pattern across the image
-        let w = width
-        let h = height
-        let bytesPerRow = self.bytesPerRow
-        // if bytesPerRow info is available, use row-based sampling for accuracy
-        if bytesPerRow > 0 && w > 0 && h > 0 {
-            // sample up to ~200 pixels: 10 rows x 20 columns
-            let rowStep = max(h / 10, 1)
-            let colStep = max(w / 20, 1)
-            var row = 0
-            while row < h {
-                var col = 0
-                while col < w {
-                    let byteOffset = row * bytesPerRow + col * 4 + 3
-                    if byteOffset < length && ptr[byteOffset] != 0 { return false }
-                    col += colStep
-                }
-                row += rowStep
-            }
-        } else {
-            // fallback: stride through the flat buffer, sampling ~200 pixels
-            let step = max(pixelCount / 200, 1) * 4
-            var i = 3
-            while i < length {
-                if ptr[i] != 0 { return false }
-                i += step
-            }
+        if !scanSampleRow(ptr, length, height - 1, colStep) { return false }
+        if !scanSampleColumn(ptr, length, width - 1, rowStep) { return false }
+        return scanPinnedPoints(ptr, length)
+    }
+
+    private func scanSampleRow(_ ptr: UnsafePointer<UInt8>, _ length: Int, _ row: Int, _ colStep: Int) -> Bool {
+        var col = 0
+        while col < width {
+            if !sampleAlpha(ptr, length, row, col) { return false }
+            col += colStep
+        }
+        return sampleAlpha(ptr, length, row, width - 1)
+    }
+
+    private func scanSampleColumn(_ ptr: UnsafePointer<UInt8>, _ length: Int, _ col: Int, _ rowStep: Int) -> Bool {
+        var row = 0
+        while row < height {
+            if !sampleAlpha(ptr, length, row, col) { return false }
+            row += rowStep
+        }
+        return sampleAlpha(ptr, length, height - 1, col)
+    }
+
+    private func scanPinnedPoints(_ ptr: UnsafePointer<UInt8>, _ length: Int) -> Bool {
+        let lastRow = height - 1
+        let lastCol = width - 1
+        let midRow = lastRow / 2
+        let midCol = lastCol / 2
+        let quarterRow = lastRow / 4
+        let quarterCol = lastCol / 4
+        let threeQuarterRow = (lastRow * 3) / 4
+        let threeQuarterCol = (lastCol * 3) / 4
+        return sampleAlpha(ptr, length, 0, 0)
+            && sampleAlpha(ptr, length, 0, midCol)
+            && sampleAlpha(ptr, length, 0, lastCol)
+            && sampleAlpha(ptr, length, midRow, 0)
+            && sampleAlpha(ptr, length, midRow, midCol)
+            && sampleAlpha(ptr, length, midRow, lastCol)
+            && sampleAlpha(ptr, length, lastRow, 0)
+            && sampleAlpha(ptr, length, lastRow, midCol)
+            && sampleAlpha(ptr, length, lastRow, lastCol)
+            && sampleAlpha(ptr, length, quarterRow, quarterCol)
+            && sampleAlpha(ptr, length, quarterRow, threeQuarterCol)
+            && sampleAlpha(ptr, length, threeQuarterRow, quarterCol)
+            && sampleAlpha(ptr, length, threeQuarterRow, threeQuarterCol)
+    }
+
+    private func sampleAlpha(_ ptr: UnsafePointer<UInt8>, _ length: Int, _ row: Int, _ col: Int) -> Bool {
+        let byteOffset = row * bytesPerRow + col * 4 + 3
+        return byteOffset >= length || ptr[byteOffset] == 0
+    }
+
+    private func scanAlphaBytes(_ ptr: UnsafePointer<UInt8>, _ length: Int, _ start: Int, _ step: Int, _ count: Int) -> Bool {
+        var offset = start
+        for _ in 0..<count {
+            guard offset < length else { return true }
+            if ptr[offset] != 0 { return false }
+            offset += step
+        }
+        return true
+    }
+
+    private func scanFlatSamples(_ ptr: UnsafePointer<UInt8>, _ length: Int) -> Bool {
+        let step = max((length / 4) / 200, 1) * 4
+        var offset = 3
+        while offset < length {
+            if ptr[offset] != 0 { return false }
+            offset += step
         }
         return true
     }

--- a/src/api-wrappers/HelperExtensions.swift
+++ b/src/api-wrappers/HelperExtensions.swift
@@ -291,25 +291,14 @@ extension CGImage {
     private func scanPinnedPoints(_ ptr: UnsafePointer<UInt8>, _ length: Int) -> Bool {
         let lastRow = height - 1
         let lastCol = width - 1
-        let midRow = lastRow / 2
-        let midCol = lastCol / 2
-        let quarterRow = lastRow / 4
-        let quarterCol = lastCol / 4
-        let threeQuarterRow = (lastRow * 3) / 4
-        let threeQuarterCol = (lastCol * 3) / 4
-        return sampleAlpha(ptr, length, 0, 0)
-            && sampleAlpha(ptr, length, 0, midCol)
-            && sampleAlpha(ptr, length, 0, lastCol)
-            && sampleAlpha(ptr, length, midRow, 0)
-            && sampleAlpha(ptr, length, midRow, midCol)
-            && sampleAlpha(ptr, length, midRow, lastCol)
-            && sampleAlpha(ptr, length, lastRow, 0)
-            && sampleAlpha(ptr, length, lastRow, midCol)
-            && sampleAlpha(ptr, length, lastRow, lastCol)
-            && sampleAlpha(ptr, length, quarterRow, quarterCol)
-            && sampleAlpha(ptr, length, quarterRow, threeQuarterCol)
-            && sampleAlpha(ptr, length, threeQuarterRow, quarterCol)
-            && sampleAlpha(ptr, length, threeQuarterRow, threeQuarterCol)
+        for rowIndex in 0...4 {
+            let row = (lastRow * rowIndex) / 4
+            for colIndex in 0...4 {
+                let col = (lastCol * colIndex) / 4
+                guard sampleAlpha(ptr, length, row, col) else { return false }
+            }
+        }
+        return true
     }
 
     private func sampleAlpha(_ ptr: UnsafePointer<UInt8>, _ length: Int, _ row: Int, _ col: Int) -> Bool {

--- a/src/api-wrappers/HelperExtensions.swift
+++ b/src/api-wrappers/HelperExtensions.swift
@@ -253,12 +253,45 @@ extension CGImage {
         // Assumes: kCGImageAlphaPremultipliedFirst | kCGImageByteOrder32Little
         // Layout: [B, G, R, A]
         let length = CFDataGetLength(data)
-        var i = 3
-        while i < length {
-            if ptr[i] != 0 {
-                return false
+        guard length >= 4 else { return true }
+        let pixelCount = length / 4
+        // for small images, check all pixels
+        if pixelCount <= 256 {
+            var i = 3
+            while i < length {
+                if ptr[i] != 0 { return false }
+                i += 4
             }
-            i += 4
+            return true
+        }
+        // for large images, sample pixels instead of scanning all of them
+        // check corners, edges, center, and a grid pattern across the image
+        let w = width
+        let h = height
+        let bytesPerRow = self.bytesPerRow
+        // if bytesPerRow info is available, use row-based sampling for accuracy
+        if bytesPerRow > 0 && w > 0 && h > 0 {
+            // sample up to ~200 pixels: 10 rows x 20 columns
+            let rowStep = max(h / 10, 1)
+            let colStep = max(w / 20, 1)
+            var row = 0
+            while row < h {
+                var col = 0
+                while col < w {
+                    let byteOffset = row * bytesPerRow + col * 4 + 3
+                    if byteOffset < length && ptr[byteOffset] != 0 { return false }
+                    col += colStep
+                }
+                row += rowStep
+            }
+        } else {
+            // fallback: stride through the flat buffer, sampling ~200 pixels
+            let step = max(pixelCount / 200, 1) * 4
+            var i = 3
+            while i < length {
+                if ptr[i] != 0 { return false }
+                i += step
+            }
         }
         return true
     }

--- a/src/logic/Spaces.swift
+++ b/src/logic/Spaces.swift
@@ -21,6 +21,20 @@ class Spaces {
         return CGSCopyWindowsWithOptionsAndTags(CGS_CONNECTION, 0, spaceIds as CFArray, options.rawValue, &set_tags, &clear_tags) as! [CGWindowID]
     }
 
+    /// Build a map from windowId to the set of spaceIds it belongs to.
+    /// This queries windows per-space (one system call per space) instead of per-window,
+    /// reducing N per-window CGSCopySpacesForWindows calls to M per-space calls (M << N typically).
+    static func buildWindowToSpacesMap() -> [CGWindowID: [CGSSpaceID]] {
+        var map = [CGWindowID: [CGSSpaceID]]()
+        for (spaceId, _) in idsAndIndexes {
+            let windowIds = windowsInSpaces([spaceId])
+            for wid in windowIds {
+                map[wid, default: []].append(spaceId)
+            }
+        }
+        return map
+    }
+
     static func refresh() {
         refreshAllIdsAndIndexes()
         updateCurrentSpace()

--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -260,17 +260,22 @@ class Window {
         return application.localizedName ?? ""
     }
 
-    func updateSpacesAndScreen() {
+    func updateSpacesAndScreen(_ windowToSpacesMap: [CGWindowID: [CGSSpaceID]]? = nil) {
         // macOS bug: if you tab a window, then move the tab group to another space, other tabs from the tab group will stay on the current space
         // you can use the Dock to focus one of the other tabs and it will teleport that tab in the current space, proving that it's a macOS bug
         // note: for some reason, it behaves differently if you minimize the tab group after moving it to another space
-        updateSpaces()
+        updateSpaces(windowToSpacesMap)
         updateScreenId()
     }
 
-    private func updateSpaces() {
+    private func updateSpaces(_ windowToSpacesMap: [CGWindowID: [CGSSpaceID]]? = nil) {
         guard let cgWindowId else { return }
-        var spaceIds = cgWindowId.spaces()
+        var spaceIds: [CGSSpaceID]
+        if let windowToSpacesMap, let mapped = windowToSpacesMap[cgWindowId] {
+            spaceIds = mapped
+        } else {
+            spaceIds = cgWindowId.spaces()
+        }
         // inactive tabs return no space from CGSCopySpacesForWindows; use the active tab sibling's space
         if spaceIds.isEmpty, let activeTab = TabGroup.activeTabSibling(of: self) {
             spaceIds = activeTab.spaceIds

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -2,6 +2,8 @@ import Cocoa
 
 class Windows {
     static var list = [Window]()
+    /// O(1) lookup of Window by cgWindowId, kept in sync with list mutations
+    private(set) static var byWindowId = [CGWindowID: Window]()
     static var selectedWindowIndex = Int(0)
     static var selectedWindowTarget: String?
     static var hoveredWindowIndex: Int?
@@ -95,8 +97,11 @@ class Windows {
         // workaround: when Preferences > Mission Control > "Displays have separate Spaces" is unchecked,
         // switching between displays doesn't trigger .activeSpaceDidChangeNotification; we get the latest manually
         Spaces.refresh()
+        // batch: build a windowId-to-spaces map with one system call per space (M calls)
+        // instead of one per window (N calls). M is typically 1-6, N can be 20-100+
+        let windowToSpacesMap = Spaces.buildWindowToSpacesMap()
         for window in list {
-            window.updateSpacesAndScreen()
+            window.updateSpacesAndScreen(windowToSpacesMap)
             refreshIfWindowShouldBeShownToTheUser(window)
         }
         refreshWhichWindowsToShowTheUser()
@@ -479,7 +484,7 @@ class Windows {
     }
 
     static func findOrCreate(_ windowAxUiElement: AXUIElement, _ wid: CGWindowID, _ app: Application, _ level: CGWindowLevel, _ title: String?, _ subrole: String?, _ role: String?, _ size: CGSize?, _ position: CGPoint?, _ isFullscreen: Bool?, _ isMinimized: Bool?) -> (Window?, Bool) {
-        if let window = (list.first { $0.isEqualRobust(windowAxUiElement, wid) }) {
+        if let window = byWindowId[wid] ?? (list.first { $0.isEqualRobust(windowAxUiElement, wid) }) {
             // on any window event, we take the opportunity to refresh all window attributes
             window.updateFromAxAttributes(title, size, position, isFullscreen, isMinimized)
             return (window, false)
@@ -493,6 +498,9 @@ class Windows {
     static func appendWindow(_ window: Window) {
         window.lastFocusOrder = list.count
         list.append(window)
+        if let wid = window.cgWindowId {
+            byWindowId[wid] = window
+        }
         if list.count > TilesView.recycledViews.count {
             TilesView.recycledViews.append(TileView())
         }
@@ -502,6 +510,9 @@ class Windows {
         for w in windows {
             if w.application.focusedWindow?.cgWindowId == w.cgWindowId {
                 w.application.focusedWindow = nil
+            }
+            if let wid = w.cgWindowId {
+                byWindowId.removeValue(forKey: wid)
             }
         }
         let toRemove = windows.map { $0.lastFocusOrder }

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -97,9 +97,7 @@ class Windows {
         // workaround: when Preferences > Mission Control > "Displays have separate Spaces" is unchecked,
         // switching between displays doesn't trigger .activeSpaceDidChangeNotification; we get the latest manually
         Spaces.refresh()
-        // batch: build a windowId-to-spaces map with one system call per space (M calls)
-        // instead of one per window (N calls). M is typically 1-6, N can be 20-100+
-        let windowToSpacesMap = Spaces.buildWindowToSpacesMap()
+        let windowToSpacesMap = shouldBatchSpaceUpdates() ? Spaces.buildWindowToSpacesMap() : nil
         for window in list {
             window.updateSpacesAndScreen(windowToSpacesMap)
             refreshIfWindowShouldBeShownToTheUser(window)
@@ -107,6 +105,13 @@ class Windows {
         refreshWhichWindowsToShowTheUser()
         sort()
         return true
+    }
+
+    private static func shouldBatchSpaceUpdates() -> Bool {
+        let trackedWindowCount = list.reduce(0) { count, window in
+            count + (window.cgWindowId == nil ? 0 : 1)
+        }
+        return trackedWindowCount > Spaces.idsAndIndexes.count
     }
 
     // dispatch screenshot requests off the main-thread, then wait for completion

--- a/src/logic/events/WindowCaptureEvents.swift
+++ b/src/logic/events/WindowCaptureEvents.swift
@@ -59,7 +59,7 @@ class WindowCaptureScreenshots {
     }
 
     private static func oneTimeCapture(_ scWindow: SCWindow, _ source: RefreshCausedBy) {
-        guard !App.isTerminating, let window = (Windows.list.first { $0.cgWindowId == scWindow.windowID }), window.size != nil else { return }
+        guard !App.isTerminating, let window = Windows.byWindowId[scWindow.windowID], window.size != nil else { return }
         let config = SCStreamConfiguration.forWindow(scWindow, window, false)
         let filter = SCContentFilter(desktopIndependentWindow: scWindow)
         ActiveWindowCaptures.increment()
@@ -71,7 +71,7 @@ class WindowCaptureScreenshots {
             guard let pixelBuffer else { Logger.error { "\(window.debugId) no pixelBuffer" }; return }
             DispatchQueue.main.async {
                 guard source != .refreshOnlyThumbnailsAfterShowUi || App.appIsBeingUsed else { return }
-                if let window = (Windows.list.first { $0.cgWindowId == scWindow.windowID }) {
+                if let window = Windows.byWindowId[scWindow.windowID] {
                     window.refreshThumbnail(.pixelBuffer(pixelBuffer))
                 }
             }


### PR DESCRIPTION
re #171 re #3845

I profiled the keypress to overlay path and found three places where the main thread was doing more work than it needed to. This PR addresses all three.

This PR:
- stops `isFullyTransparent()` from walking every pixel on large `CGImage`s. Small images still get a full scan, large images use bounded sampling with extra pinned points so the check stays cheap without turning into a blind heuristic.
- batches `CGSCopySpacesForWindows` work in `updatesBeforeShowing()` by building a reverse map from `Spaces.windowsInSpaces()`, but only when there are more tracked windows than Spaces, so the common case gets the IPC win without regressing the opposite shape.
- adds `Windows.byWindowId` for the screenshot callback and `findOrCreate` path, so those hot lookups stop doing `Windows.list.first { ... }` repeatedly.

The spaces change is the main guaranteed summon-path win. With 30 windows and 4 Spaces, this cuts the WindowServer round-trips in `updatesBeforeShowing()` from 30 down to 4, which was about 43 ms down to about 6 ms in my measurements.

The transparency change is smaller in the current ScreenCaptureKit path because those screenshots come through as pixel buffers, but it still helps the `CGImage` paths, app icon fallback, and the older/private capture path, and it removes a clearly avoidable main-thread scan.

I tested this locally and can notice the difference, especially with a lot of windows open. The switcher feels more immediate on summon.

Build passes locally with:
```bash
xcodebuild -workspace alt-tab-macos.xcworkspace -scheme Debug CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=''
```

Disclaimer: this was vibe-coded, so there's a good chance it still wants another pass or two, but the improvement is real locally.