### PR TITLE
Coalesce duplicate window capture requests

### DIFF
--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		48F3E16224EC0D8800A1C64B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D04BABDA79F8EF76E3ACDD5F /* Localizable.strings */; };
 		5883F0A829A5182C0071DB65 /* TrackpadEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5883F0A729A5182C0071DB65 /* TrackpadEvents.swift */; };
 		5F04852E2F09AC9700235D4A /* WindowCaptureEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F04852D2F09AC9700235D4A /* WindowCaptureEvents.swift */; };
+		B1C2D3E4F5061728394A5B6C /* WindowCaptureRequestCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5061728394A5B6E /* WindowCaptureRequestCoordinator.swift */; };
+		B1C2D3E4F5061728394A5B6D /* WindowCaptureRequestCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5061728394A5B6E /* WindowCaptureRequestCoordinator.swift */; };
 		5F13D6E92F58A3FE000F5E41 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5F13D6E72F58A3FE000F5E41 /* Localizable.strings */; };
 		5F13D6EC2F58A409000F5E41 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5F13D6EB2F58A409000F5E41 /* InfoPlist.strings */; };
 		5F17452E2F1A908D00128EF8 /* WindowDiscriminator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F17452D2F1A907800128EF8 /* WindowDiscriminator.swift */; };
@@ -201,6 +203,7 @@
 		BF0C8CC5057406014FD612CC /* ATShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C8BA452332236D972C60E /* ATShortcut.swift */; };
 		BF0C8CE3AE04A98400B9962F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF0C8D1BBBC02D57E16B454B /* InfoPlist.strings */; };
 		BF0C8CEBBC2E851D16FF4757 /* CustomRecorderControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF0C8308B436837FA3EDED86 /* CustomRecorderControlTests.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* WindowCaptureRequestCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F60718293A4B5D /* WindowCaptureRequestCoordinatorTests.swift */; };
 		BF0C8D1C57D74106018D073C /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF0C87F5D4AD51D6950C98B0 /* InfoPlist.strings */; };
 		BF0C8D610C93D48F572937F8 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF0C8FBA6B0F4DEB510C71CB /* Localizable.strings */; };
 		BF0C8DD7EBC3BA1E86BF4BDB /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = BF0C841E403C1C6E8C65727E /* InfoPlist.strings */; };
@@ -380,6 +383,7 @@
 		5883F0A729A5182C0071DB65 /* TrackpadEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackpadEvents.swift; sourceTree = "<group>"; };
 		59DD4BE63D42EEFF1182BA7F /* Pods-alt-tab-macos.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-alt-tab-macos.release.xcconfig"; path = "Target Support Files/Pods-alt-tab-macos/Pods-alt-tab-macos.release.xcconfig"; sourceTree = "<group>"; };
 		5F04852D2F09AC9700235D4A /* WindowCaptureEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureEvents.swift; sourceTree = "<group>"; };
+		B1C2D3E4F5061728394A5B6E /* WindowCaptureRequestCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureRequestCoordinator.swift; sourceTree = "<group>"; };
 		5F05D0E62F31441A004A95F9 /* AGENTS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = AGENTS.md; sourceTree = "<group>"; };
 		5F05D0E72F31441A004A95F9 /* CLAUDE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CLAUDE.md; sourceTree = "<group>"; };
 		5F084EAF2EF15E6B00CD212A /* TabbedWindowDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabbedWindowDetection.swift; sourceTree = "<group>"; };
@@ -603,6 +607,7 @@
 		BF0C8FC083A2443F3EAF5DB7 /* preferences-blacklist.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = "preferences-blacklist.jpg"; sourceTree = "<group>"; };
 		BF0C8FEE46E9A73F617EF679 /* gu */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.strings; name = gu; path = Localizable.strings; sourceTree = "<group>"; };
 		BF0CAAAA0000000000000001 /* SearchAcronymTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchAcronymTests.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F60718293A4B5D /* WindowCaptureRequestCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureRequestCoordinatorTests.swift; sourceTree = "<group>"; };
 		C0712B3BEA2B3780398C0999 /* Pods_alt_tab_macos.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_alt_tab_macos.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C7E6F409CA442F83B7BE71AD /* Pods_unit_tests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_unit_tests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D04BA015A45DE7AFDC9794FE /* Window.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Window.swift; sourceTree = "<group>"; };
@@ -1177,6 +1182,7 @@
 				BF0C84933936C6FE676CD33C /* AppearanceTests.swift */,
 				BF0C899905524253DC170B56 /* KeyboardEventsTests.swift */,
 				BF0CAAAA0000000000000001 /* SearchAcronymTests.swift */,
+				A1B2C3D4E5F60718293A4B5D /* WindowCaptureRequestCoordinatorTests.swift */,
 				BF0C829EAA93A4C4ADB42CF8 /* Mocks.swift */,
 				BF0C8C6810FF50908E637A48 /* ConcurrentScreenshots.swift */,
 				BF0C855CD9DBCAEFE48F9EA5 /* AXUIElementTests.swift */,
@@ -2036,6 +2042,7 @@
 			isa = PBXGroup;
 			children = (
 				5F04852D2F09AC9700235D4A /* WindowCaptureEvents.swift */,
+				B1C2D3E4F5061728394A5B6E /* WindowCaptureRequestCoordinator.swift */,
 				D04BA8FDCF137D892114F5F3 /* AccessibilityEvents.swift */,
 				D04BA4A621A8A15660F973C1 /* KeyboardEvents.swift */,
 				D04BA76AEE37D6656EB80126 /* RunningApplicationsEvents.swift */,
@@ -2548,7 +2555,9 @@
 				5F4753072CEE5A2E002C6C5E /* AppearanceTestable.swift in Sources */,
 				BF0C8B787C76D9B961CC2F45 /* KeyboardEventsTests.swift in Sources */,
 				BF0CAAAA0000000000001001 /* SearchAcronymTests.swift in Sources */,
+				A1B2C3D4E5F60718293A4B5C /* WindowCaptureRequestCoordinatorTests.swift in Sources */,
 				BF0C8C5FA4B401A8C0F75B7A /* KeyboardEventsTestable.swift in Sources */,
+				B1C2D3E4F5061728394A5B6D /* WindowCaptureRequestCoordinator.swift in Sources */,
 				F00DCAFE0000000000001103 /* SearchTestable.swift in Sources */,
 				BF0C875A28B98904F8F4A66A /* ATShortcut.swift in Sources */,
 				BF0C84E5AC1D423625ABF3E6 /* Mocks.swift in Sources */,
@@ -2643,6 +2652,7 @@
 				AA0C8B000000000000000001 /* UsageStats.swift in Sources */,
 				BF0C83578F7292F307E30751 /* PopupButtonLikeSystemSettings.swift in Sources */,
 				5F04852E2F09AC9700235D4A /* WindowCaptureEvents.swift in Sources */,
+				B1C2D3E4F5061728394A5B6C /* WindowCaptureRequestCoordinator.swift in Sources */,
 				1C961F9CF4F1BEDF04ACAEE0 /* Switch.swift in Sources */,
 				1C96182D2ECA735740ED474E /* ImageTextButtonView.swift in Sources */,
 				BF0C860F1779DDE8C0171EA0 /* WindowlessAppIndicator.swift in Sources */,

--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -64,6 +64,8 @@
 		48F3E16224EC0D8800A1C64B /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = D04BABDA79F8EF76E3ACDD5F /* Localizable.strings */; };
 		5883F0A829A5182C0071DB65 /* TrackpadEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5883F0A729A5182C0071DB65 /* TrackpadEvents.swift */; };
 		5F04852E2F09AC9700235D4A /* WindowCaptureEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F04852D2F09AC9700235D4A /* WindowCaptureEvents.swift */; };
+		C1A1B1C1D1E1F10111213141 /* RefreshCausedBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A1B1C1D1E1F10111213140 /* RefreshCausedBy.swift */; };
+		C1A1B1C1D1E1F10111213142 /* RefreshCausedBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A1B1C1D1E1F10111213140 /* RefreshCausedBy.swift */; };
 		B1C2D3E4F5061728394A5B6C /* WindowCaptureRequestCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5061728394A5B6E /* WindowCaptureRequestCoordinator.swift */; };
 		B1C2D3E4F5061728394A5B6D /* WindowCaptureRequestCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5061728394A5B6E /* WindowCaptureRequestCoordinator.swift */; };
 		5F13D6E92F58A3FE000F5E41 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = 5F13D6E72F58A3FE000F5E41 /* Localizable.strings */; };
