### PR TITLE
Two-level window switcher

### DIFF
--- a/resources/l10n/en.lproj/Localizable.strings
+++ b/resources/l10n/en.lproj/Localizable.strings
@@ -236,6 +236,7 @@
 "Show separate window for each tab" = "Show separate window for each tab";
 "Show single window for all tabs" = "Show single window for all tabs";
 "Show titles" = "Show titles";
+"Show titles for app icons" = "Show titles for app icons";
 "Show windows from applications" = "Show windows from applications";
 "Show windows from screens" = "Show windows from screens";
 "Show windows from Spaces" = "Show windows from Spaces";

--- a/resources/l10n/en.lproj/Localizable.strings
+++ b/resources/l10n/en.lproj/Localizable.strings
@@ -170,6 +170,9 @@
 "Open Screen Recording Settings…" = "Open Screen Recording Settings…";
 "Open Trackpad Settings…" = "Open Trackpad Settings…";
 "Order windows by" = "Order windows by";
+"Restore state when switching shortcut" = "Restore state when switching shortcut";
+"Use previous selected app as active app when switching shortcut" = "Use previous selected app as active app when switching shortcut";
+"Select last focused window when switching shortcut" = "Select last focused window when switching shortcut";
 "Ordering & Grouping" = "Ordering & Grouping";
 "Overridden in Shortcut:" = "Overridden in Shortcut:";
 "Paste your license key:" = "Paste your license key:";

--- a/resources/l10n/en.lproj/Localizable.strings
+++ b/resources/l10n/en.lproj/Localizable.strings
@@ -204,6 +204,7 @@
 "Screen Recording" = "Screen Recording";
 "Screen showing AltTab" = "Screen showing AltTab";
 "Search" = "Search";
+"Open" = "Open";
 "Search is a Pro feature." = "Search is a Pro feature.";
 "Search windows by typing" = "Search windows by typing";
 "Search — find a window by typing" = "Search — find a window by typing";

--- a/resources/l10n/en.lproj/Localizable.strings
+++ b/resources/l10n/en.lproj/Localizable.strings
@@ -122,6 +122,7 @@
 "Hide" = "Hide";
 "Hide colored circles on mouse hover" = "Hide colored circles on mouse hover";
 "Hide Space number labels" = "Hide Space number labels";
+"Hide more windows icon" = "Hide more windows icon";
 "Hide status icons" = "Hide status icons";
 "Hide windows" = "Hide windows";
 "Hide/Show app" = "Hide/Show app";

--- a/scripts/assets/subset_font.sh
+++ b/scripts/assets/subset_font.sh
@@ -17,4 +17,4 @@ fi
 # synthesized at runtime in StatusIconsView.symbolForSpace.
 "$(pipenv --venv)"/bin/pyftsubset "$SOURCE_FONT" \
   --output-file=resources/SF-Pro-Text-Regular.otf \
-  --text="􀀁􀅴􀁎􀁌􀕧􀀸􀀺􀀼􀀾􀁀􀁂􀁄􀑱􀁆􀁈􀁊􀑳􀓵􀓶􀓷􀓸􀓹􀓺􀓻􀓼􀓽􀓾􀓿􀔀􀔁􀔂􀔃􀔄􀔅􀔆􀔇􀔈􀔉􀕬􀀹􀀻􀀽􀀿􀁁􀘘􀁃􀁅􀑲􀁇􀁉􀁋􀑴􀔔􀔕􀔖􀔗􀔘􀔙􀔚􀔛􀔜􀔝􀔞􀔟􀔠􀔡􀔢􀔣􀔤􀔥􀔦􀔧􀔨􀕭􀝥􀆔􀣋􀉻􀉣􀙠􀕾􀢹􀯔􀛭􀅼􀅽􀁏􀇰􀊛􀊫􀮵􁐎􁐏􁐐􀆿􀆭􀆺􀟛􀋃"
+  --text="􀀁􀅴􀁎􀁌􀕧􀀸􀀺􀀼􀀾􀁀􀁂􀁄􀑱􀁆􀁈􀁊􀑳􀓵􀓶􀓷􀓸􀓹􀓺􀓻􀓼􀓽􀓾􀓿􀔀􀔁􀔂􀔃􀔄􀔅􀔆􀔇􀔈􀔉􀕬􀀹􀀻􀀽􀀿􀁁􀘘􀁃􀁅􀑲􀁇􀁉􀁋􀑴􀔔􀔕􀔖􀔗􀔘􀔙􀔚􀔛􀔜􀔝􀔞􀔟􀔠􀔡􀔢􀔣􀔤􀔥􀔦􀔧􀔨􀕭􃑷􀝥􀆔􀣋􀉻􀉣􀙠􀕾􀢹􀯔􀛭􀅼􀅽􀁏􀇰􀊛􀊫􀮵􁐎􁐏􁐐􀆿􀆭􀆺􀟛􀋃"

--- a/scripts/assets/subset_font.sh
+++ b/scripts/assets/subset_font.sh
@@ -17,4 +17,4 @@ fi
 # synthesized at runtime in StatusIconsView.symbolForSpace.
 "$(pipenv --venv)"/bin/pyftsubset "$SOURCE_FONT" \
   --output-file=resources/SF-Pro-Text-Regular.otf \
