### PR TITLE
Fix thumbnails when Stage Manager is enabled

### DIFF
--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -306,6 +306,9 @@
 		5F117E40000000000000F202 /* PermissionCalloutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F117E40000000000000F201 /* PermissionCalloutResolver.swift */; };
 		5F117E40000000000000F203 /* PermissionCalloutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F117E40000000000000F201 /* PermissionCalloutResolver.swift */; };
 		5F117E40000000000000F212 /* PermissionCalloutResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F117E40000000000000F211 /* PermissionCalloutResolverTests.swift */; };
+		5FCA50000000000000000003 /* WindowCaptureMethodResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCA50000000000000000001 /* WindowCaptureMethodResolver.swift */; };
+		5FCA50000000000000000004 /* WindowCaptureMethodResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCA50000000000000000001 /* WindowCaptureMethodResolver.swift */; };
+		5FCA50000000000000000005 /* WindowCaptureMethodResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FCA50000000000000000002 /* WindowCaptureMethodResolverTests.swift */; };
 		D04BADE4DDF7597749FB13BD /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA099FA155FB4D517D66B /* SettingsWindow.swift */; };
 		D04BAE8B16A06A10E2FA94DE /* AccessibilityEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA8FDCF137D892114F5F3 /* AccessibilityEvents.swift */; };
 		D04BAF12DF5D15B9D7D316A4 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D04BA61693F710CD7BD054D7 /* InfoPlist.strings */; };
@@ -633,6 +636,8 @@
 		D04BA7C6F2519091717F4B4E /* SystemPermissions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemPermissions.swift; sourceTree = "<group>"; };
 		5F117E40000000000000F201 /* PermissionCalloutResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionCalloutResolver.swift; sourceTree = "<group>"; };
 		5F117E40000000000000F211 /* PermissionCalloutResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionCalloutResolverTests.swift; sourceTree = "<group>"; };
+		5FCA50000000000000000001 /* WindowCaptureMethodResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureMethodResolver.swift; sourceTree = "<group>"; };
+		5FCA50000000000000000002 /* WindowCaptureMethodResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureMethodResolverTests.swift; sourceTree = "<group>"; };
 		D04BA7C836A8CE8C0B8D128B /* TextArea.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextArea.swift; sourceTree = "<group>"; };
 		D04BA7CF9C2D1BEC7C05AB24 /* Spaces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spaces.swift; sourceTree = "<group>"; };
 		D04BA7E3EA104941FE76DA70 /* AppCenterCrashes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppCenterCrashes.swift; sourceTree = "<group>"; };
@@ -1079,6 +1084,8 @@
 				D04BA7C6F2519091717F4B4E /* SystemPermissions.swift */,
 				5F117E40000000000000F201 /* PermissionCalloutResolver.swift */,
 				5F117E40000000000000F211 /* PermissionCalloutResolverTests.swift */,
+				5FCA50000000000000000001 /* WindowCaptureMethodResolver.swift */,
+				5FCA50000000000000000002 /* WindowCaptureMethodResolverTests.swift */,
 				5FA001000000000000000019 /* LoginItem.swift */,
 				AA0C8A000000000000000001 /* AXCallScheduler.swift */,
 				D04BA5BB6FB4E7D8F7AD357C /* api-wrappers */,
@@ -1854,6 +1861,8 @@
 				5F117E40000000000000F102 /* WindowFilterResolverTests.swift in Sources */,
 				5F117E40000000000000F203 /* PermissionCalloutResolver.swift in Sources */,
 				5F117E40000000000000F212 /* PermissionCalloutResolverTests.swift in Sources */,
+				5FCA50000000000000000004 /* WindowCaptureMethodResolver.swift in Sources */,
+				5FCA50000000000000000005 /* WindowCaptureMethodResolverTests.swift in Sources */,
 				5E7C0F70000000000000E003 /* ExceptionMatcher.swift in Sources */,
 				5E7C0F70000000000000E102 /* ExceptionMatcherTests.swift in Sources */,
 				5E0DE2A0000000000000D003 /* WindowOrderResolver.swift in Sources */,
@@ -1922,6 +1931,7 @@
 				D04BAC011A71E0418154F8CD /* Preferences.swift in Sources */,
 				D04BADCDA9F9A6C3D6499877 /* SystemPermissions.swift in Sources */,
 				5F117E40000000000000F202 /* PermissionCalloutResolver.swift in Sources */,
+				5FCA50000000000000000003 /* WindowCaptureMethodResolver.swift in Sources */,
 				D04BABEECBC6D922298BC93A /* Spaces.swift in Sources */,
 				D04BA6187A91A847844B6ABB /* Window.swift in Sources */,
 				5F21C9E82C6E96A00091F72F /* SheetWindow.swift in Sources */,

