### PR TITLE
feat: add global "focus previous window" shortcut

### DIFF
--- a/resources/l10n/Localizable.strings
+++ b/resources/l10n/Localizable.strings
@@ -212,6 +212,9 @@
 "Failed to import settings" = "Failed to import settings";
 
 /* No comment provided by engineer. */
+"Focus previous window" = "Focus previous window";
+
+/* No comment provided by engineer. */
 "Focus selected window" = "Focus selected window";
 
 /* No comment provided by engineer. */
@@ -222,6 +225,9 @@
 
 /* No comment provided by engineer. */
 "Gesture" = "Gesture";
+
+/* No comment provided by engineer. */
+"Global shortcuts" = "Global shortcuts";
 
 /* Menubar callout button */
 "Grant permission" = "Grant permission";

--- a/src/logic/Preferences.swift
+++ b/src/logic/Preferences.swift
@@ -8,6 +8,7 @@ class Preferences {
             "shortcutCount": "2",
             "nextWindowGesture": GesturePreference.disabled.indexAsString,
             "focusWindowShortcut": defaultShortcut(returnKeyEquivalent()),
+            "focusPreviousWindowShortcut": defaultShortcut(""),
             "previousWindowShortcut": defaultShortcut("⇧"),
             "cancelShortcut": defaultShortcut("⎋"),
             "lockSearchShortcut": defaultShortcut("Space"),
@@ -73,7 +74,7 @@ class Preferences {
     // system preferences
     static var finderShowsQuitMenuItem: Bool { UserDefaults(suiteName: "com.apple.Finder")?.bool(forKey: "QuitMenuItem") ?? false }
     static let staticShortcutKeys = [
-        "focusWindowShortcut", "previousWindowShortcut", "cancelShortcut", "lockSearchShortcut", "closeWindowShortcut",
+        "focusWindowShortcut", "focusPreviousWindowShortcut", "previousWindowShortcut", "cancelShortcut", "lockSearchShortcut", "closeWindowShortcut",
         "minDeminWindowShortcut", "toggleFullscreenWindowShortcut", "quitAppShortcut", "hideShowAppShortcut", "searchShortcut",
     ]
     static var allShortcutPreferenceKeys: [String] {
@@ -88,6 +89,7 @@ class Preferences {
     static var nextWindowShortcut: [Shortcut?] { (0..<shortcutCount).map { CachedUserDefaults.shortcut(indexToName("nextWindowShortcut", $0)) } }
     static var nextWindowGesture: GesturePreference { CachedUserDefaults.macroPref("nextWindowGesture", GesturePreference.allCases) }
     static var focusWindowShortcut: Shortcut? { CachedUserDefaults.shortcut("focusWindowShortcut") }
+    static var focusPreviousWindowShortcut: Shortcut? { CachedUserDefaults.shortcut("focusPreviousWindowShortcut") }
     static var previousWindowShortcut: Shortcut? { CachedUserDefaults.shortcut("previousWindowShortcut") }
     static var cancelShortcut: Shortcut? { CachedUserDefaults.shortcut("cancelShortcut") }
     static var lockSearchShortcut: Shortcut? { CachedUserDefaults.shortcut("lockSearchShortcut") }

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -141,6 +141,16 @@ class App: AppCenterApplication {
         focusSelectedWindow(selectedWindow)
     }
 
+    static func focusPreviousWindow() {
+        guard MissionControl.state() == .inactive || MissionControl.state() == .showDesktop else { return }
+        guard let window = (Windows.list.first { $0.lastFocusOrder == 1 }) else { return }
+        Logger.info { window.debugId }
+        window.focus()
+        if Preferences.cursorFollowFocus == .always {
+            moveCursorToSelectedWindow(window)
+        }
+    }
+
     @objc static func checkForUpdatesNow(_ sender: NSMenuItem) {
         GeneralTab.checkForUpdatesNow(sender)
     }

--- a/src/ui/settings-window/tabs/controls/AdditionalControlsSheet.swift
+++ b/src/ui/settings-window/tabs/controls/AdditionalControlsSheet.swift
@@ -2,6 +2,8 @@ import Cocoa
 
 class AdditionalControlsSheet: SheetWindow {
     override func makeContentView() -> NSView {
+        let focusPreviousWindowShortcut = TableGroupView.Row(leftTitle: NSLocalizedString("Focus previous window", comment: ""),
+            rightViews: [LabelAndControl.makeLabelWithRecorder(NSLocalizedString("Focus previous window", comment: ""), "focusPreviousWindowShortcut", Preferences.focusPreviousWindowShortcut, labelPosition: .right)[0]])
         let enableArrows = TableGroupView.Row(leftTitle: NSLocalizedString("Select windows using arrow keys", comment: ""),
             rightViews: [LabelAndControl.makeSwitch("arrowKeysEnabled", extraAction: ControlsTab.arrowKeysEnabledCallback)])
         let enableVimKeys = TableGroupView.Row(leftTitle: NSLocalizedString("Select windows using vim keys", comment: ""),
@@ -16,6 +18,9 @@ class AdditionalControlsSheet: SheetWindow {
         ControlsTab.vimKeysCheckbox = enableVimKeys.rightViews[0] as? Switch
         ControlsTab.arrowKeysEnabledCallback(ControlsTab.arrowKeysCheckbox)
         ControlsTab.vimKeysEnabledCallback(ControlsTab.vimKeysCheckbox)
+        let table0 = TableGroupView(title: NSLocalizedString("Global shortcuts", comment: ""),
+            width: SheetWindow.width)
+        _ = table0.addRow(focusPreviousWindowShortcut)
         let table1 = TableGroupView(title: NSLocalizedString("Additional controls", comment: ""),
             width: SheetWindow.width)
         _ = table1.addRow(enableArrows)
@@ -25,7 +30,7 @@ class AdditionalControlsSheet: SheetWindow {
             width: SheetWindow.width)
         _ = table2.addRow(enableCursorFollowFocus)
         _ = table2.addRow(enableTrackpadHapticFeedback)
-        let view = TableGroupSetView(originalViews: [table1, table2], padding: 0)
+        let view = TableGroupSetView(originalViews: [table0, table1, table2], padding: 0)
         return view
     }
 }

--- a/src/ui/settings-window/tabs/controls/ControlsTab.swift
+++ b/src/ui/settings-window/tabs/controls/ControlsTab.swift
@@ -117,6 +117,7 @@ class ControlsTab {
     static var shortcutControls = [String: (CustomRecorderControl, String)]()
     static var shortcutsActions = [
         "focusWindowShortcut": { App.focusTarget() },
+        "focusPreviousWindowShortcut": { App.focusPreviousWindow() },
         "previousWindowShortcut": { App.previousWindowShortcutWithRepeatingKey() },
         "→": { App.cycleSelection(.right) },
         "←": { App.cycleSelection(.left) },
@@ -150,9 +151,10 @@ class ControlsTab {
     private static var shortcutEditorContentWidth: CGFloat { shortcutEditorWidth - shortcutEditorRightPadding }
     private static let gestureSelectionIndex = -1
     private static let staticManagedShortcutPreferences = [
-        "focusWindowShortcut", "previousWindowShortcut", "cancelShortcut", "searchShortcut", "lockSearchShortcut",
+        "focusWindowShortcut", "focusPreviousWindowShortcut", "previousWindowShortcut", "cancelShortcut", "searchShortcut", "lockSearchShortcut",
         "closeWindowShortcut", "minDeminWindowShortcut", "toggleFullscreenWindowShortcut", "quitAppShortcut", "hideShowAppShortcut",
     ]
+    private static let globalStaticShortcutPreferences = ["focusPreviousWindowShortcut"]
     private static let removableShortcutPreferences = [
         "holdShortcut", "nextWindowShortcut",
         "appsToShow", "spacesToShow", "screensToShow",
@@ -690,6 +692,13 @@ class ControlsTab {
         SettingsWindow.shared.beginSheetWithSearchHighlight(additionalControlsSheet)
     }
 
+    private static func scopeForControlId(_ controlId: String) -> ShortcutScope {
+        if controlId.hasPrefix("nextWindowShortcut") || globalStaticShortcutPreferences.contains(controlId) {
+            return .global
+        }
+        return .local
+    }
+
     private static func addShortcut(_ triggerPhase: ShortcutTriggerPhase, _ scope: ShortcutScope, _ shortcut: Shortcut, _ controlId: String, _ index: Int?) {
         let atShortcut = ATShortcut(shortcut, controlId, scope, triggerPhase, index)
         removeShortcutIfExists(controlId)
@@ -738,7 +747,7 @@ class ControlsTab {
                 restrictModifiersOfHoldShortcut(controlId, [])
                 (sender as! CustomRecorderControl).objectValue = nil
             } else {
-                addShortcut(.down, controlId.hasPrefix("nextWindowShortcut") ? .global : .local, newShortcut!, controlId, nil)
+                addShortcut(.down, scopeForControlId(controlId), newShortcut!, controlId, nil)
                 restrictModifiersOfHoldShortcut(controlId, [(sender as! CustomRecorderControl).objectValue!.modifierFlags])
             }
         }
@@ -861,7 +870,7 @@ class ControlsTab {
             restrictModifiersOfHoldShortcut(controlId, [])
             return
         }
-        addShortcut(.down, controlId.hasPrefix("nextWindowShortcut") ? .global : .local, shortcut, controlId, nil)
+        addShortcut(.down, scopeForControlId(controlId), shortcut, controlId, nil)
         restrictModifiersOfHoldShortcut(controlId, [shortcut.modifierFlags])
     }
 


### PR DESCRIPTION
## Summary

Adds a single-chord global shortcut that instantly focuses the previously focused window **without** displaying the switcher UI — GNOME-style quick-flick / Windows-style tap-and-release behavior.

Under the hood the action mirrors the already-existing CLI path `AltTab --focusUsingLastFocusOrder=1` (see `src/logic/events/CliEvents.swift`). This PR just exposes the same behavior as a first-class configurable keybind so users don't need Raycast / Keyboard Maestro / skhd to glue it together.

Default binding is **empty** — users opt in by recording their own chord (e.g. `⌘+Esc`) to avoid shipping a surprise default that may clash with other apps.

## Where it lives

`Preferences → Controls → Additional controls…` — a new "Global shortcuts" section at the top of the sheet with a single recorder row: "Focus previous window".

Why the sheet and not the main tab: the sheet already hosts a multi-table layout (Additional controls, Miscellaneous), so adding a third table is ~7 lines; the main tab has a heavier sidebar+editor layout. Happy to move it if you'd prefer.

## Design choices

- **Scope `.global`, trigger phase `.down`** — fires from anywhere, immediately on press.
- **No UI shown** — the new action deliberately skips `focusTarget()` / `hideUi()`; it's a pure background focus-switch.
- **Mission Control guard** — copied from `focusSelectedWindow` to avoid focusing during Mission Control animations.
- **Honors `cursorFollowFocus == .always`** — consistent with the existing focus path.
- **Picks window with `lastFocusOrder == 1`** — same predicate the CLI flag uses.

## Changes

- `src/logic/Preferences.swift` — register `focusPreviousWindowShortcut` (default empty) + static accessor; add to `staticShortcutKeys`.
- `src/ui/App.swift` — new `focusPreviousWindow()` static method.
- `src/ui/settings-window/tabs/controls/ControlsTab.swift` — wire the action; extract `scopeForControlId()` helper so a new `globalStaticShortcutPreferences` list can opt shortcuts into `.global` scope alongside the existing `nextWindowShortcut*` prefix check.
- `src/ui/settings-window/tabs/controls/AdditionalControlsSheet.swift` — new "Global shortcuts" table with the recorder row.
- `resources/l10n/Localizable.strings` — two new English strings ("Focus previous window", "Global shortcuts"), alphabetically inserted. Other locales are expected to flow through POEditor.

## Test plan

- [ ] Build and launch the app.
- [ ] Open `Preferences → Controls → Additional controls…`. Verify a new "Global shortcuts" section shows at the top with a "Focus previous window" recorder.
- [ ] Record `⌘+Esc` (or any chord). Close Preferences.
- [ ] Open three apps; focus A → B → C. Press the shortcut → focus snaps to B. Press again → snaps to C. (Classic two-window toggle.)
- [ ] Verify the switcher UI never appears during the flick.
- [ ] Clear the recorder; pressing the shortcut becomes a no-op.
- [ ] While the switcher is open (e.g. via `⌥+⇥`), pressing the shortcut should not disrupt the session.
- [ ] Sanity: `AltTab --focusUsingLastFocusOrder=1` CLI still works unchanged.
- [ ] Edge case: only one window visible → no-op.
- [ ] Edge case: previous window on another Space → `window.focus()` handles space switching.