### PR TITLE
fix: deminimize window when focusing minimized app in "App Icons" mode

### DIFF
--- a/src/logic/Window.swift
+++ b/src/logic/Window.swift
@@ -216,6 +216,12 @@ class Window {
                 }
             } else {
                 application.runningApplication.activate(options: .activateAllWindows)
+                if isMinimized, axUiElement != nil {
+                    BackgroundWork.accessibilityCommandsQueue.addOperation { [weak self] in
+                        guard let self else { return }
+                        try? self.axUiElement!.setAttribute(kAXMinimizedAttribute, false)
+                    }
+                }
             }
             Windows.previewSelectedWindowIfNeeded()
         } else {


### PR DESCRIPTION
I personally prefer App Icons mode but missed the behavior where selecting an app with a minimized window would bring it back up, so here's a fix for that.

**Problem:** In App Icons mode, selecting an app with a minimized window does nothing visible, the window stays minimized.

**Root cause:** The App Icons focus path calls activate(options: .activateAllWindows) which doesn't deminimize windows. Thumbnails mode works because axUiElement.focusWindow() (kAXRaiseAction) auto-deminimizes.

**Fix:** After activating the app, if the selected main window is minimized, explicitly set kAXMinimizedAttribute = false on the background accessibility queue. If an app has multiple windows (some open, some minimized), only the selected main window is affected, other minimized windows are left untouched.