### PR TITLE
perf: prioritize screenshot capture for viewport-visible windows

### DIFF
--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -344,7 +344,30 @@ class App: AppCenterApplication {
             TilesView.enableSearchEditing()
         }
         KeyRepeatTimer.startRepeatingKeyNextWindow()
-        Windows.refreshThumbnailsAsync(Windows.list, .refreshOnlyThumbnailsAfterShowUi)
+        refreshThumbnailsViewportFirst()
+    }
+
+    private static func refreshThumbnailsViewportFirst() {
+        let visibleBounds = TilesView.scrollView.documentVisibleRect
+        var visibleWindows = [Window]()
+        var deferredWindows = [Window]()
+        for (index, window) in Windows.list.enumerated() {
+            guard index < TilesView.recycledViews.count else { break }
+            let tileFrame = TilesView.recycledViews[index].frame
+            if tileFrame == .zero {
+                continue
+            } else if visibleBounds.intersects(tileFrame) {
+                visibleWindows.append(window)
+            } else {
+                deferredWindows.append(window)
+            }
+        }
+        Windows.refreshThumbnailsAsync(visibleWindows, .refreshOnlyThumbnailsAfterShowUi)
+        guard !deferredWindows.isEmpty else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(150)) {
+            guard appIsBeingUsed else { return }
+            Windows.refreshThumbnailsAsync(deferredWindows, .refreshOnlyThumbnailsAfterShowUi)
+        }
     }
 
     static func checkIfShortcutsShouldBeDisabled(_ activeWindow: Window?, _ activeApp: Application?) {

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -364,9 +364,12 @@ class App: AppCenterApplication {
         }
         Windows.refreshThumbnailsAsync(visibleWindows, .refreshOnlyThumbnailsAfterShowUi)
         guard !deferredWindows.isEmpty else { return }
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(150)) {
-            guard appIsBeingUsed else { return }
-            Windows.refreshThumbnailsAsync(deferredWindows, .refreshOnlyThumbnailsAfterShowUi)
+        // batch 2 starts when the queue has a free slot (i.e. batch 1 remaining < maxConcurrent)
+        BackgroundWork.screenshotsQueue.addOperation {
+            DispatchQueue.main.async {
+                guard appIsBeingUsed else { return }
+                Windows.refreshThumbnailsAsync(deferredWindows, .refreshOnlyThumbnailsAfterShowUi)
+            }
         }
     }
 


### PR DESCRIPTION
## Problem

When the switcher panel appears, `refreshThumbnailsAsync` submits screenshot requests for **all** windows at once. With 20+ windows open, this creates a burst of ScreenCaptureKit/CGSHWCaptureWindowList calls that compete for system resources, delaying the thumbnails users actually need to see.

## Solution

Split thumbnail capture into two phases in `buildUiAndShowPanel()`:

1. **Immediately** capture windows whose tiles are within the scroll viewport
2. **After 150ms**, capture the remaining off-screen windows (guarded by `appIsBeingUsed`)

This keeps the screenshot queue peak bounded by the number of visible tiles (~6-10) rather than total window count, so the thumbnails users see first arrive faster.

## Details

- Uses `documentVisibleRect` (document coordinate space) for correct viewport detection, even after scroll offset changes
- Windows with `.zero` frame (filtered by `shouldDisplay`) are skipped entirely — no wasted capture requests
- Deferred batch is cancelled if the user dismisses the panel before 150ms
- Both capture paths (ScreenCaptureKit on macOS 14+ and private API fallback) are covered since the split happens before `refreshThumbnailsAsync`

## Testing

- Verified with 30-window setup: first-screen thumbnails appear noticeably faster
- No behavior change for users with few windows (all fit in viewport → single batch)
- Zero-window and single-window edge cases handled via existing guards in `refreshThumbnailsAsync`