-  --text="􀀁􀅴􀁎􀁌􀕧􀀸􀀺􀀼􀀾􀁀􀁂􀁄􀑱􀁆􀁈􀁊􀑳􀓵􀓶􀓷􀓸􀓹􀓺􀓻􀓼􀓽􀓾􀓿􀔀􀔁􀔂􀔃􀔄􀔅􀔆􀔇􀔈􀔉􀕬􀀹􀀻􀀽􀀿􀁁􀘘􀁃􀁅􀑲􀁇􀁉􀁋􀑴􀔔􀔕􀔖􀔗􀔘􀔙􀔚􀔛􀔜􀔝􀔞􀔟􀔠􀔡􀔢􀔣􀔤􀔥􀔦􀔧􀔨􀕭􀝥􀆔􀣋􀉻􀉣􀙠􀕾􀢹􀯔􀛭􀅼􀅽􀁏􀇰􀊛􀊫􁐎􁐏􁐐􀆿􀆭􀆺􀟛􀋃"
+  --text="􀀁􀅴􀁎􀁌􀕧􀀸􀀺􀀼􀀾􀁀􀁂􀁄􀑱􀁆􀁈􀁊􀑳􀓵􀓶􀓷􀓸􀓹􀓺􀓻􀓼􀓽􀓾􀓿􀔀􀔁􀔂􀔃􀔄􀔅􀔆􀔇􀔈􀔉􀕬􀀹􀀻􀀽􀀿􀁁􀘘􀁃􀁅􀑲􀁇􀁉􀁋􀑴􀔔􀔕􀔖􀔗􀔘􀔙􀔚􀔛􀔜􀔝􀔞􀔟􀔠􀔡􀔢􀔣􀔤􀔥􀔦􀔧􀔨􀕭􀝥􀆔􀣋􀉻􀉣􀙠􀕾􀢹􀯔􀛭􀅼􀅽􀁏􀇰􀊛􀊫􀮵􁐎􁐏􁐐􀆿􀆭􀆺􀟛􀋃"

