### PR TITLE
fix: Escape closes overlay reliably (cancelShortcut key-window bug)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,1 +1,27 @@
 @include ./AGENTS.md
+
+# Active investigation: Escape (cancelShortcut) not closing the overlay
+
+**Bug**: pressing Escape while the AltTab overlay is open does nothing in some conditions.
+Issues: #5018, #1835, #44.
+
+**Root cause**: `cancelShortcut` is registered as `.local` scope via `NSEvent.addLocalMonitorForEvents`.
+This only fires when `TilesPanel` is the key window. Because `TilesPanel` uses `.nonactivatingPanel`,
+it doesn't activate the app; `makeKeyAndOrderFront` gives it key focus, but any competing app
+(e.g. Contexts.app, which installs its own CGEventTap) can cause the panel to resign key status
+before the user presses Escape. When that happens, the local monitor never sees the event.
+
+**Why 'c' works and Escape doesn't**: In `searchOnRelease` / `doNothingOnRelease` shortcut styles,
+'c' (`closeWindowShortcut`) is handled the normal `.local` shortcut path too — it has the same
+reliability problem. The difference is that the bug most visibly manifests with Escape because
+Escape is the *only* way to dismiss the overlay in those modes. `closeWindowShortcut` only comes up
+if you're already inside the overlay and pressed a specific key.
+
+**Fix direction**: add a CGEventTap for `.keyDown` events (not just `flagsChanged`) while
+`App.appIsBeingUsed == true`, so local shortcuts are intercepted globally rather than relying on
+TilesPanel being key. This is how Contexts.app handles it.
+
+**Debug**: `bash ai/debug-escape.sh` — kills Contexts.app, sets `shortcutStyle=searchOnRelease`,
+launches the debug build. Restores settings on exit.
+
+**Suggested branch**: `fix/cancel-shortcut-key-window-reliability`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,27 +1,24 @@
 @include ./AGENTS.md
 
-# Active investigation: Escape (cancelShortcut) not closing the overlay
+# Fix: Escape (cancelShortcut) not closing the overlay
 
 **Bug**: pressing Escape while the AltTab overlay is open does nothing in some conditions.
-Issues: #5018, #1835, #44.
+Issues: #5018, #1835, #44. **Status: FIXED on branch `alkjdla`.**
 
-**Root cause**: `cancelShortcut` is registered as `.local` scope via `NSEvent.addLocalMonitorForEvents`.
-This only fires when `TilesPanel` is the key window. Because `TilesPanel` uses `.nonactivatingPanel`,
-it doesn't activate the app; `makeKeyAndOrderFront` gives it key focus, but any competing app
-(e.g. Contexts.app, which installs its own CGEventTap) can cause the panel to resign key status
-before the user presses Escape. When that happens, the local monitor never sees the event.
+**Root cause**: `cancelShortcut` is `.local` scope (`NSEvent.addLocalMonitorForEvents`), which
+only fires when `TilesPanel` is the key window. macOS can revoke that key status before Escape
+is pressed, silently dropping the event. Confirmed via debug log: Cmd+Escape never reached
+`handleKeyboardEvent`.
 
-**Why 'c' works and Escape doesn't**: In `searchOnRelease` / `doNothingOnRelease` shortcut styles,
-'c' (`closeWindowShortcut`) is handled the normal `.local` shortcut path too — it has the same
-reliability problem. The difference is that the bug most visibly manifests with Escape because
-Escape is the *only* way to dismiss the overlay in those modes. `closeWindowShortcut` only comes up
-if you're already inside the overlay and pressed a specific key.
+**Fix**: added a second `CGEventTap` (`localShortcutEventTap`) with `.defaultTap` on `keyDown`,
+at `.headInsertEventTap`. While `App.appIsBeingUsed`, it calls `handleKeyboardEvent(..., localOnly: true)`,
+skipping `scope == .global` shortcuts (already handled by `RegisterEventHotKey` + `KeyRepeatTimer`)
+and only intercepting `scope == .local` shortcuts (cancelShortcut etc.).
 
-**Fix direction**: add a CGEventTap for `.keyDown` events (not just `flagsChanged`) while
-`App.appIsBeingUsed == true`, so local shortcuts are intercepted globally rather than relying on
-TilesPanel being key. This is how Contexts.app handles it.
+**Regression fixed**: without `localOnly`, Tab/Cmd+Tab double-triggered `nextWindowShortcut`
+alongside the Carbon hotkey handler, causing infinite window cycling.
 
