### PR TITLE
fix: keep windows when macOS accessibility inventory breaks

### DIFF
--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -53,6 +53,7 @@
 		5C5A1100000000000000B102 /* WsWindowStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5A1100000000000000B101 /* WsWindowStateTests.swift */; };
 		5C5A1100000000000000C002 /* WindowAcquisitionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5A1100000000000000C001 /* WindowAcquisitionPolicy.swift */; };
 		5C5A1100000000000000C003 /* WindowAcquisitionPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5A1100000000000000C001 /* WindowAcquisitionPolicy.swift */; };
+		5C5A1100000000000000C102 /* WindowAcquisitionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5A1100000000000000C101 /* WindowAcquisitionPolicyTests.swift */; };
 		5C5A1100000000000000D002 /* WindowServerQuery.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5A1100000000000000D001 /* WindowServerQuery.swift */; };
 		5C5A1100000000000000F002 /* WindowElementAcquisition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C5A1100000000000000F001 /* WindowElementAcquisition.swift */; };
 		5EA8E110000000000000DA02 /* DragAndDropResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EA8E110000000000000DA01 /* DragAndDropResolver.swift */; };
@@ -426,6 +427,7 @@
 		5C5A1100000000000000B001 /* WsWindowState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WsWindowState.swift; sourceTree = "<group>"; };
 		5C5A1100000000000000B101 /* WsWindowStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WsWindowStateTests.swift; sourceTree = "<group>"; };
 		5C5A1100000000000000C001 /* WindowAcquisitionPolicy.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowAcquisitionPolicy.swift; sourceTree = "<group>"; };
+		5C5A1100000000000000C101 /* WindowAcquisitionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAcquisitionPolicyTests.swift; sourceTree = "<group>"; };
 		5C5A1100000000000000D001 /* WindowServerQuery.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowServerQuery.swift; sourceTree = "<group>"; };
 		5C5A1100000000000000F001 /* WindowElementAcquisition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WindowElementAcquisition.swift; sourceTree = "<group>"; };
 		5EA8E110000000000000DA01 /* DragAndDropResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DragAndDropResolver.swift; sourceTree = "<group>"; };
@@ -910,6 +912,7 @@
 				5C5A1100000000000000B001 /* WsWindowState.swift */,
 				5C5A1100000000000000B101 /* WsWindowStateTests.swift */,
 				5C5A1100000000000000C001 /* WindowAcquisitionPolicy.swift */,
+				5C5A1100000000000000C101 /* WindowAcquisitionPolicyTests.swift */,
 				5C5A1100000000000000D001 /* WindowServerQuery.swift */,
 				5C5A1100000000000000F001 /* WindowElementAcquisition.swift */,
 			);
@@ -1930,6 +1933,7 @@
 				5C5A1100000000000000B003 /* WsWindowState.swift in Sources */,
 				5C5A1100000000000000B102 /* WsWindowStateTests.swift in Sources */,
 				5C5A1100000000000000C003 /* WindowAcquisitionPolicy.swift in Sources */,
+				5C5A1100000000000000C102 /* WindowAcquisitionPolicyTests.swift in Sources */,
 				5EA8E110000000000000F203 /* SchedulingPolicy.swift in Sources */,
 				5EA8E110000000000000F212 /* SchedulingPolicyTests.swift in Sources */,
 				5EA8E110000000000000DA03 /* DragAndDropResolver.swift in Sources */,

--- a/src/switcher/state/Applications.swift
+++ b/src/switcher/state/Applications.swift
@@ -113,9 +113,7 @@ class Applications {
                     // genuinely-new windows.
                     guard Windows.byWindowId[raw.wid]?.axUiElement == nil else { continue }
                     AXCallScheduler.shared.schedule(key: "wid-\(raw.wid)-acquire", context: app.debugId, pid: raw.pid, scan: true) {
-                        if let element = WindowDiscriminator.acquireElementOrReject(raw.wid, raw.pid, .otherSpaceViaBruteForce) {
-                            addDiscoveredWindow(element, raw, app)
-                        }
+                        addResolvedWindow(WindowDiscriminator.acquireElement(raw.wid, raw.pid, .otherSpaceViaBruteForce), raw, app)
                     }
                 }
                 // regular apps with no windows show as an icon placeholder. It's dropped when a real window