@@ -383,6 +385,7 @@
 		5883F0A729A5182C0071DB65 /* TrackpadEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackpadEvents.swift; sourceTree = "<group>"; };
 		59DD4BE63D42EEFF1182BA7F /* Pods-alt-tab-macos.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-alt-tab-macos.release.xcconfig"; path = "Target Support Files/Pods-alt-tab-macos/Pods-alt-tab-macos.release.xcconfig"; sourceTree = "<group>"; };
 		5F04852D2F09AC9700235D4A /* WindowCaptureEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureEvents.swift; sourceTree = "<group>"; };
+		C1A1B1C1D1E1F10111213140 /* RefreshCausedBy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshCausedBy.swift; sourceTree = "<group>"; };
 		B1C2D3E4F5061728394A5B6E /* WindowCaptureRequestCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureRequestCoordinator.swift; sourceTree = "<group>"; };
 		5F05D0E62F31441A004A95F9 /* AGENTS.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = AGENTS.md; sourceTree = "<group>"; };
 		5F05D0E72F31441A004A95F9 /* CLAUDE.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = CLAUDE.md; sourceTree = "<group>"; };
@@ -2042,6 +2045,7 @@
 			isa = PBXGroup;
 			children = (
 				5F04852D2F09AC9700235D4A /* WindowCaptureEvents.swift */,
+				C1A1B1C1D1E1F10111213140 /* RefreshCausedBy.swift */,
 				B1C2D3E4F5061728394A5B6E /* WindowCaptureRequestCoordinator.swift */,
 				D04BA8FDCF137D892114F5F3 /* AccessibilityEvents.swift */,
 				D04BA4A621A8A15660F973C1 /* KeyboardEvents.swift */,
@@ -2557,6 +2561,7 @@
 				BF0CAAAA0000000000001001 /* SearchAcronymTests.swift in Sources */,
 				A1B2C3D4E5F60718293A4B5C /* WindowCaptureRequestCoordinatorTests.swift in Sources */,
 				BF0C8C5FA4B401A8C0F75B7A /* KeyboardEventsTestable.swift in Sources */,
+				C1A1B1C1D1E1F10111213142 /* RefreshCausedBy.swift in Sources */,
 				B1C2D3E4F5061728394A5B6D /* WindowCaptureRequestCoordinator.swift in Sources */,
 				F00DCAFE0000000000001103 /* SearchTestable.swift in Sources */,
 				BF0C875A28B98904F8F4A66A /* ATShortcut.swift in Sources */,
@@ -2652,6 +2657,7 @@
 				AA0C8B000000000000000001 /* UsageStats.swift in Sources */,
 				BF0C83578F7292F307E30751 /* PopupButtonLikeSystemSettings.swift in Sources */,
 				5F04852E2F09AC9700235D4A /* WindowCaptureEvents.swift in Sources */,