-**Debug**: `bash ai/debug-escape.sh` — kills Contexts.app, sets `shortcutStyle=searchOnRelease`,
+**Debug**: `bash ai/debug-escape.sh` — kills competing switchers, sets `shortcutStyle=searchOnRelease`,
 launches the debug build. Restores settings on exit.
 
-**Suggested branch**: `fix/cancel-shortcut-key-window-reliability`
+**Details**: `ai/bug-escape-cancel-shortcut.md`

--- a/ai/bug-escape-cancel-shortcut.md
+++ b/ai/bug-escape-cancel-shortcut.md
@@ -1,0 +1,73 @@
+# Bug: Escape / Cmd+Escape does not close the AltTab overlay
+
+**Labels**: bug
+**Related**: #5018, #1835, #44
+**Status**: FIXED (branch `alkjdla`)
+
+---
+
+## Describe the bug
+
+Pressing Escape (or hold-modifier+Escape) while the AltTab overlay is open does nothing.
+The overlay stays open.
+
+Verified repro: hold shortcut = Cmd, shortcutStyle = searchOnRelease (overlay stays open after
+releasing hold key):
+1. Press Cmd+Tab — overlay opens
+2. Release Tab — overlay stays open
+3. Press Escape — nothing happens
+
+Option+Escape (with Option as hold shortcut) works correctly on the same machine, ruling out
+a generic Escape-handling problem.
+
+## Root cause (confirmed via debug log)
+
+`cancelShortcut` is registered as `.local` scope via `NSEvent.addLocalMonitorForEvents`. This
+only fires when `TilesPanel` is the key window. The Cmd+Escape event never appeared in the
+debug log — it was dropped before `handleKeyboardEvent` was ever called.
+
+`TilesPanel` uses `.nonactivatingPanel`, so `makeKeyAndOrderFront` gives it key focus without
+activating the app. macOS (or competing processes) can revoke that key status before Escape is
+pressed, silently dropping the event before the local monitor sees it.
+
+**Why AltTab's existing CGEventTap doesn't help**: It is `.listenOnly` and only subscribed to
+`flagsChanged` (modifier keys only, not `keyDown`). It cannot intercept Escape.
+
+## Fix (implemented)
+
+Added a second `CGEventTap` (`localShortcutEventTap`) with `.defaultTap` (can absorb) on
+`keyDown` events, installed at `.headInsertEventTap` on `.cgSessionEventTap`. While
+`App.appIsBeingUsed`, it calls `handleKeyboardEvent(..., localOnly: true)`, which skips
+shortcuts with `scope == .global` (nextWindowShortcut, holdShortcut — already handled by
+`RegisterEventHotKey` + `KeyRepeatTimer`) and only handles `scope == .local` shortcuts
+(cancelShortcut etc.).
+
+The `localOnly` restriction was required to fix a secondary regression: without it, the tap
+also fired for Tab/Cmd+Tab, double-triggering `nextWindowShortcut` alongside the Carbon hotkey
+handler and `KeyRepeatTimer`, causing infinite window cycling.
+
+Key files:
+- `src/logic/events/KeyboardEvents.swift` — `addCgEventTapForLocalShortcuts()`, `cgEventKeyDownHandler`
+- `src/logic/events/KeyboardEventsTestable.swift` — `localOnly` parameter on `handleKeyboardEvent` / `triggerMatchingShortcuts`
+
+## Ruled out
+
+- Contexts.app — reproduces without it, on clean machines
+- 1Password / Secure Input — reproduces on machines with no password manager
+- Rectangle, other window managers — not required
+- GameOverlay — Game Center disabled, Option+Escape works fine
+- Single machine fluke — reproduces on multiple laptops
+- Code bug in shortcut matching — `modifiersMatch` correctly handles Cmd+Escape if event arrives
+
+## Separate bug (to file later)
+
+When AltTab shows a "conflicting shortcut" warning for GameOverlay (Cmd+Escape), it opens
+System Settings → Keyboard → Modifier Keys — the wrong pane. Also a false positive since
+Game Center is disabled.
+
+## Your environment
+
+* AltTab version: 10.12.0
+* macOS version: 15.x (Sequoia)
+* Hold shortcut: Cmd
+* Reproduces on: multiple machines, no competing apps needed