--- a/src/macos/WindowCaptureMethodResolver.swift
+++ b/src/macos/WindowCaptureMethodResolver.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+enum WindowCaptureMethod {
+    case screenCaptureKit
+    case privateApi
+}
+
+enum WindowCaptureMethodResolver {
+    static func method(osMajorVersion: Int, stageManagerEnabled: Bool) -> WindowCaptureMethod {
+        // ScreenCaptureKit can capture Stage Manager strip previews instead of the full window.
+        if stageManagerEnabled { return .privateApi }
+        // Mitigate macOS 15 bugs with ScreenCaptureKit (see https://github.com/lwouis/alt-tab-macos/issues/5190).
+        if osMajorVersion == 15 { return .privateApi }
+        if osMajorVersion >= 14 { return .screenCaptureKit }
+        return .privateApi
+    }
+}
+
+enum StageManager {
+    private static let defaultsDomain = "com.apple.WindowManager"
+    private static let globallyEnabledKey = "GloballyEnabled"
+
+    static var isEnabled: Bool {
+        isEnabled(defaults: UserDefaults(suiteName: defaultsDomain))
+    }
+
+    static func isEnabled(defaults: UserDefaults?) -> Bool {
+        defaults?.bool(forKey: globallyEnabledKey) ?? false
+    }
+}

--- a/src/macos/WindowCaptureMethodResolverTests.swift
+++ b/src/macos/WindowCaptureMethodResolverTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+
+final class WindowCaptureMethodResolverTests: XCTestCase {
+    func testMacOS14UsesScreenCaptureKitWhenStageManagerIsOff() {
+        XCTAssertEqual(WindowCaptureMethodResolver.method(osMajorVersion: 14, stageManagerEnabled: false), .screenCaptureKit)
+    }
+
+    func testMacOS15UsesPrivateApiBecauseScreenCaptureKitIsBuggy() {
+        XCTAssertEqual(WindowCaptureMethodResolver.method(osMajorVersion: 15, stageManagerEnabled: false), .privateApi)
+    }
+
+    func testOlderMacOSUsesPrivateApi() {
+        XCTAssertEqual(WindowCaptureMethodResolver.method(osMajorVersion: 13, stageManagerEnabled: false), .privateApi)
+    }
+
+    func testStageManagerUsesPrivateApiEvenOnScreenCaptureKitOSVersions() {
+        XCTAssertEqual(WindowCaptureMethodResolver.method(osMajorVersion: 14, stageManagerEnabled: true), .privateApi)
+        XCTAssertEqual(WindowCaptureMethodResolver.method(osMajorVersion: 26, stageManagerEnabled: true), .privateApi)
+    }
+
+    func testStageManagerReadsWindowManagerGlobalFlag() {
+        let suiteName = "test-window-manager-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { UserDefaults().removePersistentDomain(forName: suiteName) }
+
+        XCTAssertFalse(StageManager.isEnabled(defaults: defaults))
+
+        defaults.set(true, forKey: "GloballyEnabled")
+
+        XCTAssertTrue(StageManager.isEnabled(defaults: defaults))
+    }
+}

--- a/src/switcher/state/WindowThumbnails.swift
+++ b/src/switcher/state/WindowThumbnails.swift
@@ -31,9 +31,11 @@ enum WindowThumbnails {
             }
         }
         guard (!eligibleWindows.isEmpty || windowRemoved) else { return }
-        if #available(macOS 14.0, *),
-           // mitigate macOS 15 bugs with ScreenCapture Kit (see https://github.com/lwouis/alt-tab-macos/issues/5190)
-           ProcessInfo.processInfo.operatingSystemVersion.majorVersion != 15 {
+        let captureMethod = WindowCaptureMethodResolver.method(
+            osMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion,
+            stageManagerEnabled: StageManager.isEnabled
+        )
+        if #available(macOS 14.0, *), captureMethod == .screenCaptureKit {
             WindowCaptureScreenshots.oneTimeScreenshots(eligibleWindows, source, prioritizedIds: prioritizedIds)
         } else {
             WindowCaptureScreenshotsPrivateApi.oneTimeScreenshots(eligibleWindows, source, prioritizedIds: prioritizedIds)


### PR DESCRIPTION
## Summary
- Fall back to the existing SkyLight private capture path when Stage Manager is enabled.
- Keep ScreenCaptureKit for macOS 14+ when Stage Manager is off, while preserving the existing macOS 15 private API fallback.
- Add unit tests for capture backend selection and Stage Manager preference detection.

## Test plan
- `xcodebuild test -project alt-tab-macos.xcodeproj -scheme Test -configuration Release -derivedDataPath DerivedData -only-testing:unit-tests/WindowCaptureMethodResolverTests CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY=-`
- `xcodebuild -project alt-tab-macos.xcodeproj -scheme Debug -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY=- build`

## Notes
- I could launch the local debug app with Stage Manager enabled, but macOS required a fresh Screen Recording permission grant for the debug bundle before thumbnails could be visually inspected.