@@ -125,6 +123,19 @@ class Applications {
                 for app in list { _ = app.addWindowlessWindowIfNeeded() }
                 applyPhantomVerdict(inVisible: visibleWids, inAll: allWids)
             }
+        }
+    }
+
+    /// Route a successful AX acquire through full discovery, retain a WindowServer-only skeleton for the
+    /// poisoned-kAXWindows failure, and leave ordinary misses rejected. Runs off-main from AXCallScheduler.
+    static func addResolvedWindow(_ resolution: WindowElementAcquisition.Resolution, _ raw: WsRawWindow, _ app: Application) {
+        switch resolution {
+        case let .acquired(element):
+            addDiscoveredWindow(element, raw, app)
+        case .malformedApplicationWindows:
+            addWindowServerOnlyWindow(raw, app)
+        case .unavailable:
+            break
         }
     }
 
@@ -168,19 +179,7 @@ class Applications {
                     let wasRemovedFromSpaceWhileUntracked = Windows.windowsPendingSpaceRemoval.remove(wid) != nil
                     let findOrCreate = Windows.findOrCreate(element, wid, app, CGWindowLevel(raw.level), a.title, a.subrole, a.role, raw.bounds.size, raw.bounds.origin, isFullscreen, isMinimized)
                     guard let window = findOrCreate.0 else { return }
-                    // override Window.init's current-Space default with the real Space resolved above (new
-                    // windows only; existing ones stay live via events / syncSpacesState).
-                    if findOrCreate.1 {
-                        if wasRemovedFromSpaceWhileUntracked {
-                            // It got a removed-from-Space event while still untracked → it's a background tab.
-                            // Force it Space-less: the per-window CGS query still reports its OLD Space here
-                            // (stale right after backgrounding), so trusting that would keep it looking like a
-                            // separate on-screen window; the empty is what lets geometry group it (#5830).
-                            window.applySpacesAndScreen([wid: []])
-                        } else if !spaceIds.isEmpty {
-                            window.applySpacesAndScreen([wid: spaceIds])
-                        }
-                    }
+                    applyInitialSpaces(window, wid, findOrCreate.1, wasRemovedFromSpaceWhileUntracked, spaceIds)
                     window.isMainWindow = a.isMain ?? false
                     var tabStateChanged = false
                     if tabSiblingTitles != nil || window.tabbedSiblingWids != nil {
@@ -195,6 +194,38 @@ class Applications {
                     }
                 }
             }
+        }
+    }
+
+    /// The AX inventory is observably malformed, but WindowServer still has an authoritative top-level window.
+    /// Keep enough state to render, capture, focus and track MRU. Full scans retry AX because axUiElement stays
+    /// nil; `Windows.findOrCreate` upgrades or removes this coarse candidate when a real AXWindow returns.
+    static func addWindowServerOnlyWindow(_ raw: WsRawWindow, _ app: Application) {
+        let wid = raw.wid
+        guard wid != 0 else { return }
+        let spaceIds = app.pid == AXUIElement.currentProcessPid ? [CGSSpaceID]() : CGSCallScheduler.windowSpaces(wid)
+        DispatchQueue.main.async { [weak app] in
+            guard let app else { return }
+            windowAttributesThrottler.throttleOrProceed(key: "\(wid)-generic") {
+                let wasRemovedFromSpaceWhileUntracked = Windows.windowsPendingSpaceRemoval.remove(wid) != nil
+                let findOrCreate = Windows.findOrCreateWithoutAx(raw, app)
+                guard let window = findOrCreate.0 else { return }
+                applyInitialSpaces(window, wid, findOrCreate.1, wasRemovedFromSpaceWhileUntracked, spaceIds)
+                if findOrCreate.1 {
+                    TabGroup.reconcile()
+                    Logger.info { "discovered a WindowServer-only window:\(window.debugId)" }
+                    App.refreshOpenUiAfterExternalEvent([window])
+                }
+            }
+        }
+    }
+
+    private static func applyInitialSpaces(_ window: Window, _ wid: CGWindowID, _ isNew: Bool, _ wasRemovedFromSpaceWhileUntracked: Bool, _ spaceIds: [CGSSpaceID]) {
+        guard isNew else { return }
+        if wasRemovedFromSpaceWhileUntracked {
+            window.applySpacesAndScreen([wid: []])
+        } else if !spaceIds.isEmpty {
+            window.applySpacesAndScreen([wid: spaceIds])
         }
     }
 