--- a/ai/build.sh
+++ b/ai/build.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# NOTE: First run will prompt for keychain password multiple times — click "Always Allow" each time.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"

--- a/ai/build.sh
+++ b/ai/build.sh
@@ -1,7 +1,11 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+DERIVED_DATA="${DERIVED_DATA:-$REPO_ROOT/DerivedData}"
 
 xcodebuild \
-  -workspace alt-tab-macos.xcworkspace \
+  -workspace "$REPO_ROOT/alt-tab-macos.xcworkspace" \
   -scheme Debug \
   -configuration Debug \
-  -derivedDataPath ~/git/alt-tab-macos/DerivedData
+  -derivedDataPath "$DERIVED_DATA"

--- a/ai/debug-escape.sh
+++ b/ai/debug-escape.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Debug helper for the cancelShortcut (Escape) key event bug.
+# Stops competing window switchers (which steal keyboard events), applies debug
+# settings, launches the AltTab debug build, and restores settings on exit.
+
+set -euo pipefail
+
+BUNDLE_ID="com.lwouis.alt-tab-macos"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Locate debug build: repo-local DerivedData, then Xcode default
+DERIVED_DATA="${DERIVED_DATA:-$REPO_ROOT/DerivedData}"
+APP_BUNDLE="$DERIVED_DATA/Build/Products/Debug/AltTabDebug.app"
+if [[ ! -d "$APP_BUNDLE" ]]; then
+    XCODE_BUILD=$(find ~/Library/Developer/Xcode/DerivedData \
+        -name "AltTabDebug.app" -path "*/Debug/AltTabDebug.app" -type d 2>/dev/null | head -1)
+    APP_BUNDLE="${XCODE_BUILD:-$APP_BUNDLE}"
+fi
+
+if [[ ! -d "$APP_BUNDLE" ]]; then
+    echo "ERROR: Debug build not found. Run: bash ai/build.sh first"
+    exit 1
+fi
+
+# Save original shortcutStyle and restore on exit
+ORIG_STYLE=$(defaults read "$BUNDLE_ID" shortcutStyle 2>/dev/null || echo "0")
+restore() {
+    echo ""
+    echo "Restoring shortcutStyle → $ORIG_STYLE"
+    defaults write "$BUNDLE_ID" shortcutStyle -int "$ORIG_STYLE"
+}
+trap restore EXIT
+
+# Stop competing window switchers — they install CGEventTaps that swallow Escape
+# before AltTab's local NSEvent monitor ever sees it
+SWITCHERS=(Contexts Witch Overflow HiDock)
+echo "=== Competing window switchers ==="
+for app in "${SWITCHERS[@]}"; do
+    pid=$(pgrep -ix "$app" 2>/dev/null || true)
+    if [[ -n "$pid" ]]; then
+        echo "  $app: RUNNING — matching processes:"
+        pgrep -il "$app" | sed 's/^/    /'
+        pkill -ix "$app" && echo "  $app: stopped." || echo "  $app: stop failed (continuing anyway)"
+        sleep 0.3
+    else
+        echo "  $app: not running"
+    fi
+done
+echo ""
+
+# Kill any running AltTab so fresh settings take effect
+killall AltTab 2>/dev/null || true
+sleep 0.3
+
+# shortcutStyle=2 (searchOnRelease): overlay stays open after ⌥ is released,
+# forcing the user to press Escape to close — the most reliable path to reproduce
+# the cancelShortcut key-window bug.
+# 0=focusOnRelease  1=doNothingOnRelease  2=searchOnRelease
+defaults write "$BUNDLE_ID" shortcutStyle -int 2
+
+echo "Debug settings applied:"
+echo "  shortcutStyle → 2 (searchOnRelease)"
+echo ""
+echo "Reproduce the Escape bug:"
+echo "  1. Press your hold shortcut + Tab  — overlay opens"
+echo "  2. Release hold key               — overlay stays open (searchOnRelease)"
+echo "  3. Press Escape                   — should close overlay"
+echo ""
+echo "Launching: $APP_BUNDLE"
+echo "---"
+open -a "$APP_BUNDLE" --args --logs=debug

