### PR TITLE
fix: prevent unconditional permission request prompt

### DIFF
--- a/src/logic/SystemPermissions.swift
+++ b/src/logic/SystemPermissions.swift
@@ -102,8 +102,8 @@ class ScreenRecordingPermission {
 
     private static func detect() -> PermissionStatus {
         if #available(macOS 10.15, *) {
-            return isGrantedOnSomeDisplay() ? .granted :
-                (Preferences.screenRecordingPermissionSkipped ? .skipped : .notGranted)
+            guard !Preferences.screenRecordingPermissionSkipped else { return .skipped }
+            return isGrantedOnSomeDisplay() ? .granted : .notGranted
         }
         return .granted
     }


### PR DESCRIPTION
Fixes a bug I was experiencing where the app was asking for the Screen Recording permission on every launch, despite having the screen recording permission skipped as I only use the icon view.

## Summary
- `ScreenRecordingPermission.detect()` was calling `isGrantedOnSomeDisplay()`, which triggers the system "Screen Recording" permission prompt, before checking `screenRecordingPermissionSkipped`
- Effectively this meant that the prompt was already shown before the app could honour the user's skip preference, causing it to show on every launch

## Changes
- Moved the screenRecordingPermissionSkipped guard before the API call in detect(), so the prompt-triggering code path is never reached when the user has opted out

## Testing
- With "Use the app without this permission" unchecked: the system prompt no longer appears on launch
- With the preference not set: existing behavior (prompt shown) is unchanged