### PR TITLE
fix: rapid switches leave stale lastFocusOrder, selecting wrong window

### DIFF
--- a/src/logic/events/AccessibilityEvents.swift
+++ b/src/logic/events/AccessibilityEvents.swift
@@ -131,7 +131,11 @@ class AccessibilityEvents {
     private static func focusedWindowChanged(_ window: Window) {
         // photoshop will focus a window *after* you focus another app
         // we check that a focused window happens within an active app
-        guard window.application.runningApplication.isActive else { return }
+        // NSRunningApplication.isActive is racy: during rapid switches it can be stale/false when
+        // this callback runs, making us drop legitimate focus events and leaving lastFocusOrder stale.
+        // Applications.frontmostPid is set synchronously when AltTab processes the activation event,
+        // so it's a reliable signal that this window's app is the currently frontmost app.
+        guard Applications.frontmostPid == window.application.pid else { return }
         // if the window is shown by alt-tab, we mark it as focused for this app
         // this avoids issues with dialogs, quicklook, etc (see scenarios from #1044 and #2003)
         window.application.focusedWindow = window

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -256,6 +256,11 @@ class App: AppCenterApplication {
         hideUi(true)
         if let window = selectedWindow, MissionControl.state() == .inactive || MissionControl.state() == .showDesktop {
             window.focus()
+            // update lastFocusOrder eagerly. Otherwise we rely on the AX focusedWindow-changed event which
+            // is gated on runningApplication.isActive (AccessibilityEvents.focusedWindowChanged). That guard
+            // can fail during rapid switches, leaving the recent-order stale — next alt-tab then selects the
+            // wrong window (the one AltTab still believes was most-recently focused)
+            _ = Windows.updateLastFocusOrder(window)
             if Preferences.cursorFollowFocus == .always || (
                 Preferences.cursorFollowFocus == .differentScreen && (Spaces.screenSpacesMap.first { $0.value.contains { space in window.spaceIds.contains(space) } })?.key != NSScreen.active()?.cachedUuid()) {
                 moveCursorToSelectedWindow(window)


### PR DESCRIPTION
## Problem

When rapidly alt-tabbing between two apps (e.g. iTerm ↔ Brave), AltTab's internal "recently-focused" order goes stale. Symptom: user alt-tabs to Brave, Brave becomes frontmost in macOS, but AltTab still thinks iTerm was most-recently focused. Next alt-tab then selects position 1 (Brave again) instead of returning to iTerm — the muscle-memory flip stops working.

This looks related to the threads around #4772 / #5289, but focuses on a different root cause in the focus-tracking pipeline.

## Root cause

Two independent places leave `lastFocusOrder` stale:

1. `AccessibilityEvents.focusedWindowChanged` is gated on `window.application.runningApplication.isActive`. The guard exists to prevent Photoshop-style "focus event without actually being active" cases, but `NSRunningApplication.isActive` is racy — during rapid switches the AX callback can run while macOS hasn't yet flipped `isActive` to `true` for the newly focused app. The legitimate event is dropped and `lastFocusOrder` never updates.

2. Even when the AX event does eventually arrive, there is a latency window between `window.focus()` and the async AX callback. A second alt-tab triggered inside that window sees the old order.

## Fix

- Replace the `isActive` guard with `Applications.frontmostPid == window.application.pid`. `frontmostPid` is set synchronously by AltTab itself in `applicationActivated`, so it's a reliable "this app is now the frontmost one" signal and still rejects Photoshop's spurious events.
- Call `Windows.updateLastFocusOrder` eagerly after `window.focus()` in `focusSelectedWindow`, so the alt-tab path does not depend on the async AX event round-trip at all.

## Test

Repro steps:
1. Open iTerm and Brave (or any two apps).
2. Alt-tab between them rapidly several times.

Before: occasionally the next alt-tab selects the app you just came from instead of the previous one.
After: order stays consistent; alt-tab always returns to the previously focused app.

Verified locally on macOS 26.x against master (v10.12.0).