--- a/ai/setup-dev.sh
+++ b/ai/setup-dev.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# One-time dev environment setup for building AltTab locally.
+# Run this once after cloning, or after installing Xcode fresh.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "=== Step 1: Verify Xcode ==="
+if ! xcode-select -p | grep -q Xcode; then
+    echo "ERROR: Xcode not selected. Install Xcode from the App Store, then run:"
+    echo "  sudo xcode-select -s /Applications/Xcode.app/Contents/Developer"
+    exit 1
+fi
+echo "  Xcode: $(xcode-select -p)"
+
+echo ""
+echo "=== Step 2: Accept Xcode license ==="
+sudo xcodebuild -license accept 2>/dev/null && echo "  License accepted." || echo "  Already accepted."
+
+echo ""
+echo "=== Step 3: Run first launch ==="
+sudo xcodebuild -runFirstLaunch 2>&1 | tail -2
+
+echo ""
+echo "=== Step 4: Create local codesign certificate ==="
+if security find-certificate -c "Local Self-Signed" ~/Library/Keychains/login.keychain-db &>/dev/null; then
+    echo "  Certificate already exists."
+else
+    cd "$REPO_ROOT"
+    bash scripts/codesign/setup_local.sh
+    echo "  Certificate created and trusted."
+fi
+
+echo ""
+echo "=== Step 5: Install CocoaPods dependencies ==="
+cd "$REPO_ROOT"
+if [ ! -d Pods ]; then
+    pod install
+else
+    echo "  Pods already installed."
+fi
+
+echo ""
+echo "=== Done. Run: bash ai/build.sh ==="
+echo ""
+echo "NOTE: First build will prompt for keychain password multiple times."
+echo "      Enter your login keychain password and click 'Always Allow' each time."
+echo "      Subsequent builds will not prompt."

--- a/config/debug.xcconfig
+++ b/config/debug.xcconfig
@@ -4,6 +4,8 @@
 #include "base.xcconfig"
 
 CODE_SIGN_IDENTITY = Local Self-Signed
+PRODUCT_NAME = AltTabDebug
+PRODUCT_BUNDLE_IDENTIFIER = com.lwouis.alt-tab-macos.debug
 SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG // for macro `#if DEBUG`
 OTHER_SWIFT_FLAGS = -driver-time-compilation -Xfrontend -warn-long-function-bodies=250 -Xfrontend -warn-long-expression-type-checking=250 // find slow compilation areas
 OTHER_CODE_SIGN_FLAGS = --timestamp=none

