### PR TITLE
perf: viewport-first rendering and deferred tile updates

### DIFF
--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -344,6 +344,9 @@ class Windows {
         let focusedView = TilesView.recycledViews[index]
         focusedView.updatePendingContent()
         TilesView.scrollView.contentView.scrollToVisible(focusedView.frame)
+        DispatchQueue.main.async {
+            TilesView.scrollView.updateVisibleTiles()
+        }
         voiceOverWindow(index)
     }
 

--- a/src/logic/Windows.swift
+++ b/src/logic/Windows.swift
@@ -342,6 +342,7 @@ class Windows {
         guard let index else { return }
         TilesView.highlight(index)
         let focusedView = TilesView.recycledViews[index]
+        focusedView.updatePendingContent()
         TilesView.scrollView.contentView.scrollToVisible(focusedView.frame)
         voiceOverWindow(index)
     }

--- a/src/logic/events/WindowCaptureEvents.swift
+++ b/src/logic/events/WindowCaptureEvents.swift
@@ -34,8 +34,9 @@ class WindowCaptureScreenshots {
             BackgroundWork.screenshotsQueue.addOperation {
                 cachedSCWindows = shareableContent.windows
                 guard source != .refreshOnlyThumbnailsAfterShowUi || App.appIsBeingUsed else { return }
+                let freshMap = Dictionary(cachedSCWindows.map { ($0.windowID, $0) }, uniquingKeysWith: { first, _ in first })
                 for notCachedWindow in notCachedWindows {
-                    if let cachedWindow = (cachedSCWindows.first { $0.windowID == notCachedWindow }) {
+                    if let cachedWindow = freshMap[notCachedWindow] {
                         oneTimeCapture(cachedWindow, source)
                     } else {
                         Logger.debug { "wid:\(notCachedWindow) was not found in SCShareableContent windows" }
@@ -46,10 +47,11 @@ class WindowCaptureScreenshots {
     }
 
     private static func sortCachedAndNotCached(_ windows: [CGWindowID]) -> ([SCWindow], [CGWindowID]) {
+        let cachedMap = Dictionary(cachedSCWindows.map { ($0.windowID, $0) }, uniquingKeysWith: { first, _ in first })
         var cachedWindows = [SCWindow]()
         var notCachedWindows = [CGWindowID]()
         for window in windows {
-            if let cachedWindow = (cachedSCWindows.first { $0.windowID == window }) {
+            if let cachedWindow = cachedMap[window] {
                 cachedWindows.append(cachedWindow)
             } else {
                 notCachedWindows.append(window)

--- a/src/ui/App.swift
+++ b/src/ui/App.swift
@@ -344,7 +344,30 @@ class App: AppCenterApplication {
             TilesView.enableSearchEditing()
         }
         KeyRepeatTimer.startRepeatingKeyNextWindow()
-        Windows.refreshThumbnailsAsync(Windows.list, .refreshOnlyThumbnailsAfterShowUi)
+        refreshThumbnailsViewportFirst()
+    }
+
+    private static func refreshThumbnailsViewportFirst() {
+        let visibleBounds = TilesView.scrollView.documentVisibleRect
+        var visibleWindows = [Window]()
+        var deferredWindows = [Window]()
+        for (index, window) in Windows.list.enumerated() {
+            guard index < TilesView.recycledViews.count else { break }
+            let tileFrame = TilesView.recycledViews[index].frame
+            if tileFrame == .zero {
+                continue
+            } else if visibleBounds.intersects(tileFrame) {
+                visibleWindows.append(window)
+            } else {
+                deferredWindows.append(window)
+            }
+        }
+        Windows.refreshThumbnailsAsync(visibleWindows, .refreshOnlyThumbnailsAfterShowUi)
+        guard !deferredWindows.isEmpty else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(150)) {
+            guard appIsBeingUsed else { return }
+            Windows.refreshThumbnailsAsync(deferredWindows, .refreshOnlyThumbnailsAfterShowUi)
+        }
     }
 
     static func checkIfShortcutsShouldBeDisabled(_ activeWindow: Window?, _ activeApp: Application?) {

--- a/src/ui/main-window/TileView.swift
+++ b/src/ui/main-window/TileView.swift
@@ -55,13 +55,52 @@ class TileView: FlippedView {
         return CGRect(origin: .zero, size: frame.size)
     }
 
+    var needsContentUpdate = false
+    private var pendingWindow: Window?
+    private var pendingIndex: Int = 0
+
+    func updateFrameSizeOnly(_ element: Window, _ newHeight: CGFloat) {
+        window_ = element
+        if !thumbnail.isHidden {
+            if element.thumbnail != nil {
+                let thumbnailSize = TileView.thumbnailSize(element.size, false)
+                thumbnail.frame.size = thumbnailSize
+            } else {
+                let thumbnailSize = TileView.thumbnailSize(element.icon?.size(), true)
+                thumbnail.frame.size = thumbnailSize
+            }
+        }
+        setFrameWidthHeight(newHeight)
+    }
+
+    func updatePendingContent() {
+        guard needsContentUpdate, let window = pendingWindow else { return }
+        needsContentUpdate = false
+        let height = frame.size.height
+        label.toolTip = nil
+        updateValues(window, pendingIndex, height)
+        updateSizes(height)
+        updatePositions(height)
+        applySearchHighlight()
+    }
+
     func updateRecycledCellWithNewContent(_ element: Window, _ index: Int, _ newHeight: CGFloat) {
+        needsContentUpdate = false
+        pendingWindow = nil
         window_ = element
         label.toolTip = nil
         updateValues(element, index, newHeight)
         updateSizes(newHeight)
         updatePositions(newHeight)
         applySearchHighlight()
+    }
+
+    func deferContentUpdate(_ element: Window, _ index: Int) {
+        needsContentUpdate = true
+        pendingWindow = element
+        pendingIndex = index
+        mouseUpCallback = { () -> Void in App.focusSelectedWindow(element) }
+        mouseMovedCallback = { () -> Void in Windows.updateSelectedAndHoveredWindowIndex(index, true) }
     }
 
     func drawHighlight() {

--- a/src/ui/main-window/TilesView.swift
+++ b/src/ui/main-window/TilesView.swift
@@ -419,6 +419,7 @@ class TilesView {
         var rowSignature = [Int]()
         rows.removeAll(keepingCapacity: true)
         rows.append([TileView]())
+        let visibleRect = scrollView.documentVisibleRect
         var index = 0
         while index < TilesView.recycledViews.count {
             guard App.appIsBeingUsed else { return nil }
@@ -430,7 +431,7 @@ class TilesView {
                     view.frame = .zero
                     continue
                 }
-                view.updateRecycledCellWithNewContent(window, index, height)
+                view.updateFrameSizeOnly(window, height)
                 let width = view.frame.size.width
                 let projectedX = projectedWidth(currentX, width).rounded(.down)
                 if needNewLine(projectedX, widthMax) {
@@ -444,6 +445,11 @@ class TilesView {
                     view.frame.origin = CGPoint(x: localizedCurrentX(currentX, width), y: currentY)
                     currentX = projectedX
                     maxX = max(isLeftToRight ? currentX : widthMax - currentX, maxX)
+                }
+                if visibleRect.isEmpty || view.frame.intersects(visibleRect) {
+                    view.updateRecycledCellWithNewContent(window, index, height)
+                } else {
+                    view.deferContentUpdate(window, index)
                 }
                 rows[rows.count - 1].append(view)
                 newViews.append(view)
@@ -627,12 +633,25 @@ class ScrollView: NSScrollView {
     }
 
     private func observeScrollingEvents() {
-        NotificationCenter.default.addObserver(self, selector: #selector(scrollingStarted), name: NSScrollView.willStartLiveScrollNotification, object: nil)
-        NotificationCenter.default.addObserver(self, selector: #selector(scrollingEnded), name: NSScrollView.didEndLiveScrollNotification, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(scrollingStarted), name: NSScrollView.willStartLiveScrollNotification, object: self)
+        NotificationCenter.default.addObserver(self, selector: #selector(scrollingEnded), name: NSScrollView.didEndLiveScrollNotification, object: self)
     }
 
     @objc private func scrollingStarted() { isCurrentlyScrolling = true }
-    @objc private func scrollingEnded() { isCurrentlyScrolling = false }
+
+    @objc private func scrollingEnded() {
+        isCurrentlyScrolling = false
+        updateVisibleTiles()
+    }
+
+    func updateVisibleTiles() {
+        let visibleRect = self.documentVisibleRect
+        for view in TilesView.recycledViews where view.needsContentUpdate {
+            if view.frame.intersects(visibleRect) {
+                view.updatePendingContent()
+            }
+        }
+    }
 
     /// holding shift and using the scrolling wheel will generate a horizontal movement
     /// shift can be part of shortcuts so we force shift scrolls to be vertical

--- a/src/ui/main-window/TilesView.swift
+++ b/src/ui/main-window/TilesView.swift
@@ -391,7 +391,7 @@ class TilesView {
             guard index < Windows.list.count else { break }
             let window = Windows.list[index]
             guard Windows.shouldDisplay(window) else { view.frame = .zero; continue }
-            view.updateRecycledCellWithNewContent(window, index, height)
+            view.updateFrameSizeOnly(window, height)
             let width = view.frame.size.width
             let projectedX = projectedWidth(currentX, width).rounded(.down)
             if needNewLine(projectedX, widthMax) {


### PR DESCRIPTION
## Summary
- **Viewport-first thumbnail refresh**: prioritize screenshot capture for visible tiles, defer off-screen ones by 150ms
- **Lazy content update during layout**: only render tile content (thumbnail/icon/label/search highlight) for visible tiles; off-screen tiles get frame-only sizing with deferred content update on scroll or keyboard navigation
- **Skip content rendering in dry-run layout**: `dryRunLayoutTileViews` (auto-size mode) now uses lightweight `updateFrameSizeOnly` instead of full `updateRecycledCellWithNewContent`, avoiding up to 3 rounds of wasted rendering
- **Flush deferred tiles after keyboard scroll**: `scrollToVisible` is programmatic and doesn't fire `didEndLiveScrollNotification`, so explicitly async-flush deferred tiles that entered the viewport
- **Dictionary-based SCWindow cache lookup**: replace O(n·m) linear scan with O(n+m) dictionary lookup in screenshot capture pipeline

## Test plan
- [ ] Auto-size mode: trigger Alt-Tab with 15+ windows, verify panel shows correct size and all tiles render correctly
- [ ] Fixed size mode: verify no regression (optimizations are no-op in this path)
- [ ] Keyboard navigation with scrolling: open 10+ windows (thumbnails style), press ↓ to scroll down — tiles scrolling into view should render correctly without blank/stale content
- [ ] Search + navigation: activate search, type query, navigate with arrow keys — search highlights should display correctly on all tiles
- [ ] All appearance styles (thumbnails/titles/appIcons): verify layout and content rendering
- [ ] Screenshot capture: with 20+ windows, all thumbnails should load progressively

🤖 Generated with [Claude Code](https://claude.com/claude-code)