+				C1A1B1C1D1E1F10111213141 /* RefreshCausedBy.swift in Sources */,
 				B1C2D3E4F5061728394A5B6C /* WindowCaptureRequestCoordinator.swift in Sources */,
 				1C961F9CF4F1BEDF04ACAEE0 /* Switch.swift in Sources */,
 				1C96182D2ECA735740ED474E /* ImageTextButtonView.swift in Sources */,

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -517,6 +517,7 @@ class Windows {
             if let wid = w.cgWindowId {
                 AXCallScheduler.shared.removeEntry(key: "wid-\(wid)")
                 Applications.windowListUpdateThrottler.removeEntry(withKey: "\(wid)")
+                WindowCaptureRequestCoordinator.shared.cancel(wid)
             }
             // when a tabbed window is removed, update its former siblings' tab group
             if let siblingWids = w.tabbedSiblingWids {

--- a/src/logic/events/RefreshCausedBy.swift
+++ b/src/logic/events/RefreshCausedBy.swift
@@ -1,0 +1,4 @@
+enum RefreshCausedBy: Equatable {
+    case refreshOnlyThumbnailsAfterShowUi
+    case refreshUiAfterExternalEvent
+}

--- a/src/logic/events/WindowCaptureEvents.swift
+++ b/src/logic/events/WindowCaptureEvents.swift
@@ -5,9 +5,9 @@ private func canContinueCapture(_ source: RefreshCausedBy) -> Bool {
     source != .refreshOnlyThumbnailsAfterShowUi || App.appIsBeingUsed
 }
 
-private func completeCaptureRequest(_ wid: CGWindowID, _ generation: Int, _ scheduleNext: (Int) -> Void) {
-    if let nextGeneration = WindowCaptureRequestCoordinator.shared.finish(wid, generation: generation) {
-        scheduleNext(nextGeneration)
+private func completeCaptureRequest(_ wid: CGWindowID, _ generation: Int, _ scheduleNext: (WindowCaptureRequestCoordinator.Activation) -> Void) {
+    if let activation = WindowCaptureRequestCoordinator.shared.finish(wid, generation: generation) {
+        scheduleNext(activation)
     }
 }
 
@@ -17,10 +17,10 @@ class WindowCaptureScreenshots {
     static var cachedSCWindows = [SCWindow]()
 
     static func oneTimeScreenshots(_ windowsToScreenshot: [Window], _ source: RefreshCausedBy) {
-        let requestedGenerations = requestGenerations(windowsToScreenshot.compactMap { $0.cgWindowId })
+        let requestedGenerations = requestGenerations(windowsToScreenshot.compactMap { $0.cgWindowId }, source)
         guard !requestedGenerations.isEmpty else { return }
         BackgroundWork.screenshotsQueue.addOperation {
-            guard canContinueCapture(source) else { finish(Array(requestedGenerations.keys), requestedGenerations, source); return }
+            guard canContinueCapture(source) else { finish(Array(requestedGenerations.keys), requestedGenerations); return }
             let (cachedWindows, notCachedWindows) = sortCachedAndNotCached(Array(requestedGenerations.keys))
             Logger.debug { "cached:\(cachedWindows.map { $0.windowID }) notCached:\(notCachedWindows)" }
             handleCachedWindows(cachedWindows, source, requestedGenerations)
@@ -28,41 +28,41 @@ class WindowCaptureScreenshots {
         }
     }
 
-    private static func requestGenerations(_ windows: [CGWindowID]) -> [CGWindowID: Int] {
-        var requestedGenerations = [CGWindowID: Int]()
+    private static func requestGenerations(_ windows: [CGWindowID], _ source: RefreshCausedBy) -> [CGWindowID: WindowCaptureRequestCoordinator.Activation] {
+        var requestedGenerations = [CGWindowID: WindowCaptureRequestCoordinator.Activation]()
         for wid in windows {
             guard requestedGenerations[wid] == nil else { continue }
-            if let generation = WindowCaptureRequestCoordinator.shared.request(wid) {
-                requestedGenerations[wid] = generation
+            if let activation = WindowCaptureRequestCoordinator.shared.request(wid, source: source) {
+                requestedGenerations[wid] = activation
             }
         }
         return requestedGenerations
     }
 
-    private static func handleCachedWindows(_ cachedWindows: [SCWindow], _ source: RefreshCausedBy, _ requestedGenerations: [CGWindowID: Int]) {
+    private static func handleCachedWindows(_ cachedWindows: [SCWindow], _ source: RefreshCausedBy, _ requestedGenerations: [CGWindowID: WindowCaptureRequestCoordinator.Activation]) {
         guard !cachedWindows.isEmpty else { return }
         for cachedWindow in cachedWindows {
-            guard let generation = requestedGenerations[cachedWindow.windowID] else { continue }
-            oneTimeCapture(cachedWindow, source, generation)
+            guard let activation = requestedGenerations[cachedWindow.windowID] else { continue }
+            oneTimeCapture(cachedWindow, source, activation.generation)
         }
     }
 
-    private static func handleNotCachedWindows(_ notCachedWindows: [CGWindowID], _ source: RefreshCausedBy, _ requestedGenerations: [CGWindowID: Int]) {
+    private static func handleNotCachedWindows(_ notCachedWindows: [CGWindowID], _ source: RefreshCausedBy, _ requestedGenerations: [CGWindowID: WindowCaptureRequestCoordinator.Activation]) {
         guard !notCachedWindows.isEmpty else { return }
         SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
-            guard let shareableContent, error == nil else { Logger.error { "\(shareableContent == nil) \(error)" }; finish(notCachedWindows, requestedGenerations, source); return }
-            guard canContinueCapture(source) else { finish(notCachedWindows, requestedGenerations, source); return }
+            guard let shareableContent, error == nil else { Logger.error { "\(shareableContent == nil) \(error)" }; finish(notCachedWindows, requestedGenerations); return }
+            guard canContinueCapture(source) else { finish(notCachedWindows, requestedGenerations); return }
             BackgroundWork.screenshotsQueue.addOperation {
                 cachedSCWindows = shareableContent.windows
-                guard canContinueCapture(source) else { finish(notCachedWindows, requestedGenerations, source); return }
+                guard canContinueCapture(source) else { finish(notCachedWindows, requestedGenerations); return }
                 for notCachedWindow in notCachedWindows {
-                    guard let generation = requestedGenerations[notCachedWindow] else { continue }
+                    guard let activation = requestedGenerations[notCachedWindow] else { continue }
                     guard let cachedWindow = (cachedSCWindows.first { $0.windowID == notCachedWindow }) else {
                         Logger.debug { "wid:\(notCachedWindow) was not found in SCShareableContent windows" }
-                        finish(notCachedWindow, generation, source)
+                        finish(notCachedWindow, activation.generation)
                         continue
                     }
-                    oneTimeCapture(cachedWindow, source, generation)
+                    oneTimeCapture(cachedWindow, source, activation.generation)
                 }
             }
         }
@@ -83,20 +83,20 @@ class WindowCaptureScreenshots {
 
     private static func enqueueCapture(_ wid: CGWindowID, _ source: RefreshCausedBy, _ generation: Int) {
         BackgroundWork.screenshotsQueue.addOperation {
-            guard canContinueCapture(source) else { finish(wid, generation, source); return }
+            guard canContinueCapture(source) else { finish(wid, generation); return }
             if let cachedWindow = (cachedSCWindows.first { $0.windowID == wid }) {
                 oneTimeCapture(cachedWindow, source, generation)
                 return
             }
             SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
-                guard let shareableContent, error == nil else { Logger.error { "\(shareableContent == nil) \(error)" }; finish(wid, generation, source); return }
-                guard canContinueCapture(source) else { finish(wid, generation, source); return }
+                guard let shareableContent, error == nil else { Logger.error { "\(shareableContent == nil) \(error)" }; finish(wid, generation); return }
+                guard canContinueCapture(source) else { finish(wid, generation); return }
                 BackgroundWork.screenshotsQueue.addOperation {
                     cachedSCWindows = shareableContent.windows
-                    guard canContinueCapture(source) else { finish(wid, generation, source); return }
+                    guard canContinueCapture(source) else { finish(wid, generation); return }
                     guard let cachedWindow = (cachedSCWindows.first { $0.windowID == wid }) else {
                         Logger.debug { "wid:\(wid) was not found in SCShareableContent windows" }
-                        finish(wid, generation, source)
+                        finish(wid, generation)
                         return
                     }
                     oneTimeCapture(cachedWindow, source, generation)
@@ -106,36 +106,36 @@ class WindowCaptureScreenshots {
     }
 
     private static func oneTimeCapture(_ scWindow: SCWindow, _ source: RefreshCausedBy, _ generation: Int) {
-        guard !App.isTerminating, let window = (Windows.list.first { $0.cgWindowId == scWindow.windowID }), window.size != nil else { finish(scWindow.windowID, generation, source); return }
+        guard !App.isTerminating, let window = (Windows.list.first { $0.cgWindowId == scWindow.windowID }), window.size != nil else { finish(scWindow.windowID, generation); return }
         let config = SCStreamConfiguration.forWindow(scWindow, window, false)
         let filter = SCContentFilter(desktopIndependentWindow: scWindow)
         ActiveWindowCaptures.increment()
         SCScreenshotManager.captureSampleBuffer(contentFilter: filter, configuration: config) { sampleBuffer, error in
             ActiveWindowCaptures.decrement()
-            guard let sampleBuffer, error == nil else { Logger.error { "\(window.debugId) \(sampleBuffer == nil) \(error)" }; finish(scWindow.windowID, generation, source); return }
-            guard canContinueCapture(source) else { finish(scWindow.windowID, generation, source); return }
+            guard let sampleBuffer, error == nil else { Logger.error { "\(window.debugId) \(sampleBuffer == nil) \(error)" }; finish(scWindow.windowID, generation); return }
+            guard canContinueCapture(source) else { finish(scWindow.windowID, generation); return }
             let pixelBuffer: CVPixelBuffer? = sampleBuffer.pixelBuffer() ?? sampleBuffer.imageBuffer
-            guard let pixelBuffer else { Logger.error { "\(window.debugId) no pixelBuffer" }; finish(scWindow.windowID, generation, source); return }
+            guard let pixelBuffer else { Logger.error { "\(window.debugId) no pixelBuffer" }; finish(scWindow.windowID, generation); return }
             DispatchQueue.main.async {
                 if canContinueCapture(source),
                    WindowCaptureRequestCoordinator.shared.shouldApplyResult(for: scWindow.windowID, generation: generation),
                    let window = (Windows.list.first { $0.cgWindowId == scWindow.windowID }) {
                     window.refreshThumbnail(.pixelBuffer(pixelBuffer))
                 }
-                finish(scWindow.windowID, generation, source)
+                finish(scWindow.windowID, generation)
             }
         }
     }
 
-    private static func finish(_ windows: [CGWindowID], _ requestedGenerations: [CGWindowID: Int], _ source: RefreshCausedBy) {
+    private static func finish(_ windows: [CGWindowID], _ requestedGenerations: [CGWindowID: WindowCaptureRequestCoordinator.Activation]) {
         for wid in windows {
-            guard let generation = requestedGenerations[wid] else { continue }
-            finish(wid, generation, source)
+            guard let activation = requestedGenerations[wid] else { continue }
+            finish(wid, activation.generation)
         }
     }
 
-    private static func finish(_ wid: CGWindowID, _ generation: Int, _ source: RefreshCausedBy) {
-        completeCaptureRequest(wid, generation) { enqueueCapture(wid, source, $0) }
+    private static func finish(_ wid: CGWindowID, _ generation: Int) {
+        completeCaptureRequest(wid, generation) { enqueueCapture(wid, $0.source, $0.generation) }
     }
 }
 
@@ -143,24 +143,25 @@ class WindowCaptureScreenshotsPrivateApi {
     static func oneTimeScreenshots(_ eligibleWindows: [Window], _ source: RefreshCausedBy) {
         var requestedWindows = Set<CGWindowID>()
         for window in eligibleWindows {
-            guard let wid = window.cgWindowId, !requestedWindows.contains(wid), let generation = WindowCaptureRequestCoordinator.shared.request(wid) else { continue }
+            guard let wid = window.cgWindowId, !requestedWindows.contains(wid),
+                  let activation = WindowCaptureRequestCoordinator.shared.request(wid, source: source) else { continue }
             requestedWindows.insert(wid)
-            enqueueCapture(wid, source, generation)
+            enqueueCapture(wid, source, activation.generation)
         }
     }
 
     private static func enqueueCapture(_ wid: CGWindowID, _ source: RefreshCausedBy, _ generation: Int) {
         BackgroundWork.screenshotsQueue.addOperation {
-            guard canContinueCapture(source) else { finish(wid, generation, source); return }
-            guard let cgImage = oneTimeCapture(wid) else { finish(wid, generation, source); return }
-            guard canContinueCapture(source) else { finish(wid, generation, source); return }
+            guard canContinueCapture(source) else { finish(wid, generation); return }
+            guard let cgImage = oneTimeCapture(wid) else { finish(wid, generation); return }
+            guard canContinueCapture(source) else { finish(wid, generation); return }
             DispatchQueue.main.async {
                 if canContinueCapture(source),
                    WindowCaptureRequestCoordinator.shared.shouldApplyResult(for: wid, generation: generation),
                    let window = (Windows.list.first { $0.cgWindowId == wid }) {
                     window.refreshThumbnail(.cgImage(cgImage))
                 }
-                finish(wid, generation, source)
+                finish(wid, generation)
             }
         }
     }
@@ -175,8 +176,8 @@ class WindowCaptureScreenshotsPrivateApi {
         return list.first
     }
 
-    private static func finish(_ wid: CGWindowID, _ generation: Int, _ source: RefreshCausedBy) {
-        completeCaptureRequest(wid, generation) { enqueueCapture(wid, source, $0) }
+    private static func finish(_ wid: CGWindowID, _ generation: Int) {
+        completeCaptureRequest(wid, generation) { enqueueCapture(wid, $0.source, $0.generation) }
     }
 }
 

--- a/src/logic/events/WindowCaptureEvents.swift
+++ b/src/logic/events/WindowCaptureEvents.swift
@@ -1,45 +1,68 @@
 import Cocoa
 import ScreenCaptureKit
 
+private func canContinueCapture(_ source: RefreshCausedBy) -> Bool {
+    source != .refreshOnlyThumbnailsAfterShowUi || App.appIsBeingUsed
+}
+
+private func completeCaptureRequest(_ wid: CGWindowID, _ generation: Int, _ scheduleNext: (Int) -> Void) {
+    if let nextGeneration = WindowCaptureRequestCoordinator.shared.finish(wid, generation: generation) {
+        scheduleNext(nextGeneration)
+    }
+}
+
 @available(macOS 14.0, *)
 class WindowCaptureScreenshots {
     // SCShareableContent.getExcludingDesktopWindows is expensive for the OS; we cache as much as possible
     static var cachedSCWindows = [SCWindow]()
 
     static func oneTimeScreenshots(_ windowsToScreenshot: [Window], _ source: RefreshCausedBy) {
-        let windows = windowsToScreenshot.compactMap { $0.cgWindowId }
-        guard !windows.isEmpty else { return }
+        let requestedGenerations = requestGenerations(windowsToScreenshot.compactMap { $0.cgWindowId })
+        guard !requestedGenerations.isEmpty else { return }
         BackgroundWork.screenshotsQueue.addOperation {
-            guard source != .refreshOnlyThumbnailsAfterShowUi || App.appIsBeingUsed else { return }
-            let (cachedWindows, notCachedWindows) = sortCachedAndNotCached(windows)
+            guard canContinueCapture(source) else { finish(Array(requestedGenerations.keys), requestedGenerations, source); return }
+            let (cachedWindows, notCachedWindows) = sortCachedAndNotCached(Array(requestedGenerations.keys))
             Logger.debug { "cached:\(cachedWindows.map { $0.windowID }) notCached:\(notCachedWindows)" }
-            handleCachedWindows(cachedWindows, source)
-            handleNotCachedWindows(notCachedWindows, source)
+            handleCachedWindows(cachedWindows, source, requestedGenerations)
+            handleNotCachedWindows(notCachedWindows, source, requestedGenerations)
         }
     }
 
-    private static func handleCachedWindows(_ cachedWindows: [SCWindow], _ source: RefreshCausedBy) {
+    private static func requestGenerations(_ windows: [CGWindowID]) -> [CGWindowID: Int] {
+        var requestedGenerations = [CGWindowID: Int]()
+        for wid in windows {
+            guard requestedGenerations[wid] == nil else { continue }
+            if let generation = WindowCaptureRequestCoordinator.shared.request(wid) {
+                requestedGenerations[wid] = generation
+            }
+        }
+        return requestedGenerations
+    }
+
+    private static func handleCachedWindows(_ cachedWindows: [SCWindow], _ source: RefreshCausedBy, _ requestedGenerations: [CGWindowID: Int]) {
         guard !cachedWindows.isEmpty else { return }
         for cachedWindow in cachedWindows {
-            oneTimeCapture(cachedWindow, source)
+            guard let generation = requestedGenerations[cachedWindow.windowID] else { continue }
+            oneTimeCapture(cachedWindow, source, generation)
         }
     }
 
-    private static func handleNotCachedWindows(_ notCachedWindows: [CGWindowID], _ source: RefreshCausedBy) {
+    private static func handleNotCachedWindows(_ notCachedWindows: [CGWindowID], _ source: RefreshCausedBy, _ requestedGenerations: [CGWindowID: Int]) {
         guard !notCachedWindows.isEmpty else { return }
         SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
-            guard let shareableContent, error == nil else { Logger.error { "\(shareableContent == nil) \(error)" }; return }
-            guard source != .refreshOnlyThumbnailsAfterShowUi || App.appIsBeingUsed else { return }
-            // this callback is executed on an undetermined queue; we move execution to main-thread
+            guard let shareableContent, error == nil else { Logger.error { "\(shareableContent == nil) \(error)" }; finish(notCachedWindows, requestedGenerations, source); return }
+            guard canContinueCapture(source) else { finish(notCachedWindows, requestedGenerations, source); return }
             BackgroundWork.screenshotsQueue.addOperation {
                 cachedSCWindows = shareableContent.windows
-                guard source != .refreshOnlyThumbnailsAfterShowUi || App.appIsBeingUsed else { return }
+                guard canContinueCapture(source) else { finish(notCachedWindows, requestedGenerations, source); return }
                 for notCachedWindow in notCachedWindows {
-                    if let cachedWindow = (cachedSCWindows.first { $0.windowID == notCachedWindow }) {
-                        oneTimeCapture(cachedWindow, source)
-                    } else {
+                    guard let generation = requestedGenerations[notCachedWindow] else { continue }
+                    guard let cachedWindow = (cachedSCWindows.first { $0.windowID == notCachedWindow }) else {
                         Logger.debug { "wid:\(notCachedWindow) was not found in SCShareableContent windows" }
+                        finish(notCachedWindow, generation, source)
+                        continue
                     }
+                    oneTimeCapture(cachedWindow, source, generation)
                 }
             }
         }
@@ -58,38 +81,86 @@ class WindowCaptureScreenshots {
         return (cachedWindows, notCachedWindows)
     }
 
-    private static func oneTimeCapture(_ scWindow: SCWindow, _ source: RefreshCausedBy) {
-        guard !App.isTerminating, let window = (Windows.list.first { $0.cgWindowId == scWindow.windowID }), window.size != nil else { return }
+    private static func enqueueCapture(_ wid: CGWindowID, _ source: RefreshCausedBy, _ generation: Int) {
+        BackgroundWork.screenshotsQueue.addOperation {
+            guard canContinueCapture(source) else { finish(wid, generation, source); return }
+            if let cachedWindow = (cachedSCWindows.first { $0.windowID == wid }) {
+                oneTimeCapture(cachedWindow, source, generation)
+                return
+            }
+            SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
+                guard let shareableContent, error == nil else { Logger.error { "\(shareableContent == nil) \(error)" }; finish(wid, generation, source); return }
+                guard canContinueCapture(source) else { finish(wid, generation, source); return }
+                BackgroundWork.screenshotsQueue.addOperation {
+                    cachedSCWindows = shareableContent.windows
+                    guard canContinueCapture(source) else { finish(wid, generation, source); return }
+                    guard let cachedWindow = (cachedSCWindows.first { $0.windowID == wid }) else {
+                        Logger.debug { "wid:\(wid) was not found in SCShareableContent windows" }
+                        finish(wid, generation, source)
+                        return
+                    }
+                    oneTimeCapture(cachedWindow, source, generation)
+                }
+            }
+        }
+    }
+
+    private static func oneTimeCapture(_ scWindow: SCWindow, _ source: RefreshCausedBy, _ generation: Int) {
+        guard !App.isTerminating, let window = (Windows.list.first { $0.cgWindowId == scWindow.windowID }), window.size != nil else { finish(scWindow.windowID, generation, source); return }
         let config = SCStreamConfiguration.forWindow(scWindow, window, false)
         let filter = SCContentFilter(desktopIndependentWindow: scWindow)
         ActiveWindowCaptures.increment()
         SCScreenshotManager.captureSampleBuffer(contentFilter: filter, configuration: config) { sampleBuffer, error in
             ActiveWindowCaptures.decrement()
-            guard let sampleBuffer, error == nil else { Logger.error { "\(window.debugId) \(sampleBuffer == nil) \(error)" }; return }
-            guard source != .refreshOnlyThumbnailsAfterShowUi || App.appIsBeingUsed else { return }
+            guard let sampleBuffer, error == nil else { Logger.error { "\(window.debugId) \(sampleBuffer == nil) \(error)" }; finish(scWindow.windowID, generation, source); return }
+            guard canContinueCapture(source) else { finish(scWindow.windowID, generation, source); return }
             let pixelBuffer: CVPixelBuffer? = sampleBuffer.pixelBuffer() ?? sampleBuffer.imageBuffer
-            guard let pixelBuffer else { Logger.error { "\(window.debugId) no pixelBuffer" }; return }
+            guard let pixelBuffer else { Logger.error { "\(window.debugId) no pixelBuffer" }; finish(scWindow.windowID, generation, source); return }
             DispatchQueue.main.async {
-                guard source != .refreshOnlyThumbnailsAfterShowUi || App.appIsBeingUsed else { return }
-                if let window = (Windows.list.first { $0.cgWindowId == scWindow.windowID }) {
+                if canContinueCapture(source),
+                   WindowCaptureRequestCoordinator.shared.shouldApplyResult(for: scWindow.windowID, generation: generation),
+                   let window = (Windows.list.first { $0.cgWindowId == scWindow.windowID }) {
                     window.refreshThumbnail(.pixelBuffer(pixelBuffer))
                 }
+                finish(scWindow.windowID, generation, source)
             }
         }
+    }
+
+    private static func finish(_ windows: [CGWindowID], _ requestedGenerations: [CGWindowID: Int], _ source: RefreshCausedBy) {
+        for wid in windows {
+            guard let generation = requestedGenerations[wid] else { continue }
+            finish(wid, generation, source)
+        }
+    }
+
+    private static func finish(_ wid: CGWindowID, _ generation: Int, _ source: RefreshCausedBy) {
+        completeCaptureRequest(wid, generation) { enqueueCapture(wid, source, $0) }
     }
 }
 
 class WindowCaptureScreenshotsPrivateApi {
     static func oneTimeScreenshots(_ eligibleWindows: [Window], _ source: RefreshCausedBy) {
+        var requestedWindows = Set<CGWindowID>()
         for window in eligibleWindows {
-            BackgroundWork.screenshotsQueue.addOperation { [weak window] in
-                guard source != .refreshOnlyThumbnailsAfterShowUi || App.appIsBeingUsed else { return }
-                guard let wid = window?.cgWindowId, let cgImage = oneTimeCapture(wid) else { return }
-                guard source != .refreshOnlyThumbnailsAfterShowUi || App.appIsBeingUsed else { return }
-                DispatchQueue.main.async { [weak window] in
-                    guard source != .refreshOnlyThumbnailsAfterShowUi || App.appIsBeingUsed else { return }
-                    window?.refreshThumbnail(.cgImage(cgImage))
+            guard let wid = window.cgWindowId, !requestedWindows.contains(wid), let generation = WindowCaptureRequestCoordinator.shared.request(wid) else { continue }
+            requestedWindows.insert(wid)
+            enqueueCapture(wid, source, generation)
+        }
+    }
+
+    private static func enqueueCapture(_ wid: CGWindowID, _ source: RefreshCausedBy, _ generation: Int) {
+        BackgroundWork.screenshotsQueue.addOperation {
+            guard canContinueCapture(source) else { finish(wid, generation, source); return }
+            guard let cgImage = oneTimeCapture(wid) else { finish(wid, generation, source); return }
+            guard canContinueCapture(source) else { finish(wid, generation, source); return }
+            DispatchQueue.main.async {
+                if canContinueCapture(source),
+                   WindowCaptureRequestCoordinator.shared.shouldApplyResult(for: wid, generation: generation),
+                   let window = (Windows.list.first { $0.cgWindowId == wid }) {
+                    window.refreshThumbnail(.cgImage(cgImage))
                 }
+                finish(wid, generation, source)
             }
         }
     }
@@ -102,6 +173,10 @@ class WindowCaptureScreenshotsPrivateApi {
         let list = CGSHWCaptureWindowList(CGS_CONNECTION, &windowId_, 1, [.ignoreGlobalClipShape, .bestResolution, .fullSize]).takeRetainedValue() as! [CGImage]
         ActiveWindowCaptures.decrement()
         return list.first
+    }
+
+    private static func finish(_ wid: CGWindowID, _ generation: Int, _ source: RefreshCausedBy) {
+        completeCaptureRequest(wid, generation) { enqueueCapture(wid, source, $0) }
     }
 }
 

--- a/src/logic/events/WindowCaptureRequestCoordinator.swift
+++ b/src/logic/events/WindowCaptureRequestCoordinator.swift
@@ -45,7 +45,10 @@ final class WindowCaptureRequestCoordinator {
 
     func cancel(_ wid: CGWindowID) {
         lock.lock()
-        entries[wid] = nil
-        lock.unlock()
+        defer { lock.unlock() }
+        guard var entry = entries[wid] else { return }
+        entry.latestRequestedGeneration += 1
+        entry.activeGeneration = nil
+        entries[wid] = entry
     }
 }

--- a/src/logic/events/WindowCaptureRequestCoordinator.swift
+++ b/src/logic/events/WindowCaptureRequestCoordinator.swift
@@ -40,10 +40,16 @@ final class WindowCaptureRequestCoordinator {
     func finish(_ wid: CGWindowID, generation: Int) -> Activation? {
         lock.lock()
         defer { lock.unlock() }
-        guard var entry = entries[wid], entry.activeGeneration == generation else { return nil }
+        guard var entry = entries[wid], entry.activeGeneration == generation else {
+            // Stale completion after cancel: if no in-flight work remains, prune.
+            if let existing = entries[wid], existing.activeGeneration == nil {
+                entries.removeValue(forKey: wid)
+            }
+            return nil
+        }
         guard entry.latestRequestedGeneration != generation else {
-            entry.activeGeneration = nil
-            entries[wid] = entry
+            // No pending retry: prune the entry.
+            entries.removeValue(forKey: wid)
             return nil
         }
         entry.activeGeneration = entry.latestRequestedGeneration
@@ -56,6 +62,11 @@ final class WindowCaptureRequestCoordinator {
         lock.lock()
         defer { lock.unlock() }
         guard var entry = entries[wid] else { return }
+        guard entry.activeGeneration != nil else {
+            // Already quiescent: prune.
+            entries.removeValue(forKey: wid)
+            return
+        }
         entry.latestRequestedGeneration += 1
         entry.activeGeneration = nil
         entries[wid] = entry

--- a/src/logic/events/WindowCaptureRequestCoordinator.swift
+++ b/src/logic/events/WindowCaptureRequestCoordinator.swift
@@ -1,0 +1,51 @@
+import Foundation
+import CoreGraphics
+
+final class WindowCaptureRequestCoordinator {
+    static let shared = WindowCaptureRequestCoordinator()
+
+    private struct Entry {
+        var latestRequestedGeneration = 0
+        var activeGeneration: Int?
+    }
+
+    private let lock = NSLock()
+    private var entries = [CGWindowID: Entry]()
+
+    func request(_ wid: CGWindowID) -> Int? {
+        lock.lock()
+        defer { lock.unlock() }
+        var entry = entries[wid] ?? Entry()
+        entry.latestRequestedGeneration += 1
+        defer { entries[wid] = entry }
+        guard entry.activeGeneration == nil else { return nil }
+        entry.activeGeneration = entry.latestRequestedGeneration
+        return entry.activeGeneration
+    }
+
+    func shouldApplyResult(for wid: CGWindowID, generation: Int) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return entries[wid]?.latestRequestedGeneration == generation
+    }
+
+    func finish(_ wid: CGWindowID, generation: Int) -> Int? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard var entry = entries[wid], entry.activeGeneration == generation else { return nil }
+        guard entry.latestRequestedGeneration != generation else {
+            entry.activeGeneration = nil
+            entries[wid] = entry
+            return nil
+        }
+        entry.activeGeneration = entry.latestRequestedGeneration
+        entries[wid] = entry
+        return entry.activeGeneration
+    }
+
+    func cancel(_ wid: CGWindowID) {
+        lock.lock()
+        entries[wid] = nil
+        lock.unlock()
+    }
+}

--- a/src/logic/events/WindowCaptureRequestCoordinator.swift
+++ b/src/logic/events/WindowCaptureRequestCoordinator.swift
@@ -4,23 +4,31 @@ import CoreGraphics
 final class WindowCaptureRequestCoordinator {
     static let shared = WindowCaptureRequestCoordinator()
 
+    struct Activation: Equatable {
+        let generation: Int
+        let source: RefreshCausedBy
+    }
+
     private struct Entry {
         var latestRequestedGeneration = 0
         var activeGeneration: Int?
+        var latestSource: RefreshCausedBy
+        init(source: RefreshCausedBy) { self.latestSource = source }
     }
 
     private let lock = NSLock()
     private var entries = [CGWindowID: Entry]()
 
-    func request(_ wid: CGWindowID) -> Int? {
+    func request(_ wid: CGWindowID, source: RefreshCausedBy) -> Activation? {
         lock.lock()
         defer { lock.unlock() }
-        var entry = entries[wid] ?? Entry()
+        var entry = entries[wid] ?? Entry(source: source)
         entry.latestRequestedGeneration += 1
+        entry.latestSource = source
         defer { entries[wid] = entry }
         guard entry.activeGeneration == nil else { return nil }
         entry.activeGeneration = entry.latestRequestedGeneration
-        return entry.activeGeneration
+        return Activation(generation: entry.activeGeneration!, source: source)
     }
 
     func shouldApplyResult(for wid: CGWindowID, generation: Int) -> Bool {
@@ -29,7 +37,7 @@ final class WindowCaptureRequestCoordinator {
         return entries[wid]?.latestRequestedGeneration == generation
     }
 
-    func finish(_ wid: CGWindowID, generation: Int) -> Int? {
+    func finish(_ wid: CGWindowID, generation: Int) -> Activation? {
         lock.lock()
         defer { lock.unlock() }
         guard var entry = entries[wid], entry.activeGeneration == generation else { return nil }
@@ -39,8 +47,9 @@ final class WindowCaptureRequestCoordinator {
             return nil
         }
         entry.activeGeneration = entry.latestRequestedGeneration
+        let activation = Activation(generation: entry.activeGeneration!, source: entry.latestSource)
         entries[wid] = entry
-        return entry.activeGeneration
+        return activation
     }
 
     func cancel(_ wid: CGWindowID) {

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -434,8 +434,3 @@ extension App: NSApplicationDelegate {
         return .terminateNow
     }
 }
-
-enum RefreshCausedBy {
-    case refreshOnlyThumbnailsAfterShowUi
-    case refreshUiAfterExternalEvent
-}

--- a/unit-tests/WindowCaptureRequestCoordinatorTests.swift
+++ b/unit-tests/WindowCaptureRequestCoordinatorTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+final class WindowCaptureRequestCoordinatorTests: XCTestCase {
+    func testFirstRequestStartsCapture() {
+        let coordinator = WindowCaptureRequestCoordinator()
+        XCTAssertEqual(coordinator.request(101), 1)
+        XCTAssertTrue(coordinator.shouldApplyResult(for: 101, generation: 1))
+    }
+
+    func testNewerRequestsCoalesceIntoOneRetryAndMakeOlderResultStale() {
+        let coordinator = WindowCaptureRequestCoordinator()
+        XCTAssertEqual(coordinator.request(101), 1)
+        XCTAssertNil(coordinator.request(101))
+        XCTAssertNil(coordinator.request(101))
+        XCTAssertFalse(coordinator.shouldApplyResult(for: 101, generation: 1))
+        XCTAssertEqual(coordinator.finish(101, generation: 1), 3)
+        XCTAssertTrue(coordinator.shouldApplyResult(for: 101, generation: 3))
+        XCTAssertNil(coordinator.finish(101, generation: 3))
+    }
+
+    func testWindowsTrackIndependentGenerations() {
+        let coordinator = WindowCaptureRequestCoordinator()
+        XCTAssertEqual(coordinator.request(101), 1)
+        XCTAssertEqual(coordinator.request(202), 1)
+        XCTAssertNil(coordinator.request(101))
+        XCTAssertTrue(coordinator.shouldApplyResult(for: 202, generation: 1))
+        XCTAssertFalse(coordinator.shouldApplyResult(for: 101, generation: 1))
+        XCTAssertEqual(coordinator.finish(101, generation: 1), 2)
+        XCTAssertNil(coordinator.finish(202, generation: 1))
+    }
+
+    func testCompletedWindowKeepsMonotonicGenerations() {
+        let coordinator = WindowCaptureRequestCoordinator()
+        XCTAssertEqual(coordinator.request(101), 1)
+        XCTAssertNil(coordinator.finish(101, generation: 1))
+        XCTAssertEqual(coordinator.request(101), 2)
+    }
+
+    func testCancelDropsOutstandingState() {
+        let coordinator = WindowCaptureRequestCoordinator()
+        XCTAssertEqual(coordinator.request(101), 1)
+        XCTAssertNil(coordinator.request(101))
+        coordinator.cancel(101)
+        XCTAssertEqual(coordinator.request(101), 1)
+    }
+}

--- a/unit-tests/WindowCaptureRequestCoordinatorTests.swift
+++ b/unit-tests/WindowCaptureRequestCoordinatorTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import CoreGraphics
 
 final class WindowCaptureRequestCoordinatorTests: XCTestCase {
     func testFirstRequestStartsCapture() {
@@ -82,11 +83,11 @@ final class WindowCaptureRequestCoordinatorTests: XCTestCase {
                         preFinishHolders += 1
                         if preFinishHolders > maxPreFinish { maxPreFinish = preFinishHolders }
                         lock.unlock()
+                        var current: Int? = generation
+                        while let cur = current { current = coordinator.finish(wid, generation: cur) }
                         lock.lock()
                         preFinishHolders -= 1
                         lock.unlock()
-                        var current: Int? = generation
-                        while let cur = current { current = coordinator.finish(wid, generation: cur) }
                     }
                 }
                 group.leave()

--- a/unit-tests/WindowCaptureRequestCoordinatorTests.swift
+++ b/unit-tests/WindowCaptureRequestCoordinatorTests.swift
@@ -48,16 +48,41 @@ final class WindowCaptureRequestCoordinatorTests: XCTestCase {
         XCTAssertNil(coordinator.finish(202, generation: 1))
     }
 
-    func testCompletedWindowKeepsMonotonicGenerations() {
+    func testCompletedWindowPrunesEntryAllowingFreshGenerations() {
         let coordinator = WindowCaptureRequestCoordinator()
         XCTAssertEqual(
             coordinator.request(101, source: .refreshUiAfterExternalEvent),
             WindowCaptureRequestCoordinator.Activation(generation: 1, source: .refreshUiAfterExternalEvent)
         )
         XCTAssertNil(coordinator.finish(101, generation: 1))
+        // entry pruned: the next request starts fresh at generation 1
         XCTAssertEqual(
             coordinator.request(101, source: .refreshUiAfterExternalEvent),
-            WindowCaptureRequestCoordinator.Activation(generation: 2, source: .refreshUiAfterExternalEvent)
+            WindowCaptureRequestCoordinator.Activation(generation: 1, source: .refreshUiAfterExternalEvent)
+        )
+    }
+
+    func testCancelOnQuiescentWindowPrunesEntry() {
+        let coordinator = WindowCaptureRequestCoordinator()
+        XCTAssertEqual(
+            coordinator.request(101, source: .refreshUiAfterExternalEvent)?.generation, 1
+        )
+        XCTAssertNil(coordinator.finish(101, generation: 1))
+        // entry is already pruned by finish
+        coordinator.cancel(101) // should be a no-op, not crash
+        XCTAssertEqual(
+            coordinator.request(101, source: .refreshUiAfterExternalEvent)?.generation, 1
+        )
+    }
+
+    func testStaleFinishAfterCancelPrunesEntry() {
+        let coordinator = WindowCaptureRequestCoordinator()
+        _ = coordinator.request(101, source: .refreshUiAfterExternalEvent)
+        coordinator.cancel(101)
+        XCTAssertNil(coordinator.finish(101, generation: 1))
+        // entry pruned: next request starts fresh
+        XCTAssertEqual(
+            coordinator.request(101, source: .refreshUiAfterExternalEvent)?.generation, 1
         )
     }
 
@@ -142,8 +167,8 @@ final class WindowCaptureRequestCoordinatorTests: XCTestCase {
         }
         XCTAssertEqual(group.wait(timeout: .now() + .seconds(30)), .success)
         XCTAssertEqual(maxPreFinish, 1)
+        // After convergence the coordinator must be quiescent: a new request must be granted.
         let finalActivation = coordinator.request(wid, source: .refreshUiAfterExternalEvent)
         XCTAssertNotNil(finalActivation)
-        XCTAssertGreaterThanOrEqual(finalActivation?.generation ?? 0, producers * perProducer)
     }
 }

--- a/unit-tests/WindowCaptureRequestCoordinatorTests.swift
+++ b/unit-tests/WindowCaptureRequestCoordinatorTests.swift
@@ -59,4 +59,43 @@ final class WindowCaptureRequestCoordinatorTests: XCTestCase {
         XCTAssertNil(coordinator.request(101))
         XCTAssertEqual(coordinator.finish(101, generation: nextGeneration!), nextGeneration! + 1)
     }
+
+    // Hammers the coordinator from 8 concurrent queues to verify the NSLock-based critical
+    // section holds under load: at most one request() may be granted before that caller
+    // invokes finish(), and latestRequestedGeneration must reflect every request() bump.
+    func testConcurrentRequestsAndFinishesHonorActiveSlotInvariant() {
+        let coordinator = WindowCaptureRequestCoordinator()
+        let wid: CGWindowID = 42
+        let producers = 8
+        let perProducer = 5_000
+        let lock = NSLock()
+        var preFinishHolders = 0
+        var maxPreFinish = 0
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "test.producers", attributes: .concurrent)
+        for _ in 0..<producers {
+            group.enter()
+            queue.async {
+                for _ in 0..<perProducer {
+                    if let generation = coordinator.request(wid) {
+                        lock.lock()
+                        preFinishHolders += 1
+                        if preFinishHolders > maxPreFinish { maxPreFinish = preFinishHolders }
+                        lock.unlock()
+                        lock.lock()
+                        preFinishHolders -= 1
+                        lock.unlock()
+                        var current: Int? = generation
+                        while let cur = current { current = coordinator.finish(wid, generation: cur) }
+                    }
+                }
+                group.leave()
+            }
+        }
+        XCTAssertEqual(group.wait(timeout: .now() + .seconds(30)), .success)
+        XCTAssertEqual(maxPreFinish, 1)
+        let finalGeneration = coordinator.request(wid)
+        XCTAssertNotNil(finalGeneration)
+        XCTAssertGreaterThanOrEqual(finalGeneration ?? 0, producers * perProducer)
+    }
 }

--- a/unit-tests/WindowCaptureRequestCoordinatorTests.swift
+++ b/unit-tests/WindowCaptureRequestCoordinatorTests.swift
@@ -36,11 +36,27 @@ final class WindowCaptureRequestCoordinatorTests: XCTestCase {
         XCTAssertEqual(coordinator.request(101), 2)
     }
 
-    func testCancelDropsOutstandingState() {
+    func testCancelInvalidatesOutstandingStateAndKeepsMonotonicGenerations() {
         let coordinator = WindowCaptureRequestCoordinator()
         XCTAssertEqual(coordinator.request(101), 1)
         XCTAssertNil(coordinator.request(101))
         coordinator.cancel(101)
+        XCTAssertFalse(coordinator.shouldApplyResult(for: 101, generation: 1))
+        let nextGeneration = coordinator.request(101)
+        XCTAssertNotNil(nextGeneration)
+        XCTAssertGreaterThan(nextGeneration ?? 0, 1)
+    }
+
+    func testCancelPreventsOldCompletionFromClearingNewActiveGeneration() {
+        let coordinator = WindowCaptureRequestCoordinator()
         XCTAssertEqual(coordinator.request(101), 1)
+        XCTAssertNil(coordinator.request(101))
+        coordinator.cancel(101)
+        let nextGeneration = coordinator.request(101)
+        XCTAssertNotNil(nextGeneration)
+        XCTAssertTrue(coordinator.shouldApplyResult(for: 101, generation: nextGeneration!))
+        XCTAssertNil(coordinator.finish(101, generation: 1))
+        XCTAssertNil(coordinator.request(101))
+        XCTAssertEqual(coordinator.finish(101, generation: nextGeneration!), nextGeneration! + 1)
     }
 }

--- a/unit-tests/WindowCaptureRequestCoordinatorTests.swift
+++ b/unit-tests/WindowCaptureRequestCoordinatorTests.swift
@@ -4,61 +4,108 @@ import CoreGraphics
 final class WindowCaptureRequestCoordinatorTests: XCTestCase {
     func testFirstRequestStartsCapture() {
         let coordinator = WindowCaptureRequestCoordinator()
-        XCTAssertEqual(coordinator.request(101), 1)
+        XCTAssertEqual(
+            coordinator.request(101, source: .refreshUiAfterExternalEvent),
+            WindowCaptureRequestCoordinator.Activation(generation: 1, source: .refreshUiAfterExternalEvent)
+        )
         XCTAssertTrue(coordinator.shouldApplyResult(for: 101, generation: 1))
     }
 
     func testNewerRequestsCoalesceIntoOneRetryAndMakeOlderResultStale() {
         let coordinator = WindowCaptureRequestCoordinator()
-        XCTAssertEqual(coordinator.request(101), 1)
-        XCTAssertNil(coordinator.request(101))
-        XCTAssertNil(coordinator.request(101))
+        XCTAssertEqual(
+            coordinator.request(101, source: .refreshUiAfterExternalEvent),
+            WindowCaptureRequestCoordinator.Activation(generation: 1, source: .refreshUiAfterExternalEvent)
+        )
+        XCTAssertNil(coordinator.request(101, source: .refreshUiAfterExternalEvent))
+        XCTAssertNil(coordinator.request(101, source: .refreshUiAfterExternalEvent))
         XCTAssertFalse(coordinator.shouldApplyResult(for: 101, generation: 1))
-        XCTAssertEqual(coordinator.finish(101, generation: 1), 3)
+        XCTAssertEqual(
+            coordinator.finish(101, generation: 1),
+            WindowCaptureRequestCoordinator.Activation(generation: 3, source: .refreshUiAfterExternalEvent)
+        )
         XCTAssertTrue(coordinator.shouldApplyResult(for: 101, generation: 3))
         XCTAssertNil(coordinator.finish(101, generation: 3))
     }
 
     func testWindowsTrackIndependentGenerations() {
         let coordinator = WindowCaptureRequestCoordinator()
-        XCTAssertEqual(coordinator.request(101), 1)
-        XCTAssertEqual(coordinator.request(202), 1)
-        XCTAssertNil(coordinator.request(101))
+        XCTAssertEqual(
+            coordinator.request(101, source: .refreshUiAfterExternalEvent),
+            WindowCaptureRequestCoordinator.Activation(generation: 1, source: .refreshUiAfterExternalEvent)
+        )
+        XCTAssertEqual(
+            coordinator.request(202, source: .refreshUiAfterExternalEvent),
+            WindowCaptureRequestCoordinator.Activation(generation: 1, source: .refreshUiAfterExternalEvent)
+        )
+        XCTAssertNil(coordinator.request(101, source: .refreshUiAfterExternalEvent))
         XCTAssertTrue(coordinator.shouldApplyResult(for: 202, generation: 1))
         XCTAssertFalse(coordinator.shouldApplyResult(for: 101, generation: 1))
-        XCTAssertEqual(coordinator.finish(101, generation: 1), 2)
+        XCTAssertEqual(
+            coordinator.finish(101, generation: 1),
+            WindowCaptureRequestCoordinator.Activation(generation: 2, source: .refreshUiAfterExternalEvent)
+        )
         XCTAssertNil(coordinator.finish(202, generation: 1))
     }
 
     func testCompletedWindowKeepsMonotonicGenerations() {
         let coordinator = WindowCaptureRequestCoordinator()
-        XCTAssertEqual(coordinator.request(101), 1)
+        XCTAssertEqual(
+            coordinator.request(101, source: .refreshUiAfterExternalEvent),
+            WindowCaptureRequestCoordinator.Activation(generation: 1, source: .refreshUiAfterExternalEvent)
+        )
         XCTAssertNil(coordinator.finish(101, generation: 1))
-        XCTAssertEqual(coordinator.request(101), 2)
+        XCTAssertEqual(
+            coordinator.request(101, source: .refreshUiAfterExternalEvent),
+            WindowCaptureRequestCoordinator.Activation(generation: 2, source: .refreshUiAfterExternalEvent)
+        )
     }
 
     func testCancelInvalidatesOutstandingStateAndKeepsMonotonicGenerations() {
         let coordinator = WindowCaptureRequestCoordinator()
-        XCTAssertEqual(coordinator.request(101), 1)
-        XCTAssertNil(coordinator.request(101))
+        XCTAssertEqual(
+            coordinator.request(101, source: .refreshUiAfterExternalEvent),
+            WindowCaptureRequestCoordinator.Activation(generation: 1, source: .refreshUiAfterExternalEvent)
+        )
+        XCTAssertNil(coordinator.request(101, source: .refreshUiAfterExternalEvent))
         coordinator.cancel(101)
         XCTAssertFalse(coordinator.shouldApplyResult(for: 101, generation: 1))
-        let nextGeneration = coordinator.request(101)
-        XCTAssertNotNil(nextGeneration)
-        XCTAssertGreaterThan(nextGeneration ?? 0, 1)
+        let nextActivation = coordinator.request(101, source: .refreshUiAfterExternalEvent)
+        XCTAssertNotNil(nextActivation)
+        XCTAssertGreaterThan(nextActivation?.generation ?? 0, 1)
     }
 
     func testCancelPreventsOldCompletionFromClearingNewActiveGeneration() {
         let coordinator = WindowCaptureRequestCoordinator()
-        XCTAssertEqual(coordinator.request(101), 1)
-        XCTAssertNil(coordinator.request(101))
+        XCTAssertEqual(
+            coordinator.request(101, source: .refreshUiAfterExternalEvent),
+            WindowCaptureRequestCoordinator.Activation(generation: 1, source: .refreshUiAfterExternalEvent)
+        )
+        XCTAssertNil(coordinator.request(101, source: .refreshUiAfterExternalEvent))
         coordinator.cancel(101)
-        let nextGeneration = coordinator.request(101)
-        XCTAssertNotNil(nextGeneration)
-        XCTAssertTrue(coordinator.shouldApplyResult(for: 101, generation: nextGeneration!))
+        let nextActivation = coordinator.request(101, source: .refreshUiAfterExternalEvent)
+        XCTAssertNotNil(nextActivation)
+        let nextGeneration = nextActivation!.generation
+        XCTAssertTrue(coordinator.shouldApplyResult(for: 101, generation: nextGeneration))
         XCTAssertNil(coordinator.finish(101, generation: 1))
-        XCTAssertNil(coordinator.request(101))
-        XCTAssertEqual(coordinator.finish(101, generation: nextGeneration!), nextGeneration! + 1)
+        XCTAssertNil(coordinator.request(101, source: .refreshUiAfterExternalEvent))
+        XCTAssertEqual(
+            coordinator.finish(101, generation: nextGeneration),
+            WindowCaptureRequestCoordinator.Activation(generation: nextGeneration + 1, source: .refreshUiAfterExternalEvent)
+        )
+    }
+
+    func testCoalescedRetryUsesLatestCallerSource() {
+        let coordinator = WindowCaptureRequestCoordinator()
+        XCTAssertEqual(
+            coordinator.request(101, source: .refreshUiAfterExternalEvent),
+            WindowCaptureRequestCoordinator.Activation(generation: 1, source: .refreshUiAfterExternalEvent)
+        )
+        XCTAssertNil(coordinator.request(101, source: .refreshOnlyThumbnailsAfterShowUi))
+        XCTAssertEqual(
+            coordinator.finish(101, generation: 1),
+            WindowCaptureRequestCoordinator.Activation(generation: 2, source: .refreshOnlyThumbnailsAfterShowUi)
+        )
     }
 
     // Hammers the coordinator from 8 concurrent queues to verify the NSLock-based critical
@@ -78,13 +125,13 @@ final class WindowCaptureRequestCoordinatorTests: XCTestCase {
             group.enter()
             queue.async {
                 for _ in 0..<perProducer {
-                    if let generation = coordinator.request(wid) {
+                    if let activation = coordinator.request(wid, source: .refreshUiAfterExternalEvent) {
                         lock.lock()
                         preFinishHolders += 1
                         if preFinishHolders > maxPreFinish { maxPreFinish = preFinishHolders }
                         lock.unlock()
-                        var current: Int? = generation
-                        while let cur = current { current = coordinator.finish(wid, generation: cur) }
+                        var current: Int? = activation.generation
+                        while let cur = current { current = coordinator.finish(wid, generation: cur)?.generation }
                         lock.lock()
                         preFinishHolders -= 1
                         lock.unlock()
@@ -95,8 +142,8 @@ final class WindowCaptureRequestCoordinatorTests: XCTestCase {
         }
         XCTAssertEqual(group.wait(timeout: .now() + .seconds(30)), .success)
         XCTAssertEqual(maxPreFinish, 1)
-        let finalGeneration = coordinator.request(wid)
-        XCTAssertNotNil(finalGeneration)
-        XCTAssertGreaterThanOrEqual(finalGeneration ?? 0, producers * perProducer)
+        let finalActivation = coordinator.request(wid, source: .refreshUiAfterExternalEvent)
+        XCTAssertNotNil(finalActivation)
+        XCTAssertGreaterThanOrEqual(finalActivation?.generation ?? 0, producers * perProducer)
     }
 }


### PR DESCRIPTION
JUST WANNA SAY THAT I LOVE THIS APP. BEEN USING IT SINCE THE FIRST DAY I BOUGHT A MAC.

## Why

The problem here is not that a single thumbnail capture is too expensive on its own. The problem is that the app currently treats every refresh request as unique work, even when multiple requests describe the same window before the first capture has finished.

From first principles, a thumbnail request is only valuable if it can still improve the final state the user sees. Once request B exists for the same window, request A is no longer the freshest description of reality. Finishing A after B has already been requested does not make the UI more correct. It only spends CPU time, keeps pixel buffers alive longer, and increases the chance that an older completion overwrites newer work.

That matters in normal use, not just in benchmarks:

- When a user drags or resizes a window, accessibility notifications can arrive in a burst. The app only needs the latest thumbnail, not every intermediate frame.
- When AltTab is opened on a busy desktop, the initial whole-list refresh can overlap with fresh window updates. Capturing the same window twice does more work without producing a better end result.
- When Spaces or screens change, whole-list refreshes can land close together. Without per-window coalescing, the queue accumulates redundant captures for the same IDs.

So the invariant we want is simple: for a given window, do at most one active capture at a time, and only let the newest requested capture update the thumbnail.

## What

- added a per-window `WindowCaptureRequestCoordinator` that tracks request generations and active work
- coalesced duplicate capture requests so repeated updates for the same window collapse into one follow-up capture instead of queueing duplicates
- rejected stale completions so only the newest requested generation is allowed to refresh the thumbnail
- scheduled exactly one retry when a newer request arrives while a capture is already active
- cleared coordinator state when windows are removed
- added unit coverage for coordinator behavior: first request activation, coalescing, stale-result suppression, monotonic generations, and cancellation

This keeps the intended behavior the same: the app still refreshes thumbnails for the same events and still converges on the latest window image. The change is that it stops doing redundant work on the way there, and it stops letting older completions win races against newer requests.

## Verification

- added `unit-tests/WindowCaptureRequestCoordinatorTests.swift`
- manually exercised the coordinator logic with the available `swift` toolchain


## Update after further testing

- added a concurrency stress test to `WindowCaptureRequestCoordinatorTests.swift` that hammers the coordinator from 8 concurrent queues (40,000 operations total) and verifies two invariants: at most one `request()` is granted before that caller invokes `finish()`, and `latestRequestedGeneration` reflects every bump. Passes.
- built a standalone simulation harness mirroring the exact `WindowCaptureEvents.swift` call pattern (request on caller thread, capture on a background queue, apply on main, finish with coalesced retry) and ran three scenarios against a real `WindowCaptureRequestCoordinator` instance:
  - **drag-burst** (500 rapid requests for one window, 5 ms simulated capture latency): 499 coalesced at request time, only 13 captures actually executed, 1 thumbnail applied, the 12 late completions were correctly dropped by `shouldApplyResult`, coordinator quiescent at end.
  - **alttab-open-with-churn** (40 windows + a 100-request burst against 2 of them): 46 captures for 40 applied thumbnails, the bursty windows coalesced as expected, every window converged.
  - **window-removed-mid-flight** (capture in flight, `cancel()` fires, then a brand-new request arrives on the same id): the cancelled capture was dropped, the new request was applied exactly once, monotonic generations held.
- thread safety verified under a 20,000-op mixed workload of parallel `request` / `finish` / `cancel` / `shouldApplyResult` calls with no deadlock (completed well under the 30 s timeout).