@@ -263,9 +294,7 @@ class Applications {
             DispatchQueue.main.async {
                 guard Windows.byWindowId[wid] == nil, let app = findOrCreate(raw.pid, false) else { return }
                 AXCallScheduler.shared.schedule(key: "wid-\(wid)-acquire", context: app.debugId, pid: raw.pid, scan: true) {
-                    if let element = WindowDiscriminator.acquireElementOrReject(wid, raw.pid, .currentSpaceViaApplicationWindows) {
-                        addDiscoveredWindow(element, raw, app)
-                    }
+                    addResolvedWindow(WindowDiscriminator.acquireElement(wid, raw.pid, .currentSpaceViaApplicationWindows), raw, app)
                 }
             }
         }

--- a/src/switcher/state/Window.swift
+++ b/src/switcher/state/Window.swift
@@ -36,7 +36,7 @@ class Window {
         set { state[keyPath: keyPath] = newValue }
     }
 
-    init(_ axUiElement: AXUIElement, _ application: Application, _ wid: CGWindowID, _ title: String?, _ isFullscreen: Bool?, _ isMinimized: Bool?, _ position: CGPoint?, _ size: CGSize?) {
+    init(_ axUiElement: AXUIElement?, _ application: Application, _ wid: CGWindowID, _ title: String?, _ isFullscreen: Bool?, _ isMinimized: Bool?, _ position: CGPoint?, _ size: CGSize?) {
         state = WindowState(
             id: "wid-\(wid)", isPhantom: false, isWindowlessApp: false,
             isFullscreen: false, isMinimized: false, isTabbed: false,
@@ -168,7 +168,7 @@ class Window {
     }
 
     func canBeClosed() -> Bool {
-        return !self.isWindowlessApp
+        return !self.isWindowlessApp && axUiElement != nil
     }
 
     func close() {
@@ -205,7 +205,7 @@ class Window {
     }
 
     func canBeMinDeminOrFullscreened() -> Bool {
-        return !self.isWindowlessApp && !self.isTabbed
+        return !self.isWindowlessApp && !self.isTabbed && axUiElement != nil
     }
 
     func minDemin() {
@@ -218,16 +218,16 @@ class Window {
             return
         }
         BackgroundWork.accessibilityCommandsQueue.addOperation { [weak self] in
-            guard let self else { return }
+            guard let self, let element = self.axUiElement else { return }
             if self.isFullscreen {
-                try? self.axUiElement!.setAttribute(kAXFullscreenAttribute, false)
+                try? element.setAttribute(kAXFullscreenAttribute, false)
                 // minimizing is ignored if sent immediatly; we wait for the de-fullscreen animation to be over
                 BackgroundWork.accessibilityCommandsQueue.addOperationAfter(deadline: .now() + .seconds(1)) { [weak self] in
-                    guard let self else { return }
-                    try? self.axUiElement!.setAttribute(kAXMinimizedAttribute, true)
+                    guard let element = self?.axUiElement else { return }
+                    try? element.setAttribute(kAXMinimizedAttribute, true)
                 }
             } else {
-                try? self.axUiElement!.setAttribute(kAXMinimizedAttribute, !self.isMinimized)
+                try? element.setAttribute(kAXMinimizedAttribute, !self.isMinimized)
             }
         }
     }
@@ -242,8 +242,8 @@ class Window {
             return
         }
         BackgroundWork.accessibilityCommandsQueue.addOperation { [weak self] in
-            guard let self else { return }
-            try? self.axUiElement!.setAttribute(kAXFullscreenAttribute, !self.isFullscreen)
+            guard let self, let element = self.axUiElement else { return }
+            try? element.setAttribute(kAXFullscreenAttribute, !self.isFullscreen)
         }
     }
 
@@ -278,8 +278,8 @@ class Window {
             let originFrontPid = targetMaybeCrossSpace ? NSWorkspace.shared.frontmostApplication?.processIdentifier : nil
             BackgroundWork.accessibilityCommandsQueue.addOperation { [weak self] in
                 guard let self else { return }
-                if self.isMinimized {
-                    try? self.axUiElement!.setAttribute(kAXMinimizedAttribute, false)
+                if self.isMinimized, let element = self.axUiElement {
+                    try? element.setAttribute(kAXMinimizedAttribute, false)
                 }
                 // Focusing another app's window reliably takes the steps below. The public APIs alone don't
                 // move key focus across apps (macOS 14 downgraded NSRunningApplication.activate to an advisory
@@ -300,7 +300,7 @@ class Window {
                 GetProcessForPID(self.application.pid, &psn)
                 _SLPSSetFrontProcessWithOptions(&psn, self.cgWindowId!, SLPSMode.userGenerated.rawValue)
                 makeKeyWindow(&psn, self.cgWindowId!)
-                if self.axUiElement!.raiseWindow() == .invalidUIElement, let fresh = self.refreshedAxElement() {
+                if let element = self.axUiElement, element.raiseWindow() == .invalidUIElement, let fresh = self.refreshedAxElement() {
                     fresh.raiseWindow()
                     DispatchQueue.main.async { [weak self] in
                         guard let self, self.axUiElement != fresh else { return }

--- a/src/switcher/state/WindowDiscriminator.swift
+++ b/src/switcher/state/WindowDiscriminator.swift
@@ -57,17 +57,31 @@ class WindowDiscriminator {
         return true
     }
 
-    /// Acquire the AX element for a WindowServer-discovered wid, rejecting (with a log) when AX can't resolve
-    /// it to a live window: the wid isn't in the app's `kAXWindows` on its Space and no brute-force token
-    /// matched. That's a window CGS still lists but AX no longer backs — a transient that never ordered in
-    /// (Joplin), or a window torn down between the snapshot and this read. Off-main (AX IPC), like the
-    /// underlying `WindowElementAcquisition`.
-    static func acquireElementOrReject(_ wid: CGWindowID, _ pid: pid_t, _ route: WindowAcquisitionPolicy.Route) -> AXUIElement? {
-        guard let element = WindowElementAcquisition.element(for: wid, pid: pid, route: route) else {
+    /// Acquire the AX element for a WindowServer-discovered wid. An ordinary miss stays rejected: it is often
+    /// a transient or torn-down window. The distinct malformed-kAXWindows result is preserved so discovery can
+    /// keep a WindowServer-only window until the macOS accessibility session recovers.
+    static func acquireElement(_ wid: CGWindowID, _ pid: pid_t, _ route: WindowAcquisitionPolicy.Route) -> WindowElementAcquisition.Resolution {
+        let resolution = WindowElementAcquisition.resolve(for: wid, pid: pid, route: route)
+        switch resolution {
+        case .unavailable:
             Logger.debug { "Window rejected (pid:\(pid) wid:\(wid)) because no live AX window element could be acquired for it" }
-            return nil
+        case .malformedApplicationWindows:
+            Logger.info { "Window retained without AX (pid:\(pid) wid:\(wid)) because kAXWindows returned AXApplication elements" }
+        case .acquired:
+            break
         }
-        return element
+        return resolution
+    }
+
+    /// Coarse fallback used only after the poisoned-kAXWindows shape was observed. WindowServer level, identity,
+    /// and geometry keep obvious chrome out; precise AX subrole/app-specific discrimination resumes on recovery.
+    static func isActualWindowWithoutAx(_ app: Application, _ raw: WsRawWindow) -> Bool {
+        guard WindowAcquisitionPolicy.windowServerFallbackIsEligible(wid: raw.wid, level: raw.level, size: raw.bounds.size) else {
+            Logger.debug { logTemplate("it failed the WindowServer-only identity/level/size gates", app, raw.wid, CGWindowLevel(raw.level), raw.title, nil, nil, raw.bounds.size) }
+            return false
+        }
+        Logger.debug { "Window accepted with WindowServer-only evidence \(app.debugId) (wid:\(raw.wid) level:\(raw.level) title:\(raw.title) size:\(raw.bounds.size))" }
+        return true
     }
 
     private static func isStandardSubrole(_ subrole: String?) -> Bool {

--- a/src/switcher/state/Windows.swift
+++ b/src/switcher/state/Windows.swift
@@ -409,6 +409,13 @@ class Windows {
 
     static func findOrCreate(_ windowAxUiElement: AXUIElement, _ wid: CGWindowID, _ app: Application, _ level: CGWindowLevel, _ title: String?, _ subrole: String?, _ role: String?, _ size: CGSize?, _ position: CGPoint?, _ isFullscreen: Bool?, _ isMinimized: Bool?) -> (Window?, Bool) {
         if let window = byWindowId[wid] ?? (list.first { $0.isEqualRobust(windowAxUiElement, wid) }) {
+            // A WindowServer-only fallback was accepted with coarse evidence while kAXWindows was malformed.
+            // Once AX recovers, apply the precise discriminator before upgrading it; remove any false-positive
+            // utility window that the level/size fallback could not distinguish.
+            if window.axUiElement == nil && !WindowDiscriminator.isActualWindow(app, wid, level, title, subrole, role, size) {
+                removeWindows([window], true)
+                return (nil, false)
+            }
             // Adopt the freshest element for this wid. Some apps (e.g. Zoom meeting windows) silently rebuild a
             // window's accessibility element while keeping the same CGWindowID, with no destroyed notification,
             // so our cached ref goes stale and every AX call returns kAXErrorInvalidUIElement. Rebinding here
@@ -423,6 +430,22 @@ class Windows {
         }
         guard WindowDiscriminator.isActualWindow(app, wid, level, title, subrole, role, size) else { return (nil, false) }
         let window = Window(windowAxUiElement, app, wid, title, isFullscreen, isMinimized, position, size)
+        appendWindow(window)
+        return (window, true)
+    }
+
+    /// Create the minimal model that remains useful while macOS returns AXApplication objects from kAXWindows.
+    /// Existence, title, geometry, fullscreen, Spaces, thumbnails, focus and MRU are all WindowServer-backed;
+    /// the nil AX element disables only AX-specific metadata/actions and makes the next full scan retry recovery.
+    static func findOrCreateWithoutAx(_ raw: WsRawWindow, _ app: Application) -> (Window?, Bool) {
+        if let window = byWindowId[raw.wid] {
+            let newTitle = window.bestEffortTitle(raw.title)
+            if window.title != newTitle { window.title = newTitle; window.lastSearchQuery = nil }
+            window.updateFromWindowServer(position: raw.bounds.origin, size: raw.bounds.size, isFullscreen: WsWindowState.isFullscreen(raw))
+            return (window, false)
+        }
+        guard WindowDiscriminator.isActualWindowWithoutAx(app, raw) else { return (nil, false) }
+        let window = Window(nil, app, raw.wid, raw.title, WsWindowState.isFullscreen(raw), false, raw.bounds.origin, raw.bounds.size)
         appendWindow(window)
         return (window, true)
     }

--- a/src/windowserver/README.md
+++ b/src/windowserver/README.md
@@ -38,6 +38,12 @@ wid, and cached** — current-Space via `kAXWindows`, other-Space via a targeted
 old every-show exhaustive scan. A window we can't get an element for still shows and is focusable (focus is
 wid/psn-based); only minimize/close/fullscreen no-op until it reaches the current Space and self-heals.
 
+An ordinary acquisition miss is still rejected: it is usually a transient or torn-down window. The fallback
+is enabled only when `kAXWindows` returns the poisoned macOS shape — an `AXApplication` element with wid `0` —
+which violates the attribute's window-element contract. In that state the level/identity/geometry-qualified
+WindowServer skeleton is retained with a nil AX element. Every inventory refresh retries acquisition; a valid
+AX window upgrades the skeleton in place and restores precise discrimination, tabs, minimized state and actions.
+
 ## Pure vs impure
 
 Pure kernels are co-located triads (`Foo.swift` + `FooSpecs.md` + `FooTests.swift`), compiled into both the

--- a/src/windowserver/WindowAcquisitionPolicy.swift
+++ b/src/windowserver/WindowAcquisitionPolicy.swift
@@ -6,9 +6,25 @@ import Cocoa
 /// enumerate-and-match (then cached). This enum names the two acquisition routes; `WindowElementAcquisition`
 /// picks one per newly-discovered wid and executes it.
 enum WindowAcquisitionPolicy {
+    struct ApplicationWindowObservation: Equatable {
+        let wid: CGWindowID?
+        let role: String?
+    }
+
     /// How to get the AX element for a newly-discovered wid.
     enum Route: Equatable {
         case currentSpaceViaApplicationWindows  // cheap: AXUIElementCreateApplication(pid).kAXWindows, match by wid
         case otherSpaceViaBruteForce            // _AXUIElementCreateWithRemoteToken enumeration, targeted + cached
+    }
+
+    /// `kAXWindows` must contain window elements. Tahoe can instead return application elements whose wid is
+    /// zero; that is a distinct system failure, not an ordinary missing/off-Space window, so WindowServer-only
+    /// discovery is safe to enable for this app until AX recovers.
+    static func applicationWindowsAreMalformed(_ observations: [ApplicationWindowObservation]) -> Bool {
+        observations.contains { $0.wid == 0 && $0.role == kAXApplicationRole }
+    }
+
+    static func windowServerFallbackIsEligible(wid: CGWindowID, level: Int32, size: CGSize) -> Bool {
+        wid != 0 && level == WsWindowState.applicationWindowLevel && size.width > 100 && size.height > 50
     }
 }

--- a/src/windowserver/WindowAcquisitionPolicySpecs.md
+++ b/src/windowserver/WindowAcquisitionPolicySpecs.md
@@ -1,0 +1,28 @@
+# WindowAcquisitionPolicy — Specs
+
+## Summary
+
+`WindowAcquisitionPolicy` distinguishes an ordinary AX miss from the macOS failure where an application's
+`kAXWindows` attribute returns application elements. An ordinary miss keeps the existing reject/retry behavior.
+The malformed inventory enables a WindowServer-only window until AX recovers.
+
+## Detection boundary
+
+- A returned element with wid `0` and role `AXApplication` is malformed. `kAXWindows` is required to contain
+  window elements, and this exact shape is emitted by the poisoned Tahoe accessibility session.
+- A normal `AXWindow`, an empty inventory, an unreadable role, or an ordinary wid mismatch is not enough to
+  enable the fallback. These are existing per-app/transient cases and continue through the normal routes.
+- Detection is per application. A broken app can degrade without changing discovery for healthy apps.
+- The degraded candidate must still have a non-zero wid, application level `0`, width over `100`, and height
+  over `50`. This mirrors the cheap identity/geometry gates from full discrimination without pretending that
+  WindowServer can supply an AX subrole.
+
+## Test scenarios
+
+- **testApplicationElementWithZeroWidIsMalformed** — the poisoned Tahoe shape enables the fallback.
+- **testHealthyWindowIsNotMalformed** — a normal AX window keeps full AX discovery.
+- **testOrdinaryMissIsNotMalformed** — an empty inventory does not broaden WindowServer filtering.
+- **testZeroWidWithoutApplicationRoleIsNotMalformed** — both poison signals must be present.
+- **testApplicationRoleWithRealWidIsNotMalformed** — both poison signals must be present.
+- **testNormalWindowServerCandidateIsEligibleForFallback** — a normal top-level window can degrade.
+- **testFallbackRejectsMissingIdentityChromeAndSmallSurfaces** — the coarse gates remain enforced.

--- a/src/windowserver/WindowAcquisitionPolicyTests.swift
+++ b/src/windowserver/WindowAcquisitionPolicyTests.swift
@@ -1,0 +1,39 @@
+import Cocoa
+import XCTest
+
+final class WindowAcquisitionPolicyTests: XCTestCase {
+    private func observation(_ wid: CGWindowID?, _ role: String?) -> WindowAcquisitionPolicy.ApplicationWindowObservation {
+        WindowAcquisitionPolicy.ApplicationWindowObservation(wid: wid, role: role)
+    }
+
+    func testApplicationElementWithZeroWidIsMalformed() {
+        XCTAssertTrue(WindowAcquisitionPolicy.applicationWindowsAreMalformed([observation(0, kAXApplicationRole)]))
+    }
+
+    func testHealthyWindowIsNotMalformed() {
+        XCTAssertFalse(WindowAcquisitionPolicy.applicationWindowsAreMalformed([observation(42, kAXWindowRole)]))
+    }
+
+    func testOrdinaryMissIsNotMalformed() {
+        XCTAssertFalse(WindowAcquisitionPolicy.applicationWindowsAreMalformed([]))
+    }
+
+    func testZeroWidWithoutApplicationRoleIsNotMalformed() {
+        XCTAssertFalse(WindowAcquisitionPolicy.applicationWindowsAreMalformed([observation(0, nil)]))
+    }
+
+    func testApplicationRoleWithRealWidIsNotMalformed() {
+        XCTAssertFalse(WindowAcquisitionPolicy.applicationWindowsAreMalformed([observation(42, kAXApplicationRole)]))
+    }
+
+    func testNormalWindowServerCandidateIsEligibleForFallback() {
+        XCTAssertTrue(WindowAcquisitionPolicy.windowServerFallbackIsEligible(wid: 42, level: 0, size: CGSize(width: 800, height: 600)))
+    }
+
+    func testFallbackRejectsMissingIdentityChromeAndSmallSurfaces() {
+        XCTAssertFalse(WindowAcquisitionPolicy.windowServerFallbackIsEligible(wid: 0, level: 0, size: CGSize(width: 800, height: 600)))
+        XCTAssertFalse(WindowAcquisitionPolicy.windowServerFallbackIsEligible(wid: 42, level: 3, size: CGSize(width: 800, height: 600)))
+        XCTAssertFalse(WindowAcquisitionPolicy.windowServerFallbackIsEligible(wid: 42, level: 0, size: CGSize(width: 100, height: 600)))
+        XCTAssertFalse(WindowAcquisitionPolicy.windowServerFallbackIsEligible(wid: 42, level: 0, size: CGSize(width: 800, height: 50)))
+    }
+}

--- a/src/windowserver/WindowElementAcquisition.swift
+++ b/src/windowserver/WindowElementAcquisition.swift
@@ -6,18 +6,39 @@ import Cocoa
 /// the remote-token brute-force for other-Space ones. Mach IPC; call off the main thread. No Specs/Tests
 /// triad (impure — verified at runtime). See README.md.
 enum WindowElementAcquisition {
-    static func element(for wid: CGWindowID, pid: pid_t, route: WindowAcquisitionPolicy.Route) -> AXUIElement? {
+    enum Resolution {
+        case acquired(AXUIElement)
+        case malformedApplicationWindows
+        case unavailable
+    }
+
+    static func resolve(for wid: CGWindowID, pid: pid_t, route: WindowAcquisitionPolicy.Route) -> Resolution {
         let app = AXUIElementCreateApplication(pid)
         // Current Space first: the cheap `kAXWindows` read resolves the wid with no brute-force — the common
         // case, since most newly-discovered windows are on the active Space. The own-process read is routed to
         // main (own-process AX is an in-process AppKit call, not IPC; off-main it races AppKit teardown).
         let currentSpace = AXUIElement.onCorrectThread(pid: pid) { try? app.windows() }
-        if let found = currentSpace?.first(where: { (try? $0.cgWindowId()) == wid }) {
-            return found
+        var observations = [WindowAcquisitionPolicy.ApplicationWindowObservation]()
+        for candidate in currentSpace ?? [] {
+            let candidateWid = try? candidate.cgWindowId(pid: pid)
+            if candidateWid == wid { return .acquired(candidate) }
+            guard candidateWid == 0 else { continue }
+            let role = try? candidate.attributes([kAXRoleAttribute], pid: pid).role
+            observations.append(.init(wid: candidateWid, role: role))
         }
+        // Tahoe can poison kAXWindows system-wide, returning AXApplication elements with wid 0. Brute-force
+        // uses the same broken service and only burns its 250ms budget; report the distinct failure so discovery
+        // can retain the authoritative WindowServer skeleton instead of collapsing the app to one icon.
+        if WindowAcquisitionPolicy.applicationWindowsAreMalformed(observations) { return .malformedApplicationWindows }
         // Other Space: the only path is the targeted remote-token brute-force. Skipped for the current-Space
         // -only route and for our own process (always current-Space, and off-main AX on self would crash).
-        guard route == .otherSpaceViaBruteForce, pid != AXUIElement.currentProcessPid else { return nil }
-        return AXUIElement.windowByBruteForce(pid, wid)
+        guard route == .otherSpaceViaBruteForce, pid != AXUIElement.currentProcessPid else { return .unavailable }
+        guard let element = AXUIElement.windowByBruteForce(pid, wid) else { return .unavailable }
+        return .acquired(element)
+    }
+
+    static func element(for wid: CGWindowID, pid: pid_t, route: WindowAcquisitionPolicy.Route) -> AXUIElement? {
+        guard case let .acquired(element) = resolve(for: wid, pid: pid, route: route) else { return nil }
+        return element
     }
 }


### PR DESCRIPTION
Sorry - opened in accident! Playing around with a busted mcos accessibility inventory :)