--- a/src/App.swift
+++ b/src/App.swift
@@ -64,6 +64,7 @@ class App: AppCenterApplication {
         Logger.info { "active:\(SwitcherSession.isActive)" }
         guard SwitcherSession.current != nil else { return } // already hidden
         SwitcherSession.current = nil
+        SwitcherSession.sessionOverrides = [:]
         UsageStats.resetSession()
         TilesView.endSearchSession()
         ContextMenuEvents.toggle(false)
@@ -308,15 +309,42 @@ class App: AppCenterApplication {
     }
 
     static func showUiOrCycleSelection(_ shortcutIndex: Int, _ forceDoNothingOnRelease_: Bool) {
-        let session = SwitcherSession.current ?? {
+        var session = SwitcherSession.current ?? {
             let new = SwitcherSession()
             SwitcherSession.current = new
             return new
         }()
         session.forceDoNothingOnRelease = forceDoNothingOnRelease_
-        Logger.debug { "isFirstSummon:\(session.isFirstSummon) shortcutIndex:\(shortcutIndex)" }
+        let shortcutSwitching = !session.isFirstSummon && shortcutIndex != session.shortcutIndex
+        Logger.debug { "isFirstSummon:\(session.isFirstSummon) shortcutIndex:\(shortcutIndex) shortcutSwitching:\(shortcutSwitching)" }
         UsageStats.recordTrigger(shortcutIndex)
-        if session.isFirstSummon || shortcutIndex != session.shortcutIndex {
+        if session.isFirstSummon || shortcutSwitching {
+            var restoreState = false
+            SwitcherSession.frontmostPidOverride = nil
+            SwitcherSession.useLastFocusedRuleOverride = nil
+            if shortcutSwitching {
+                if Preferences.restoreState(session.shortcutIndex) {
+                    SwitcherSession.sessionOverrides[session.shortcutIndex] = session.copy()
+                }
+                if Preferences.usePreviousSelectedApp(shortcutIndex) {
+                    SwitcherSession.frontmostPidOverride = Windows.selectedWindow()?.application.pid
+                }
+                if Preferences.selectLastFocusedWindow(shortcutIndex) {
+                    SwitcherSession.useLastFocusedRuleOverride = true
+                }
+                if
+                    Preferences.restoreState(shortcutIndex),
+                    let sessionOverride = SwitcherSession.sessionOverrides[shortcutIndex]
+                {
+                    SwitcherSession.current = sessionOverride
+                    session = sessionOverride
+                    restoreState = true
+                } else {
+                    let newSession = SwitcherSession()
+                    SwitcherSession.current = newSession
+                    session = newSession
+                }
+            }
             NSScreen.updatePreferred()
             if isVeryFirstSummon {
                 Windows.sortByLevel()
@@ -335,7 +363,11 @@ class App: AppCenterApplication {
                 session.forceDoNothingOnRelease = true
             }
             if !Windows.updatesBeforeShowing() { hideUi(); return }
-            Windows.setInitialSelectedAndHoveredWindowIndex()
+            if restoreState {
+                Windows.cycleSelectedWindowIndex(1, allowWrap: true)
+            } else {
+                Windows.setInitialSelectedAndHoveredWindowIndex()
+            }
             if Preferences.windowDisplayDelay == DispatchTimeInterval.milliseconds(0) {
                 buildUiAndShowPanel()
             } else {

--- a/src/App.swift
+++ b/src/App.swift
@@ -98,7 +98,8 @@ class App: AppCenterApplication {
         guard SwitcherSession.isActive else { return } // already hidden
         let selectedWindow = Windows.selectedWindow()
         Logger.info { selectedWindow?.debugId }
-        focusSelectedWindow(selectedWindow)
+        let forceIsWindowlessApp = Preferences.effectiveShortcutStyle(SwitcherSession.activeShortcutIndex) == .openOnRelease
+        focusSelectedWindow(selectedWindow, forceIsWindowlessApp)
     }
 
     @objc static func checkForUpdatesNow(_ sender: NSMenuItem) {
@@ -264,11 +265,11 @@ class App: AppCenterApplication {
         KeyRepeatTimer.startRepeatingKeyPreviousWindow()
     }
 
-    static func focusSelectedWindow(_ selectedWindow: Window?) {
+    static func focusSelectedWindow(_ selectedWindow: Window?, _ forceIsWindowlessApp: Bool) {
         guard SwitcherSession.isActive else { return } // already hidden
         hideUi(true)
         if let window = selectedWindow, MissionControl.state() == .inactive || MissionControl.state() == .showDesktop {
-            window.focus()
+            window.focus(forceIsWindowlessApp)
             if Preferences.cursorFollowFocus == .always || (
                 Preferences.cursorFollowFocus == .differentScreen && (Spaces.screenSpacesMap.first { $0.value.contains { space in window.spaceIds.contains(space) } })?.key != NSScreen.active()?.cachedUuid()) {
                 moveCursorToSelectedWindow(window)

--- a/src/events/TrackpadEvents.swift
+++ b/src/events/TrackpadEvents.swift
@@ -85,10 +85,12 @@ class TrackpadEvents {
         if fingersDown <= TriggerSwipeDetector.maxFingersDownDuringTrigger - requiredFingers {
             if let session = SwitcherSession.current,
                session.shortcutIndex == Preferences.gestureIndex,
-               !session.forceDoNothingOnRelease,
-               Preferences.effectiveShortcutStyle(session.shortcutIndex) == .focusOnRelease {
-                DispatchQueue.main.async {
-                    App.focusTarget()
+               !session.forceDoNothingOnRelease {
+                let style = Preferences.effectiveShortcutStyle(session.shortcutIndex)
+                if style == .focusOnRelease || style == .openOnRelease {
+                    DispatchQueue.main.async {
+                        App.focusTarget()
+                    }
                 }
             }
             return

--- a/src/preferences/MacroPreferences.swift
+++ b/src/preferences/MacroPreferences.swift
@@ -101,12 +101,14 @@ enum ShortcutStylePreference: CaseIterable, SfSymbolMacroPreference {
     case focusOnRelease
     case doNothingOnRelease
     case searchOnRelease
+    case openOnRelease
 
     var localizedString: LocalizedString {
         switch self {
             case .focusOnRelease: return NSLocalizedString("Focus", comment: "")
             case .doNothingOnRelease: return NSLocalizedString("Hold", comment: "")
             case .searchOnRelease: return NSLocalizedString("Search", comment: "")
+            case .openOnRelease: return NSLocalizedString("Open", comment: "")
         }
     }
 
@@ -115,6 +117,7 @@ enum ShortcutStylePreference: CaseIterable, SfSymbolMacroPreference {
             case .focusOnRelease: return .cursorarrowRays
             case .doNothingOnRelease: return .pauseRectangle
             case .searchOnRelease: return .magnifyingglass
+            case .openOnRelease: return .arrowUpForwardApp
         }
     }
 }

--- a/src/preferences/Preferences.swift
+++ b/src/preferences/Preferences.swift
@@ -30,6 +30,7 @@ class Preferences {
             "showOnScreen": ShowOnScreenPreference.active.indexAsString,
             "titleTruncation": TitleTruncationPreference.end.indexAsString,
             "showTitles": ShowTitlesPreference.windowTitle.indexAsString,
+            "showTitlesForAppIcons": ShowTitlesPreference.appName.indexAsString,
             "fadeOutAnimation": "false",
             "previewFadeInAnimation": "true",
             "startAtLogin": "true",
@@ -137,6 +138,7 @@ class Preferences {
     static var showOnScreen: ShowOnScreenPreference { CachedUserDefaults.macroPref("showOnScreen", ShowOnScreenPreference.allCases) }
     static var titleTruncation: TitleTruncationPreference { CachedUserDefaults.macroPref("titleTruncation", TitleTruncationPreference.allCases) }
     static var showTitles: ShowTitlesPreference { CachedUserDefaults.macroPref("showTitles", ShowTitlesPreference.allCases) }
+    static var showTitlesForAppIcons: ShowTitlesPreference { CachedUserDefaults.macroPref("showTitlesForAppIcons", ShowTitlesPreference.allCases) }
     static var updatePolicy: UpdatePolicyPreference { CachedUserDefaults.macroPref("updatePolicy", UpdatePolicyPreference.allCases) }
     static var crashPolicy: CrashPolicyPreference { CachedUserDefaults.macroPref("crashPolicy", CrashPolicyPreference.allCases) }
     static var appsToShow: [AppsToShowPreference] { (0...maxShortcutCount).map { CachedUserDefaults.macroPref(indexToName("appsToShow", $0), AppsToShowPreference.allCases) } }

--- a/src/preferences/Preferences.swift
+++ b/src/preferences/Preferences.swift
@@ -61,6 +61,9 @@ class Preferences {
             values[indexToName("showFullscreenWindows", index)] = ShowHowPreference.show.indexAsString
             values[indexToName("showWindowlessApps", index)] = ShowHowPreference.showAtTheEnd.indexAsString
             values[indexToName("windowOrder", index)] = WindowOrderPreference.recentlyFocused.indexAsString
+            values[indexToName("restoreState", index)] = "false"
+            values[indexToName("usePreviousSelectedApp", index)] = "false"
+            values[indexToName("selectLastFocusedWindow", index)] = "false"
             values[indexToName("shortcutStyle", index)] = ShortcutStylePreference.focusOnRelease.indexAsString
             values[indexToName("showAppsOrWindows", index)] = GroupAppsPreference.allWindows.indexAsString
             values[indexToName("showTabsAsWindows", index)] = GroupTabsPreference.singleWindow.indexAsString
@@ -150,6 +153,9 @@ class Preferences {
     static func showFullscreenWindows(_ i: Int) -> ShowHowPreference { CachedUserDefaults.macroPref(indexToName("showFullscreenWindows", i), ShowHowPreference.allCases) }
     static func showWindowlessApps(_ i: Int) -> ShowHowPreference { CachedUserDefaults.macroPref(indexToName("showWindowlessApps", i), ShowHowPreference.allCases) }
     static func windowOrder(_ i: Int) -> WindowOrderPreference { CachedUserDefaults.macroPref(indexToName("windowOrder", i), WindowOrderPreference.allCases) }
+    static func restoreState(_ i: Int) -> Bool { CachedUserDefaults.bool(indexToName("restoreState", i)) }
+    static func usePreviousSelectedApp(_ i: Int) -> Bool { CachedUserDefaults.bool(indexToName("usePreviousSelectedApp", i)) }
+    static func selectLastFocusedWindow(_ i: Int) -> Bool { CachedUserDefaults.bool(indexToName("selectLastFocusedWindow", i)) }
     static func groupApps(_ i: Int) -> GroupAppsPreference { CachedUserDefaults.macroPref(indexToName("showAppsOrWindows", i), GroupAppsPreference.allCases) }
     static func groupTabs(_ i: Int) -> GroupTabsPreference { CachedUserDefaults.macroPref(indexToName("showTabsAsWindows", i), GroupTabsPreference.allCases) }
     static var shortcutStyle: ShortcutStylePreference { ProGatedPreferences.shortcutStyle.read() }

--- a/src/preferences/Preferences.swift
+++ b/src/preferences/Preferences.swift
@@ -42,6 +42,7 @@ class Preferences {
             "crashPolicy": CrashPolicyPreference.ask.indexAsString,
             "hideThumbnails": "false",
             "hideSpaceNumberLabels": "false",
+            "hideMoreWindowsIcon": "false",
             "hideStatusIcons": "false",
             "previewFocusedWindow": "false",
             "captureWindowsInBackground": "true",
@@ -120,6 +121,7 @@ class Preferences {
     static var fadeOutAnimation: Bool { CachedUserDefaults.bool("fadeOutAnimation") }
     static var previewFadeInAnimation: Bool { CachedUserDefaults.bool("previewFadeInAnimation") }
     static var hideSpaceNumberLabels: Bool { CachedUserDefaults.bool("hideSpaceNumberLabels") }
+    static var hideMoreWindowsIcon: Bool { CachedUserDefaults.bool("hideMoreWindowsIcon") }
     static var hideStatusIcons: Bool { CachedUserDefaults.bool("hideStatusIcons") }
     // periphery:ignore
     static var startAtLogin: Bool { CachedUserDefaults.bool("startAtLogin") }

--- a/src/preferences/settings-window/SettingsWindow.swift
+++ b/src/preferences/settings-window/SettingsWindow.swift
@@ -1264,6 +1264,10 @@ extension SettingsWindow: NSWindowDelegate {
             SettingsWindow.shared = nil
         }
     }
+    
+    func window(_ window: NSWindow, willPositionSheet sheet: NSWindow, using rect: NSRect) -> NSRect {
+        return NSRect(x: rect.origin.x, y: window.frame.height, width: rect.width, height: rect.height)
+    }
 }
 
 extension SettingsWindow: NSSearchFieldDelegate {

--- a/src/preferences/settings-window/SettingsWindow.swift
+++ b/src/preferences/settings-window/SettingsWindow.swift
@@ -242,7 +242,7 @@ private final class SidebarSearchField: NSSearchField {
 }
 
 class SettingsWindow: NSWindow {
-    static let contentWidth = CGFloat(710)
+    static let contentWidth = CGFloat(790)
     static let width = contentWidth
     /// Horizontal margin inside each section between the section's container and the
     /// TableGroupView's rounded background, so the gray-bg blocks "float" inside the section

--- a/src/preferences/settings-window/tabs/appearance/AppearanceTab.swift
+++ b/src/preferences/settings-window/tabs/appearance/AppearanceTab.swift
@@ -8,8 +8,8 @@ class NonHitTestingView: NSView {
 
 struct ShowHideRowInfo {
     var rowId: String!
-    var uncheckedImage: String!
-    var checkedImage: String!
+    var uncheckedImage: String?
+    var checkedImage: String?
     var supportedStyles: [AppearanceStylePreference]!
     var subTitle: String?
     var leftViews = [NSView]()
@@ -156,6 +156,7 @@ class ShowHideIllustratedView {
     static let hideStatusIconsLabel = NSLocalizedString("Hide status icons", comment: "")
     static let hideStatusIconsSubtitle = NSLocalizedString("AltTab will show if the window is currently minimized or fullscreen with a status icon.", comment: "")
     static let hideSpaceNumberLabelsLabel = NSLocalizedString("Hide Space number labels", comment: "")
+    static let hideMoreWindowsIconLabel = NSLocalizedString("Hide more windows icon", comment: "")
     static let hideColoredCirclesLabel = NSLocalizedString("Hide colored circles on mouse hover", comment: "")
 
     private let style: AppearanceStylePreference
@@ -213,6 +214,16 @@ class ShowHideIllustratedView {
             self.onCheckboxClicked(sender: sender, rowId: hideSpaceNumberLabels.rowId)
         }))
         showHideRows.append(hideSpaceNumberLabels)
+        var hideMoreWindowsIcon = ShowHideRowInfo()
+        hideMoreWindowsIcon.rowId = "hideMoreWindowsIcon"
+        hideMoreWindowsIcon.uncheckedImage = nil
+        hideMoreWindowsIcon.checkedImage = nil
+        hideMoreWindowsIcon.supportedStyles = [.thumbnails, .titles]
+        hideMoreWindowsIcon.leftViews = [TableGroupView.makeText(ShowHideIllustratedView.hideMoreWindowsIconLabel)]
+        hideMoreWindowsIcon.rightViews.append(LabelAndControl.makeSwitch(hideMoreWindowsIcon.rowId, extraAction: { sender in
+            self.onCheckboxClicked(sender: sender, rowId: hideMoreWindowsIcon.rowId)
+        }))
+        showHideRows.append(hideMoreWindowsIcon)
         var hideColoredCircles = ShowHideRowInfo()
         hideColoredCircles.rowId = "hideColoredCircles"
         hideColoredCircles.uncheckedImage = "show_colored_circles"
@@ -244,8 +255,11 @@ class ShowHideIllustratedView {
             illustratedImageView.showPlaceholder()
             return
         }
-        let imageName = isChecked ? row.checkedImage : row.uncheckedImage
-        illustratedImageView.highlight(true, imageName!)
+        if let imageName = isChecked ? row.checkedImage : row.uncheckedImage {
+            illustratedImageView.highlight(true, imageName)
+        } else {
+            illustratedImageView.highlight(false)
+        }
     }
 
     private func updateImageView(rowId: String) {
@@ -257,8 +271,11 @@ class ShowHideIllustratedView {
         row.rightViews.forEach { view in
             if let checkbox = view as? NSButton {
                 let isChecked = checkbox.state == .on
-                let imageName = isChecked ? row.checkedImage : row.uncheckedImage
-                illustratedImageView.highlight(true, imageName!)
+                if let imageName = isChecked ? row.checkedImage : row.uncheckedImage {
+                    illustratedImageView.highlight(true, imageName)
+                } else {
+                    illustratedImageView.highlight(false)
+                }
             }
         }
     }

--- a/src/preferences/settings-window/tabs/appearance/CustomizeStyleSheet.swift
+++ b/src/preferences/settings-window/tabs/appearance/CustomizeStyleSheet.swift
@@ -5,11 +5,13 @@ class CustomizeStyleSheet: SheetWindow {
     // `ShowHideIllustratedView`'s static constants so each NSLocalizedString call lives in
     // exactly one place across the codebase.
     private static let labelShowTitles = NSLocalizedString("Show titles", comment: "")
+    private static let labelShowTitlesForAppIcons = NSLocalizedString("Show titles for app icons", comment: "")
     private static let labelTitleTruncation = NSLocalizedString("Title truncation", comment: "")
 
     /// Pre-build search index for the open-button. See `SettingsSearchIndex.sheetSearchableStrings`.
     static let searchableStrings: [String] = [
         labelShowTitles,
+        labelShowTitlesForAppIcons,
         labelTitleTruncation,
         ShowHideIllustratedView.hideStatusIconsLabel,
         ShowHideIllustratedView.hideStatusIconsSubtitle,
@@ -43,6 +45,14 @@ class CustomizeStyleSheet: SheetWindow {
         advancedTable.addRow(showTitles, onMouseEntered: { [weak self] _, _ in
             self?.showTitlesIllustratedImage()
         })
+        let showTitlesForAppIcons = TableGroupView.Row(leftTitle: Self.labelShowTitlesForAppIcons,
+            rightViews: [LabelAndControl.makeDropdown(
+                "showTitlesForAppIcons", ShowTitlesPreference.allCases, extraAction: { [weak self] _ in
+                    self?.showTitlesForAppIconsIllustratedImage()
+                })])
+        advancedTable.addRow(showTitlesForAppIcons, onMouseEntered: { [weak self] _, _ in
+            self?.showTitlesForAppIconsIllustratedImage()
+        })
         let titleTruncation = TableGroupView.Row(leftTitle: Self.labelTitleTruncation,
             rightViews: LabelAndControl.makeRadioButtons("titleTruncation", TitleTruncationPreference.allCases))
         advancedTable.addRow(titleTruncation)
@@ -56,5 +66,9 @@ class CustomizeStyleSheet: SheetWindow {
 
     private func showTitlesIllustratedImage() {
         illustratedImageView.highlight(true, Preferences.showTitles.image.name)
+    }
+    
+    private func showTitlesForAppIconsIllustratedImage() {
+        illustratedImageView.highlight(false)
     }
 }

--- a/src/preferences/settings-window/tabs/appearance/CustomizeStyleSheet.swift
+++ b/src/preferences/settings-window/tabs/appearance/CustomizeStyleSheet.swift
@@ -16,6 +16,7 @@ class CustomizeStyleSheet: SheetWindow {
         ShowHideIllustratedView.hideStatusIconsLabel,
         ShowHideIllustratedView.hideStatusIconsSubtitle,
         ShowHideIllustratedView.hideSpaceNumberLabelsLabel,
+        ShowHideIllustratedView.hideMoreWindowsIconLabel,
         ShowHideIllustratedView.hideColoredCirclesLabel,
         IllustratedImageThemeView.placeholderLabelText,
     ] + ShowTitlesPreference.allCases.map { $0.localizedString }

--- a/src/preferences/settings-window/tabs/controls/ShortcutEditor.swift
+++ b/src/preferences/settings-window/tabs/controls/ShortcutEditor.swift
@@ -361,10 +361,13 @@ final class OrderingPane {
     private static let labelGroupApps = NSLocalizedString("Group apps", comment: "")
     private static let labelGroupTabs = NSLocalizedString("Group tabs", comment: "")
     private static let labelWindowOrder = NSLocalizedString("Order windows by", comment: "")
+    private static let labelRestoreState = NSLocalizedString("Restore state when switching shortcut", comment: "")
+    private static let labelUsePreviousSelectedApp = NSLocalizedString("Use previous selected app as active app when switching shortcut", comment: "")
+    private static let labelSelectLastFocusedWindow = NSLocalizedString("Select last focused window when switching shortcut", comment: "")
 
     /// See `FilteringPane.searchableStrings`.
     static let searchableStrings: [String] = [
-        labelGroupApps, labelGroupTabs, labelWindowOrder,
+        labelGroupApps, labelGroupTabs, labelWindowOrder, labelRestoreState, labelUsePreviousSelectedApp, labelSelectLastFocusedWindow
     ] + GroupAppsPreference.allCases.map { $0.localizedString }
       + GroupTabsPreference.allCases.map { $0.localizedString }
       + WindowOrderPreference.allCases.map { $0.localizedString }
@@ -373,16 +376,25 @@ final class OrderingPane {
     private let showAppsOrWindows: ShortcutBoundDropdown
     private let showTabsAsWindows: ShortcutBoundDropdown
     private let windowOrder: ShortcutBoundDropdown
+    private let restoreState: ShortcutBoundSwitch
+    private let usePreviousSelectedApp: ShortcutBoundSwitch
+    private let selectLastFocusedWindow: ShortcutBoundSwitch
 
     init(width: CGFloat) {
         showAppsOrWindows = ShortcutBoundDropdown(baseName: "showAppsOrWindows", cases: GroupAppsPreference.allCases)
         showTabsAsWindows = ShortcutBoundDropdown(baseName: "showTabsAsWindows", cases: GroupTabsPreference.allCases)
         windowOrder = ShortcutBoundDropdown(baseName: "windowOrder", cases: WindowOrderPreference.allCases)
+        restoreState = ShortcutBoundSwitch(baseName: "restoreState")
+        usePreviousSelectedApp = ShortcutBoundSwitch(baseName: "usePreviousSelectedApp")
+        selectLastFocusedWindow = ShortcutBoundSwitch(baseName: "selectLastFocusedWindow")
 
         let table = TableGroupView(width: width)
         table.addRow(TableGroupView.Row(leftTitle: Self.labelGroupApps, rightViews: [showAppsOrWindows]))
         table.addRow(TableGroupView.Row(leftTitle: Self.labelGroupTabs, rightViews: [showTabsAsWindows]))
         table.addRow(TableGroupView.Row(leftTitle: Self.labelWindowOrder, rightViews: [windowOrder]))
+        table.addRow(TableGroupView.Row(leftTitle: Self.labelRestoreState, rightViews: [restoreState.toggle]))
+        table.addRow(TableGroupView.Row(leftTitle: Self.labelUsePreviousSelectedApp, rightViews: [usePreviousSelectedApp.toggle]))
+        table.addRow(TableGroupView.Row(leftTitle: Self.labelSelectLastFocusedWindow, rightViews: [selectLastFocusedWindow.toggle]))
         view = table
     }
 
@@ -390,6 +402,9 @@ final class OrderingPane {
         showAppsOrWindows.bind(toShortcut: index)
         showTabsAsWindows.bind(toShortcut: index)
         windowOrder.bind(toShortcut: index)
+        restoreState.bind(toShortcut: index)
+        usePreviousSelectedApp.bind(toShortcut: index)
+        selectLastFocusedWindow.bind(toShortcut: index)
     }
 }
 
@@ -521,6 +536,36 @@ final class ShortcutBoundDropdown: PopupButtonLikeSystemSettings {
         let selectedIndex = CachedUserDefaults.intFromMacroPref(key, cases)
         let clamped = max(0, min(selectedIndex, numberOfItems - 1))
         selectItem(at: clamped)
+    }
+}
+
+final class ShortcutBoundSwitch {
+    let toggle: Switch
+
+    private let baseName: String
+    private var currentShortcutIndex: Int = 0
+
+    init(baseName: String) {
+        self.baseName = baseName
+        toggle = LabelAndControl.makeSwitch(Preferences.indexToName(baseName, 0), extraAction: nil)
+
+        let weakSelf = WeakRef(self)
+        toggle.onAction = { c in
+            weakSelf.value?.handleToggle(c as! Switch)
+        }
+    }
+
+    func bind(toShortcut index: Int) {
+        currentShortcutIndex = index
+        let key = Preferences.indexToName(baseName, index)
+        toggle.identifier = NSUserInterfaceItemIdentifier(key)
+        let on = CachedUserDefaults.bool(key)
+        toggle.setSilently(on ? .on : .off)
+    }
+
+    private func handleToggle(_ control: Switch) {
+        let key = Preferences.indexToName(baseName, currentShortcutIndex)
+        Preferences.set(key, control.state == .on ? "true" : "false")
     }
 }
 

--- a/src/pro/ui/ProBadgeView.swift
+++ b/src/pro/ui/ProBadgeView.swift
@@ -263,6 +263,7 @@ class ProBadgeView: NSView {
             segmentedControl.setToolTip(label, forSegment: segmentIndex)
         }
         let segmentLeading = (0..<segmentIndex).reduce(CGFloat(0)) { $0 + segmentedControl.width(forSegment: $1) }
+        let segmentTrailing = ((segmentIndex + 1)..<segmentedControl.segmentCount).reduce(CGFloat(0)) { $0 + segmentedControl.width(forSegment: $1) }
         let colorProvider = segmentColorProvider(for: segmentedControl, segmentIndex: segmentIndex)
         let iconView = DynamicColorImageView()
         iconView.colorProvider = colorProvider
@@ -304,6 +305,7 @@ class ProBadgeView: NSView {
         } else {
             leadingOffset = segmentLeading + max(maxContentRightEdge - contentWidth, 8)
         }
+        let trailingOffset = segmentTrailingPadding + segmentTrailing
         NSLayoutConstraint.activate([
             iconView.leadingAnchor.constraint(equalTo: segmentedControl.leadingAnchor, constant: leadingOffset),
             iconView.centerYAnchor.constraint(equalTo: segmentedControl.centerYAnchor),
@@ -312,7 +314,7 @@ class ProBadgeView: NSView {
             textLabel.trailingAnchor.constraint(lessThanOrEqualTo: badge.leadingAnchor),
             textLabel.widthAnchor.constraint(lessThanOrEqualToConstant: availableWidth - iconWidth - 2),
             badge.centerYAnchor.constraint(equalTo: segmentedControl.centerYAnchor),
-            badge.trailingAnchor.constraint(equalTo: segmentedControl.trailingAnchor, constant: -segmentTrailingPadding),
+            badge.trailingAnchor.constraint(equalTo: segmentedControl.trailingAnchor, constant: -trailingOffset),
         ])
         return SegmentOverlay(badge: badge, icon: iconView, label: textLabel)
     }

--- a/src/switcher/ATShortcut.swift
+++ b/src/switcher/ATShortcut.swift
@@ -67,8 +67,11 @@ class ATShortcut {
                 return true
             }
             if triggerPhase == .up, let session, index == nil || index == session.shortcutIndex,
-               !session.forceDoNothingOnRelease, Preferences.effectiveShortcutStyle(session.shortcutIndex) == .focusOnRelease {
-                return true
+               !session.forceDoNothingOnRelease {
+                let style = Preferences.effectiveShortcutStyle(session.shortcutIndex)
+                if style == .focusOnRelease || style == .openOnRelease {
+                    return true
+                }
             }
         }
         if scope == .local {
@@ -93,13 +96,16 @@ class ATShortcut {
         // Another issue is events being dropped by macOS, which we never receive
         // Knowing this, we handle these edge-cases by double checking if holdShortcut is UP, when any shortcut state is UP
         // If it is, then we trigger the holdShortcut action
-        if let session = SwitcherSession.current, !session.forceDoNothingOnRelease, Preferences.effectiveShortcutStyle(session.shortcutIndex) == .focusOnRelease {
-            if let currentHoldShortcut = ControlsTab.shortcuts[Preferences.indexToName("holdShortcut", session.shortcutIndex)],
-               id == currentHoldShortcut.id {
-                let currentModifiers = cocoaToCarbonFlags(ModifierFlags.current)
-                if currentModifiers != (currentModifiers | (currentHoldShortcut.shortcut.carbonModifierFlags)) {
-                    currentHoldShortcut.state = .up
-                    ShortcutActions.execute(currentHoldShortcut.id)
+        if let session = SwitcherSession.current, !session.forceDoNothingOnRelease {
+            let style = Preferences.effectiveShortcutStyle(session.shortcutIndex)
+            if style == .focusOnRelease || style == .openOnRelease {
+                if let currentHoldShortcut = ControlsTab.shortcuts[Preferences.indexToName("holdShortcut", session.shortcutIndex)],
+                   id == currentHoldShortcut.id {
+                    let currentModifiers = cocoaToCarbonFlags(ModifierFlags.current)
+                    if currentModifiers != (currentModifiers | (currentHoldShortcut.shortcut.carbonModifierFlags)) {
+                        currentHoldShortcut.state = .up
+                        ShortcutActions.execute(currentHoldShortcut.id)
+                    }
                 }
             }
         }

--- a/src/switcher/SwitcherSession.swift
+++ b/src/switcher/SwitcherSession.swift
@@ -12,6 +12,9 @@ final class SwitcherSession {
     /// The shortcut index of the currently-active session, or 0 when no session is active.
     /// Used by every per-shortcut effective preference read in `Appearance`, `TileView`, etc.
     static var activeShortcutIndex: Int { current?.shortcutIndex ?? 0 }
+    static var sessionOverrides: [Int: SwitcherSession] = [:]
+    static var frontmostPidOverride: pid_t?
+    static var useLastFocusedRuleOverride: Bool?
 
     var shortcutIndex: Int = 0
     var isFirstSummon: Bool = true
@@ -21,4 +24,16 @@ final class SwitcherSession {
     var hoveredIndex: Int?
     var selectedTarget: String?
     var searchQuery: String = ""
+    
+    func copy() -> SwitcherSession {
+        let session = SwitcherSession()
+        session.shortcutIndex = shortcutIndex
+        session.isFirstSummon = isFirstSummon
+        session.forceDoNothingOnRelease = forceDoNothingOnRelease
+        session.selectedIndex = selectedIndex
+        session.hoveredIndex = hoveredIndex
+        session.selectedTarget = selectedTarget
+        session.searchQuery = searchQuery
+        return session
+    }
 }

--- a/src/switcher/main-window/StatusIconsView.swift
+++ b/src/switcher/main-window/StatusIconsView.swift
@@ -11,12 +11,14 @@ class StatusIconsView: FlippedView {
     static let hiddenIdx = 1
     static let fullscreenIdx = 2
     static let minimizedIdx = 3
+    static let moreWindowsIdx = 4
 
     private static let defaultSymbols: [(Symbols, String?)] = [
         (.circledNumber0, nil),
         (.circledSlashSign, NSLocalizedString("App is hidden", comment: "")),
         (.circledPlusSign, NSLocalizedString("Window is fullscreen", comment: "")),
         (.circledMinusSign, NSLocalizedString("Window is minimized", comment: "")),
+        (.macwindowStack, NSLocalizedString("More windows", comment: ""))
     ]
 
     var icons: [Icon]
@@ -60,11 +62,12 @@ class StatusIconsView: FlippedView {
 
     var totalWidth: CGFloat { CGFloat(visibleCount) * TilesView.layoutCache.iconWidth }
 
-    func update(isHidden: Bool, isFullscreen: Bool, isMinimized: Bool, showSpace: Bool) {
+    func update(isHidden: Bool, isFullscreen: Bool, isMinimized: Bool, showSpace: Bool, showMoreWindows: Bool) {
         icons[Self.hiddenIdx].visible = isHidden
         icons[Self.fullscreenIdx].visible = isFullscreen
         icons[Self.minimizedIdx].visible = isMinimized
         icons[Self.spaceIdx].visible = showSpace
+        icons[Self.moreWindowsIdx].visible = showMoreWindows
         visibleCount = icons.count(where: { $0.visible })
     }
 

--- a/src/switcher/main-window/TileFontIconView.swift
+++ b/src/switcher/main-window/TileFontIconView.swift
@@ -13,6 +13,7 @@ enum Symbols: String {
     case circledStar = "􀕬"           // star.circle
     case filledCircledStar = "􀕭"     // star.circle.fill
     case circledInfo = "􀅴"           // info.circle
+    case macwindowStack = "􃑷"        // macwindow.stack
     // Preferences sidebar tab icons
     case paintpalette = "􀝥"          // paintpalette
     case command = "􀆔"               // command

--- a/src/switcher/main-window/TileFontIconView.swift
+++ b/src/switcher/main-window/TileFontIconView.swift
@@ -35,6 +35,7 @@ enum Symbols: String {
     case cursorarrowRays = "􀇰"       // cursorarrow.rays
     case pauseRectangle = "􀊛"        // pause.rectangle
     case magnifyingglass = "􀊫"       // magnifyingglass
+    case arrowUpForwardApp = "􀮵"                   // arrow.up.forward.app
     // AppearanceSizePreference
     case moonphaseWaningGibbousInverse = "􁐎"   // moonphase.waning.gibbous.inverse
     case moonphaseLastQuarterInverse = "􁐏"     // moonphase.last.quarter.inverse

--- a/src/switcher/main-window/TileView.swift
+++ b/src/switcher/main-window/TileView.swift
@@ -265,7 +265,8 @@ class TileView: FlippedView {
                 return Preferences.spacesToShow[shortcutIndex] == .visible && (
                     NSScreen.screens.count < 2 || Preferences.screensToShow[shortcutIndex] == .showingAltTab
                 )
-            }())
+            }()),
+            showMoreWindows: !Preferences.hideMoreWindowsIcon && Preferences.groupApps(SwitcherSession.activeShortcutIndex) == .mainWindow && !element.isWindowlessApp && Windows.list.contains { $0.application.pid == element.application.pid && !$0.shouldShowTheUser && !$0.isPhantom && (Preferences.groupTabs(SwitcherSession.activeShortcutIndex) == .separateWindows || !$0.isTabbed) }
         )
         if !thumbnail.isHidden {
             if let screenshot = element.thumbnail {

--- a/src/switcher/main-window/TileView.swift
+++ b/src/switcher/main-window/TileView.swift
@@ -297,7 +297,10 @@ class TileView: FlippedView {
         updateAppIcon(element, title)
         updateDockLabelIcon(element.dockLabel)
         setAccessibilityHelp(getAccessibilityHelp(element.application.localizedName, element.dockLabel))
-        mouseUpCallback = { () -> Void in App.focusSelectedWindow(element) }
+        mouseUpCallback = { () -> Void in
+            let forceIsWindowlessApp = Preferences.effectiveShortcutStyle(SwitcherSession.activeShortcutIndex) == .openOnRelease
+            App.focusSelectedWindow(element, forceIsWindowlessApp)
+        }
         mouseMovedCallback = { () -> Void in Windows.updateSelectedAndHoveredWindowIndex(index, true) }
     }
 

--- a/src/switcher/main-window/TileView.swift
+++ b/src/switcher/main-window/TileView.swift
@@ -366,13 +366,14 @@ class TileView: FlippedView {
 
     private func searchSpanRanges() -> [NSRange] {
         var spanRanges = [NSRange]()
-        if Preferences.showTitles == .appName {
+        let showTitles = Preferences.effectiveAppearanceStyle(SwitcherSession.activeShortcutIndex) == .appIcons ? Preferences.showTitlesForAppIcons : Preferences.showTitles
+        if showTitles == .appName {
             for result in window_?.swAppResults ?? [] {
                 spanRanges.append(NSRange(location: result.span.lowerBound, length: result.span.count))
             }
             return spanRanges
         }
-        if Preferences.showTitles == .appNameAndWindowTitle {
+        if showTitles == .appNameAndWindowTitle {
             let appName = window_?.application.localizedName ?? ""
             let windowTitle = window_?.title ?? ""
             let offset = (appName.isEmpty || appName == windowTitle) ? 0 : (appName + " - ").count
@@ -570,9 +571,10 @@ class TileView: FlippedView {
     private func getAppOrAndWindowTitle() -> String {
         let appName = window_?.application.localizedName
         let windowTitle = window_?.title
-        if Preferences.showTitles == .appName {
+        let showTitles = Preferences.effectiveAppearanceStyle(SwitcherSession.activeShortcutIndex) == .appIcons ? Preferences.showTitlesForAppIcons : Preferences.showTitles
+        if showTitles == .appName {
             return appName ?? ""
-        } else if Preferences.showTitles == .appNameAndWindowTitle {
+        } else if showTitles == .appNameAndWindowTitle {
             if appName == windowTitle {
                 return appName ?? ""
             }

--- a/src/switcher/state/SelectionResolver.swift
+++ b/src/switcher/state/SelectionResolver.swift
@@ -94,15 +94,17 @@ enum SelectionResolver {
     /// the list is empty or no window is visible.
     static func cycleFromZero(_ list: [SelectionWindow]) -> Int? {
         guard !list.isEmpty else { return nil }
-        // Try indices 1, 2, …, count-1, then 0 (wrap). Single return point — the trailing
-        // `return nil` covers the "no window visible" case without needing a separate guard.
-        for offset in 1...list.count {
-            let idx = offset % list.count
+        var firstVisible: Int?
+        for idx in 0..<list.count {
             if list[idx].visible {
-                return idx
+                if firstVisible == nil {
+                    firstVisible = idx
+                } else {
+                    return idx
+                }
             }
         }
-        return nil
+        return firstVisible
     }
 
     /// Returns the index of the visible non-windowless window with the lowest `lastFocusOrder`.

--- a/src/switcher/state/Window.swift
+++ b/src/switcher/state/Window.swift
@@ -248,12 +248,12 @@ class Window {
         }
     }
 
-    func focus() {
+    func focus(_ forceIsWindowlessApp: Bool = false) {
         if let altTabWindow = altTabWindow() {
             App.shared.activate(ignoringOtherApps: true)
             altTabWindow.makeKeyAndOrderFront(nil)
             WindowThumbnails.previewSelectedIfNeeded()
-        } else if self.isWindowlessApp || cgWindowId == nil {
+        } else if forceIsWindowlessApp || self.isWindowlessApp || cgWindowId == nil {
             if let bundleUrl = application.bundleURL, self.isWindowlessApp {
                 if (try? NSWorkspace.shared.launchApplication(at: bundleUrl, configuration: [:])) == nil {
                     application.runningApplication.activate(options: .activateAllWindows)

--- a/src/switcher/state/Windows.swift
+++ b/src/switcher/state/Windows.swift
@@ -113,7 +113,7 @@ class Windows {
             onlyNonVisibleSpaces: f.spacesToShow == .nonVisible,
             onlyPreferredScreen: f.screensToShow == .showingAltTab,
             separateTabs: f.groupTabs == .separateWindows,
-            frontmostPid: Applications.frontmostPid,
+            frontmostPid: SwitcherSession.frontmostPidOverride ?? Applications.frontmostPid,
             visibleSpaceIds: Spaces.visibleSpaces,
             exceptions: f.exceptions,
             isOnPreferredScreen: window.isOnScreen(NSScreen.preferred))
@@ -193,8 +193,8 @@ class Windows {
             list: snapshot,
             selectedIndex: session.selectedIndex,
             selectedTarget: session.selectedTarget,
-            useLastFocusedRule: Applications.frontmostPid != nil
-                && Preferences.windowOrder[session.shortcutIndex] != .recentlyFocused,
+            useLastFocusedRule: SwitcherSession.useLastFocusedRuleOverride ?? (Applications.frontmostPid != nil
+                && Preferences.windowOrder[session.shortcutIndex] != .recentlyFocused),
             restoreDefaultOnSearchClear: shouldRestoreDefaultSelectionOnSearchClear,
             bestMatchOnSearchChange: shouldSelectBestMatchOnSearchChange)
     }


### PR DESCRIPTION
Add the necessary settings to create a two-level window switcher: selecting the app and then the window

- Restore state when switching shortcut
- Use previous selected app as active app when switching shortcut
- Select last focused window when switching shortcut
- Show titles for app icons
- After keys are released: Open
- Hide more windows icon

This is more of a proof of concept. A better user experience might be to display both apps and windows, either in two panels or in a grid.

Example of settings for selecting the app and then the window:

```
<dict>
	<key>appearanceStyleOverride</key>
	<string>1</string>
    <key>shortcutStyleOverride</key>
	<string>3</string>
    <key>showAppsOrWindows</key>
	<string>0</string>
	<key>restoreState</key>
	<string>true</string>
    <key>usePreviousSelectedApp2</key>
	<string>true</string>
	<key>selectLastFocusedWindow2</key>
	<string>true</string>
</dict>
```

Example of settings for selecting the main window and then another window:

```
<dict>
    <key>showAppsOrWindows</key>
	<string>0</string>
	<key>restoreState</key>
	<string>true</string>
	<key>usePreviousSelectedApp2</key>
	<string>true</string>
</dict>
```