--- a/src/logic/events/KeyboardEvents.swift
+++ b/src/logic/events/KeyboardEvents.swift
@@ -10,6 +10,20 @@ class KeyboardEvents {
     private static var hotKeyReleasedEventHandler: EventHandlerRef?
     private static var globalShortcutsAreDisabled = false
     private static var eventTap: CFMachPort?
+    private static var localShortcutEventTap: CFMachPort?
+
+    private static let cgEventKeyDownHandler: CGEventTapCallBack = { _, type, cgEvent, _ in
+        if type == .keyDown, App.appIsBeingUsed {
+            let keyCode = UInt32(cgEvent.getIntegerValueField(.keyboardEventKeycode))
+            let isARepeat = cgEvent.getIntegerValueField(.keyboardEventAutorepeat) != 0
+            let modifiers = NSEvent.ModifierFlags(rawValue: UInt(cgEvent.flags.rawValue))
+            let absorbed = handleKeyboardEvent(nil, nil, keyCode, modifiers, isARepeat, localOnly: true)
+            if absorbed { return nil }
+        } else if type == .tapDisabledByUserInput || type == .tapDisabledByTimeout {
+            CGEvent.tapEnable(tap: localShortcutEventTap!, enable: true)
+        }
+        return Unmanaged.passUnretained(cgEvent)
+    }
 
     private static let cgEventFlagsChangedHandler: CGEventTapCallBack = { _, type, cgEvent, _ in
         if type == .flagsChanged {
@@ -60,6 +74,7 @@ class KeyboardEvents {
     static func addEventHandlers() {
         addLocalMonitorForKeyDownAndKeyUp()
         addCgEventTapForModifierFlags()
+        addCgEventTapForLocalShortcuts()
     }
 
     private static func unregisterHotKeyIfNeeded(_ controlId: String, _ shortcut: Shortcut) {
@@ -91,6 +106,23 @@ class KeyboardEvents {
             let isARepeat = event.type == .keyDown ? event.isARepeat : false
             let shouldAbsorbEvent = handleKeyboardEvent(nil, nil, keyCode, event.modifierFlags, isARepeat, event)
             return shouldAbsorbEvent ? nil : event
+        }
+    }
+
+    private static func addCgEventTapForLocalShortcuts() {
+        let eventMask = CGEventMask(1 << CGEventType.keyDown.rawValue)
+        localShortcutEventTap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: eventMask,
+            callback: cgEventKeyDownHandler,
+            userInfo: nil)
+        if let localShortcutEventTap {
+            let runLoopSource = CFMachPortCreateRunLoopSource(nil, localShortcutEventTap, 0)
+            CFRunLoopAddSource(CFRunLoopGetMain(), runLoopSource, .commonModes)
+        } else {
+            App.restart()
         }
     }
 

--- a/src/logic/events/KeyboardEventsTestable.swift
+++ b/src/logic/events/KeyboardEventsTestable.swift
@@ -10,7 +10,7 @@ class KeyboardEventsTestable {
 }
 
 @discardableResult
-func handleKeyboardEvent(_ globalId: Int?, _ shortcutState: ShortcutState?, _ keyCode: UInt32?, _ modifiers: NSEvent.ModifierFlags?, _ isARepeat: Bool, _ event: NSEvent? = nil) -> Bool {
+func handleKeyboardEvent(_ globalId: Int?, _ shortcutState: ShortcutState?, _ keyCode: UInt32?, _ modifiers: NSEvent.ModifierFlags?, _ isARepeat: Bool, _ event: NSEvent? = nil, localOnly: Bool = false) -> Bool {
     if let event, shouldAbsorbSearchEditingKeyDown(event) {
         switch TilesView.handleSearchEditingKeyDown(event) {
         case .handled: return true
@@ -19,7 +19,7 @@ func handleKeyboardEvent(_ globalId: Int?, _ shortcutState: ShortcutState?, _ ke
         }
     }
     logKeyboardEvent(globalId, shortcutState, keyCode, modifiers, isARepeat)
-    let someShortcutTriggered = triggerMatchingShortcuts(globalId, shortcutState, keyCode, modifiers, isARepeat)
+    let someShortcutTriggered = triggerMatchingShortcuts(globalId, shortcutState, keyCode, modifiers, isARepeat, localOnly: localOnly)
     return someShortcutTriggered
 }
 
@@ -46,9 +46,10 @@ private func shouldAbsorbSearchEditingKeyDown(_ event: NSEvent?) -> Bool {
     return true
 }
 
-private func triggerMatchingShortcuts(_ globalId: Int?, _ shortcutState: ShortcutState?, _ keyCode: UInt32?, _ modifiers: NSEvent.ModifierFlags?, _ isARepeat: Bool) -> Bool {
+private func triggerMatchingShortcuts(_ globalId: Int?, _ shortcutState: ShortcutState?, _ keyCode: UInt32?, _ modifiers: NSEvent.ModifierFlags?, _ isARepeat: Bool, localOnly: Bool = false) -> Bool {
     var someShortcutTriggered = false
     for shortcut in ControlsTab.shortcuts.values {
+        if localOnly && shortcut.scope == .global { continue }
         if shortcut.matches(globalId, shortcutState, keyCode, modifiers) && shortcut.shouldTrigger() {
             shortcut.executeAction(isARepeat)
             // we want to pass-through alt-up to the active app, since it saw alt-down previously


### PR DESCRIPTION
## Summary

Closes #5616. Related: #5018, #1835, #44 (closed but underlying problem still reproduces).

Pressing Escape (or hold-modifier+Escape) does not close the AltTab overlay in some conditions.

**Contributor Journey**:
I noticed that Escape didn't close the AltTab overlay and tried several workarounds and troubleshooting steps as outlined in #5018, #1835, #44.

I love AltTab and I figured I would see if I could help out by using Claude Code.

_Investigated and authored with the help of an agentic test harness (Claude Code): repro scripts, debug log analysis, and the patch itself were iterated through automated tooling. All findings verified manually on real hardware._

## Root cause

`cancelShortcut` is `.local` scope, registered via `NSEvent.addLocalMonitorForEvents`, which only fires when `TilesPanel` is the key window. `TilesPanel` is a `.nonactivatingPanel`; macOS can revoke its key status before Escape is pressed, silently dropping the event. Confirmed via debug log: Cmd+Escape never reached `handleKeyboardEvent`.

The existing `flagsChanged` `CGEventTap` is `.listenOnly` and modifier-only, so it can't intercept Escape.

## Fix

Adds a second `CGEventTap` (`localShortcutEventTap`) at `.headInsertEventTap` on `kCGSessionEventTap`, with `.defaultTap` (can absorb), subscribed to `keyDown`. While `App.appIsBeingUsed`, it calls `handleKeyboardEvent(..., localOnly: true)`, which:

- Skips `scope == .global` shortcuts (already handled by `RegisterEventHotKey` + `KeyRepeatTimer`)
- Only intercepts `scope == .local` shortcuts (cancelShortcut etc.)

The `localOnly` filter was required to avoid a regression: without it, the new tap double-fired `nextWindowShortcut` alongside the Carbon hotkey handler, causing infinite window cycling on Cmd+Tab.

## Files

- `src/logic/events/KeyboardEvents.swift`: new `addCgEventTapForLocalShortcuts()` and `cgEventKeyDownHandler`
- `src/logic/events/KeyboardEventsTestable.swift`: `localOnly` parameter on `handleKeyboardEvent` / `triggerMatchingShortcuts`
- `ai/bug-escape-cancel-shortcut.md`: full investigation notes
- `ai/debug-escape.sh`: repro helper
- `ai/setup-dev.sh`: one-time dev environment setup

## Test plan

Mapped to the "Shortcuts" use-case list in [`docs/contributing.md`](docs/contributing.md).

**Verified working:**
- [x] [**`cancelShortcut` (Escape) closes the overlay reliably**](https://github.com/YoinkBird/alt-tab-macos/blob/fix/cancel-shortcut-key-window/docs/contributing.md#L140): the fix's target; previously failed when `TilesPanel` lost key-window status
- [x] [_"Some shortcuts should only work when AltTab is open"_](https://github.com/YoinkBird/alt-tab-macos/blob/fix/cancel-shortcut-key-window/docs/contributing.md#L138): local-scope shortcuts now active whenever `appIsBeingUsed`, regardless of `TilesPanel.isKeyWindow`
- [x] [_"...active whether the hold shortcut is held or not"_](https://github.com/YoinkBird/alt-tab-macos/blob/fix/cancel-shortcut-key-window/docs/contributing.md#L139): verified for both hold-still-held and hold-released paths
- [x] [_"Shortcuts should have priority over system shortcuts such as `cmd+tab`"_](https://github.com/YoinkBird/alt-tab-macos/blob/fix/cancel-shortcut-key-window/docs/contributing.md#L133): the new tap installs at `.headInsertEventTap`, ahead of most other taps, improving priority for local-scope shortcuts
- [x] [`select next window` containing hold-key modifiers](https://github.com/YoinkBird/alt-tab-macos/blob/fix/cancel-shortcut-key-window/docs/contributing.md#L134): Cmd hold + Cmd+Tab next
- [x] [Shortcuts repeat if kept pressed](https://github.com/YoinkBird/alt-tab-macos/blob/fix/cancel-shortcut-key-window/docs/contributing.md#L142): regression caught and fixed via `localOnly` filter; without it, Cmd+Tab cycled infinitely from double-firing
- [x] `bash ai/build.sh` succeeds

**Not verified, flagging for maintainer QA:**
- [ ] Multi-modifier hold key (e.g. `⌥⇧`); only Cmd was tested
- [ ] Capslock interactions
- [ ] Shortcut sets 1 and 2 isolation
- [ ] `focusOnRelease` / `doNothingOnRelease` modes (only `searchOnRelease` tested)
- [ ] International keyboard layouts
- [ ] **Secure Input**: the existing `flagsChanged` tap has a comment noting it survives Secure Input; the new `keyDown` tap may not. Worth verifying.
