### PR TITLE
feat: allow triggering switcher backward with hold key + select-previous shortcut

### DIFF
--- a/resources/l10n/Localizable.strings
+++ b/resources/l10n/Localizable.strings
@@ -62,6 +62,9 @@
 "Alphabetical Order" = "Alphabetical Order";
 
 /* No comment provided by engineer. */
+"Also trigger with 'Select previous'" = "Also trigger with 'Select previous'";
+
+/* No comment provided by engineer. */
 "AltTab crashed last time you used it. Sending a crash report will help get the issue fixed" = "AltTab crashed last time you used it. Sending a crash report will help get the issue fixed";
 
 /* No comment provided by engineer. */

--- a/src/logic/ATShortcut.swift
+++ b/src/logic/ATShortcut.swift
@@ -50,7 +50,7 @@ class ATShortcut {
         // other shortcuts: contains exactly or exactly + holdShortcut modifiers
         let holdModifiersCleaned = ControlsTab.shortcuts[Preferences.indexToName("holdShortcut", App.shortcutIndex)]?.shortcut.carbonModifierFlags.cleaned() ?? 0
         // nextWindowShortcut when panel is open: also match base key without holdShortcut modifiers
-        if App.appIsBeingUsed && id.hasPrefix("nextWindowShortcut") {
+        if App.appIsBeingUsed && (id.hasPrefix("nextWindowShortcut") || id.hasPrefix("prevWindowShortcut")) {
             let baseModifiersCleaned = shortcutModifiersCleaned & ~holdModifiersCleaned
             if modifiersCleaned == baseModifiersCleaned {
                 return true

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -55,6 +55,7 @@ class Preferences {
         (0..<maxShortcutCount).forEach { index in
             values[indexToName("holdShortcut", index)] = defaultShortcut("⌥")
             values[indexToName("nextWindowShortcut", index)] = defaultShortcut(index == 0 ? "⇥" : (index == 1 ? keyAboveTabDependingOnInputSource() : ""))
+            values[indexToName("triggerWithPreviousWindow", index)] = "false"
         }
         (0...maxShortcutCount).forEach { index in
             values[indexToName("appsToShow", index)] = index == 1 ? AppsToShowPreference.active.indexAsString : (index == 2 ? AppsToShowPreference.nonActive.indexAsString : AppsToShowPreference.all.indexAsString)
@@ -86,6 +87,7 @@ class Preferences {
     // persisted values
     static var holdShortcut: [Shortcut?] { (0..<shortcutCount).map { CachedUserDefaults.shortcut(indexToName("holdShortcut", $0)) } }
     static var nextWindowShortcut: [Shortcut?] { (0..<shortcutCount).map { CachedUserDefaults.shortcut(indexToName("nextWindowShortcut", $0)) } }
+    static var triggerWithPreviousWindow: [Bool] { (0..<maxShortcutCount).map { CachedUserDefaults.bool(indexToName("triggerWithPreviousWindow", $0)) } }
     static var nextWindowGesture: GesturePreference { CachedUserDefaults.macroPref("nextWindowGesture", GesturePreference.allCases) }
     static var focusWindowShortcut: Shortcut? { CachedUserDefaults.shortcut("focusWindowShortcut") }
     static var previousWindowShortcut: Shortcut? { CachedUserDefaults.shortcut("previousWindowShortcut") }

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -214,7 +214,7 @@ class Windows {
         return shouldDisplay(window) ? window : nil
     }
 
-    static func setInitialSelectedAndHoveredWindowIndex() {
+    static func setInitialSelectedAndHoveredWindowIndex(backward: Bool = false) {
         let oldIndex = selectedWindowIndex
         selectedWindowIndex = 0
         selectedWindowTarget = nil
@@ -228,13 +228,17 @@ class Windows {
            let lastFocusedOrderWindowIndex = getLastFocusedOrderWindowIndex() {
             updateSelectedAndHoveredWindowIndex(lastFocusedOrderWindowIndex)
         } else {
-            // edge-case: when the 2 most recently focused windows are both minimized, select the first
-            if list.count >= 2 && list[0].isMinimized && list[1].isMinimized {
-                updateSelectedAndHoveredWindowIndex(0)
+            if backward {
+                cycleSelectedWindowIndex(-1)
             } else {
-                cycleSelectedWindowIndex(1)
-                if selectedWindowIndex == 0 {
+                // edge-case: when the 2 most recently focused windows are both minimized, select the first
+                if list.count >= 2 && list[0].isMinimized && list[1].isMinimized {
                     updateSelectedAndHoveredWindowIndex(0)
+                } else {
+                    cycleSelectedWindowIndex(1)
+                    if selectedWindowIndex == 0 {
+                        updateSelectedAndHoveredWindowIndex(0)
+                    }
                 }
             }
         }

--- a/src/logic/events/KeyboardEventsTestable.swift
+++ b/src/logic/events/KeyboardEventsTestable.swift
@@ -5,6 +5,7 @@ class KeyboardEventsTestable {
         var ids = [String: Int]()
         (0..<Preferences.maxShortcutCount).forEach { ids[Preferences.indexToName("nextWindowShortcut", $0)] = $0 }
         (0..<Preferences.maxShortcutCount).forEach { ids[Preferences.indexToName("holdShortcut", $0)] = Preferences.maxShortcutCount + $0 }
+        (0..<Preferences.maxShortcutCount).forEach { ids[Preferences.indexToName("prevWindowShortcut", $0)] = 2 * Preferences.maxShortcutCount + $0 }
         return ids
     }
 }

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -295,7 +295,7 @@ class App: AppCenterApplication {
         Applications.refreshBadgesAsync()
     }
 
-    static func showUiOrCycleSelection(_ shortcutIndex: Int, _ forceDoNothingOnRelease_: Bool) {
+    static func showUiOrCycleSelection(_ shortcutIndex: Int, _ forceDoNothingOnRelease_: Bool, backward: Bool = false) {
         forceDoNothingOnRelease = forceDoNothingOnRelease_
         Logger.debug { "isFirstSummon:\(isFirstSummon) shortcutIndex:\(shortcutIndex)" }
         appIsBeingUsed = true
@@ -314,7 +314,7 @@ class App: AppCenterApplication {
                 forceDoNothingOnRelease = true
             }
             if !Windows.updatesBeforeShowing() { hideUi(); return }
-            Windows.setInitialSelectedAndHoveredWindowIndex()
+            Windows.setInitialSelectedAndHoveredWindowIndex(backward: backward)
             if Preferences.windowDisplayDelay == DispatchTimeInterval.milliseconds(0) {
                 buildUiAndShowPanel()
             } else {

--- a/src/ui/settings-window/tabs/controls/ControlsTab.swift
+++ b/src/ui/settings-window/tabs/controls/ControlsTab.swift
@@ -137,6 +137,7 @@ class ControlsTab {
     ]
     static var arrowKeysCheckbox: Switch!
     static var vimKeysCheckbox: Switch!
+    private static var triggerBackwardLabels = [Int: NSTextField]()
 
     static var shortcutsWhenActiveSheet: ShortcutsWhenActiveSheet!
     static var additionalControlsSheet: AdditionalControlsSheet!
@@ -154,7 +155,7 @@ class ControlsTab {
         "closeWindowShortcut", "minDeminWindowShortcut", "toggleFullscreenWindowShortcut", "quitAppShortcut", "hideShowAppShortcut",
     ]
     private static let removableShortcutPreferences = [
-        "holdShortcut", "nextWindowShortcut",
+        "holdShortcut", "nextWindowShortcut", "triggerWithPreviousWindow",
         "appsToShow", "spacesToShow", "screensToShow",
         "showMinimizedWindows", "showHiddenWindows", "showFullscreenWindows", "showWindowlessApps",
         "windowOrder", "shortcutStyle",
@@ -205,6 +206,12 @@ class ControlsTab {
                 removeShortcutIfExists(k)
             }
             refreshShortcutRows()
+        case let k where k.hasPrefix("triggerWithPreviousWindow"):
+            let i = Preferences.nameToIndex(k)
+            applyTriggerWithPreviousWindowPreference(i)
+        case "previousWindowShortcut":
+            (0..<Preferences.shortcutCount).forEach { applyTriggerWithPreviousWindowPreference($0) }
+            applyShortcutPreference("previousWindowShortcut")
         case let k where staticManagedShortcutPreferences.contains(k):
             applyShortcutPreference(k)
         case "arrowKeysEnabled":
@@ -373,7 +380,9 @@ class ControlsTab {
         holdShortcut.append(LabelAndControl.makeLabel(NSLocalizedString("and press", comment: "")))
         let nextName = Preferences.indexToName("nextWindowShortcut", index)
         let nextWindowShortcut = LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Select next window", comment: ""), nextName, Preferences.shortcut(nextName), labelPosition: .right)
-        return controlTab(index, holdShortcut + [nextWindowShortcut[0]], shortcutEditorContentWidth)
+        let triggerBackwardName = Preferences.indexToName("triggerWithPreviousWindow", index)
+        let triggerBackwardSwitch = LabelAndControl.makeSwitch(triggerBackwardName)
+        return controlTab(index, holdShortcut + [nextWindowShortcut[0]], triggerBackwardSwitch, shortcutEditorContentWidth)
     }
 
     private static func gestureTab(_ index: Int) -> TableGroupView {
@@ -395,6 +404,10 @@ class ControlsTab {
     }
 
     private static func controlTab(_ index: Int, _ trigger: [NSView], _ width: CGFloat) -> TableGroupView {
+        controlTab(index, trigger, nil, width)
+    }
+
+    private static func controlTab(_ index: Int, _ trigger: [NSView], _ triggerBackwardSwitch: Switch?, _ width: CGFloat) -> TableGroupView {
         let appsToShow = LabelAndControl.makeDropdown(Preferences.indexToName("appsToShow", index), AppsToShowPreference.allCases)
         let spacesToShow = LabelAndControl.makeDropdown(Preferences.indexToName("spacesToShow", index), SpacesToShowPreference.allCases)
         let screensToShow = LabelAndControl.makeDropdown(Preferences.indexToName("screensToShow", index), ScreensToShowPreference.allCases)
@@ -405,6 +418,11 @@ class ControlsTab {
         let windowOrder = LabelAndControl.makeDropdown(Preferences.indexToName("windowOrder", index), WindowOrderPreference.allCases)
         let table = TableGroupView(width: width)
         table.addRow(TableGroupView.Row(leftTitle: NSLocalizedString("Trigger", comment: ""), rightViews: trigger))
+        if let triggerBackwardSwitch {
+            let label = TableGroupView.makeText(triggerBackwardLabelText(index))
+            triggerBackwardLabels[index] = label
+            table.addRow(leftViews: [label], rightViews: [triggerBackwardSwitch])
+        }
         table.addNewTable()
         table.addRow(leftViews: [TableGroupView.makeText(NSLocalizedString("Show windows from applications", comment: ""))], rightViews: [appsToShow])
         table.addRow(leftViews: [TableGroupView.makeText(NSLocalizedString("Show windows from Spaces", comment: ""))], rightViews: [spacesToShow])
@@ -679,6 +697,7 @@ class ControlsTab {
                     removeShortcutIfExists(key)
                 }
             }
+            applyTriggerWithPreviousWindowPreference(index)
         }
     }
 
@@ -869,9 +888,37 @@ class ControlsTab {
         let i = Preferences.nameToIndex(controlId)
         guard let shortcut = Preferences.shortcut(controlId) else {
             removeShortcutIfExists(controlId)
+            applyTriggerWithPreviousWindowPreference(i)
             return
         }
         addShortcut(.up, .global, shortcut, controlId, i)
+        applyTriggerWithPreviousWindowPreference(i)
+    }
+
+    private static func applyTriggerWithPreviousWindowPreference(_ index: Int) {
+        let controlId = Preferences.indexToName("prevWindowShortcut", index)
+        refreshTriggerBackwardLabel(index)
+        guard index < Preferences.shortcutCount,
+              Preferences.triggerWithPreviousWindow[index],
+              let prevShortcut = Preferences.previousWindowShortcut else {
+            removeShortcutIfExists(controlId)
+            return
+        }
+        let holdShortcut = Preferences.shortcut(Preferences.indexToName("holdShortcut", index))
+        addShortcut(.down, .global, combineShortcuts(holdShortcut, prevShortcut), controlId, index)
+    }
+
+    private static func triggerBackwardLabelText(_ index: Int) -> String {
+        let base = NSLocalizedString("Also trigger with 'Select previous'", comment: "")
+        let holdShortcut = Preferences.shortcut(Preferences.indexToName("holdShortcut", index))
+        guard let prevShortcut = Preferences.previousWindowShortcut else { return base }
+        let hotkeyStr = combineShortcuts(holdShortcut, prevShortcut).keyEquivalent
+        guard !hotkeyStr.isEmpty else { return base }
+        return "\(base) (\(hotkeyStr))"
+    }
+
+    private static func refreshTriggerBackwardLabel(_ index: Int) {
+        triggerBackwardLabels[index]?.stringValue = triggerBackwardLabelText(index)
     }
 
     private static func combinedShortcut(_ controlId: String) -> Shortcut? {
@@ -933,6 +980,14 @@ class ControlsTab {
         }
         if action.hasPrefix("nextWindowShortcut") {
             App.showUiOrCycleSelection(Preferences.nameToIndex(action), false)
+        }
+        if action.hasPrefix("prevWindowShortcut") {
+            let index = Preferences.nameToIndex(action)
+            if App.appIsBeingUsed && App.shortcutIndex == index {
+                App.previousWindowShortcutWithRepeatingKey()
+            } else {
+                App.showUiOrCycleSelection(index, false, backward: true)
+            }
         }
     }
 }


### PR DESCRIPTION
### Motivation

On macOS, Cmd+Tab opens the app switcher forward and Cmd+Shift+Tab opens it backward. AltTab doesn't have an equivalent: you can only trigger the switcher in the forward direction. If you want to jump to the last window in the list, you have to open it first and then press the select-previous shortcut. This goes against muscle memory built from years of usage.

### What this PR adds

A per-shortcut toggle in Controls: "Also trigger with 'Select previous' (⌥⇧⇥)" (the hotkey shown is computed dynamically from your actual shortcuts).

When enabled, pressing your hold key + the "Select previous window" shortcut opens the switcher with the last window already selected, instead of the second. If the switcher is already open, the same combo cycles backward.

The option is off by default, so existing behavior is completely unchanged.

