### PR TITLE
feat: new XS and XL appearance sizes

### DIFF
--- a/resources/l10n/Localizable.strings
+++ b/resources/l10n/Localizable.strings
@@ -916,6 +916,12 @@
 /* No comment provided by engineer. */
 "Window title contains" = "Window title contains";
 
+/* Extra large appearance size */
+"XL" = "XL";
+
+/* Extra small appearance size */
+"XS" = "XS";
+
 /* No comment provided by engineer. */
 "You can’t undo this action." = "You can’t undo this action.";
 

--- a/src/kit/WindowlessAppIndicator.swift
+++ b/src/kit/WindowlessAppIndicator.swift
@@ -50,12 +50,12 @@ class WindowlessAppIndicator: NSView {
     static func getAppearanceParameter() -> AppearanceParameter {
         let style = Preferences.effectiveAppearanceStyle(SwitcherSession.activeShortcutIndex)
         if style == .thumbnails || style == .appIcons {
-            if Appearance.resolvedSize == .large {
+            if Appearance.resolvedSize.isLargeOrAbove {
                 return AppearanceParameter(width: 12, height: 5, cornerRadius: 2)
             }
             return AppearanceParameter(width: 10, height: 5, cornerRadius: 2)
         }
-        if Appearance.resolvedSize == .large {
+        if Appearance.resolvedSize.isLargeOrAbove {
             return AppearanceParameter(width: 8, height: 3, cornerRadius: 1)
         }
         return AppearanceParameter(width: 6, height: 3, cornerRadius: 1)

--- a/src/preferences/MacroPreferences.swift
+++ b/src/preferences/MacroPreferences.swift
@@ -305,26 +305,39 @@ enum AppearanceStylePreference: CaseIterable, ImageMacroPreference {
     }
 }
 
+/// Cases are stored as their `allCases` position, so inserting one shifts every stored index
+/// (`migrateAppearanceSizeIndexes`). `.auto` must stay last: `AppearanceTab` addresses it as
+/// `allCases.count - 1`.
 enum AppearanceSizePreference: CaseIterable, SfSymbolMacroPreference {
+    case extraSmall
     case small
     case medium
     case large
+    case extraLarge
     case auto
 
     var localizedString: LocalizedString {
         switch self {
+            case .extraSmall: return NSLocalizedString("XS", comment: "Extra small appearance size")
             case .small: return NSLocalizedString("Small", comment: "")
             case .medium: return NSLocalizedString("Medium", comment: "")
             case .large: return NSLocalizedString("Large", comment: "")
+            case .extraLarge: return NSLocalizedString("XL", comment: "Extra large appearance size")
             case .auto: return NSLocalizedString("Auto", comment: "")
         }
     }
 
+    /// `.auto` is excluded on purpose: callers read `Appearance.resolvedSize`, which `updateSize()`
+    /// has already resolved to a concrete size.
+    var isLargeOrAbove: Bool { self == .large || self == .extraLarge }
+
     var symbol: Symbols {
         switch self {
+            case .extraSmall: return .circledMinusSign
             case .small: return .moonphaseWaningGibbousInverse
             case .medium: return .moonphaseLastQuarterInverse
             case .large: return .moonphaseWaningCrescentInverse
+            case .extraLarge: return .circledPlusSign
             case .auto: return .sparkles
         }
     }

--- a/src/preferences/PreferencesMigrations.swift
+++ b/src/preferences/PreferencesMigrations.swift
@@ -29,6 +29,7 @@ class PreferencesMigrations {
     static func updateToNewPreferences(_ versionInPlist: String) {
         Logger.debug { "App-version:\(App.version), Plist-version:\(versionInPlist)" }
         for (version, migration) in [
+            ("11.4.4", migrateAppearanceSizeIndexes),
             ("10.13.0", migrateGroupingToPerShortcut),
             ("10.12.0", migrateExceptionsTitleArray),
             ("10.12.0", migrateLanguagePreferenceIndex),
@@ -98,6 +99,35 @@ class PreferencesMigrations {
         }
         if oldGlobal != nil {
             Self.defaults.removeObject(forKey: "showTabsAsWindows")
+        }
+    }
+
+    // AppearanceSizePreference gained extraSmall (first) and extraLarge (before auto); stored indexes need remapping
+    // before: small 0, medium 1, large 2, auto 3
+    // after: extraSmall 0, small 1, medium 2, large 3, extraLarge 4, auto 5
+    // this runs before registerDefaults(), so an unset override stays unset, which hasOverride() relies on
+    static func migrateAppearanceSizeIndexes() {
+        let oldToNew = ["0": "1", "1": "2", "2": "3", "3": "5"]
+        let keys = ["appearanceSize"] + (0...Preferences.maxShortcutCount).map {
+            Preferences.indexToName("appearanceSizeOverride", $0)
+        }
+        for key in keys {
+            if let old = Self.defaults.string(forKey: key), let new = oldToNew[old] {
+                Self.defaults.set(new, forKey: key)
+            }
+        }
+        migrateRememberedAppearanceSizeIndexes(oldToNew)
+    }
+
+    // the Pro gate snapshots the stored index under `proTransition.remembered*`: a different suite,
+    // stored as Int. Left unmapped, a locked Pro user on auto would be restored to large on unlock
+    private static func migrateRememberedAppearanceSizeIndexes(_ oldToNew: [String: String]) {
+        let defaults = ProTransitionState.defaults
+        for key in ["proTransition.rememberedAppearanceSize", "proTransition.rememberedAppearanceSizeOverride"] {
+            if let old = defaults.object(forKey: key) as? Int,
+               let new = oldToNew[String(old)].flatMap({ Int($0) }) {
+                defaults.set(new, forKey: key)
+            }
         }
     }
 

--- a/src/preferences/PreferencesMigrationsSpecs.md
+++ b/src/preferences/PreferencesMigrationsSpecs.md
@@ -14,7 +14,7 @@
 - **Order matters**: `updateToNewPreferences` runs migrations newest-threshold-first; some depend on keys earlier ones leave behind. The per-migration tests isolate each, but the registration list in `updateToNewPreferences` is the integration contract.
 - **Idempotency**: `migrateExceptionsTitleArray` must be safe to re-run — already-migrated (array-form) data fails to decode into the legacy (`String?`) shape, triggering an early return that leaves data untouched.
 - **A quirk worth knowing** (pinned by a test): the global→per-shortcut grouping migration copies the global value into the indexed keys, but because index 0's key *is* the old global key, that key is removed at the end — so slot 0 ends up unset while slots 2…10 hold the value.
-- **Testability**: production reads/writes `UserDefaults.standard`; the tests inject an isolated suite via `PreferencesMigrations.defaults` (reset in `tearDown`) so they never touch the dev machine's real prefs.
+- **Testability**: production reads/writes `UserDefaults.standard`; the tests inject an isolated suite via `PreferencesMigrations.defaults` (reset in `tearDown`) so they never touch the dev machine's real prefs. `migrateAppearanceSizeIndexes` also touches the license suite through `ProTransitionState.defaults` (the `proTransition.remembered*` indices); the test target's stand-in for that type points at its own suite for the same reason.
 - **Not covered** (documented gaps): `migrateShortcutPreferencesToSecureCoding` (needs the real NSKeyedArchiver/ShortcutRecorder codec, stubbed compile-only) and `migrateLoginItem` (mutates real Login Items via deprecated LaunchServices APIs).
 
 ---
@@ -76,6 +76,13 @@ Mirrors `PreferencesMigrationsTests.swift` 1:1.
 ### L/M. Width / size splits
 - **testMinMaxWidthZeroBecomesOne** — `windowMinWidthInRow "0"` → `"1"`.
 - **testMaxSizeOnScreenSplitsIntoWidthAndHeight** — `maxScreenUsage` → both `maxWidthOnScreen` + `maxHeightOnScreen`.
+
+### L2. `AppearanceSizePreference` gained XS + XL
+- **testAppearanceSizeIndexesShiftForInsertedExtraSmallAndExtraLarge** — `appearanceSize "0"` (small) → `"1"`.
+- **testAppearanceSizeAutoJumpsPastExtraLarge** — `"3"` (auto) → `"5"`, the only two-step shift.
+- **testAppearanceSizePerShortcutOverridesShiftToo** — `appearanceSizeOverride` / `…Override2` / `…Override10` remap identically.
+- **testAppearanceSizeLeavesUnsetKeysUnset** — an unset key stays absent, so `hasOverride(_:_:)` (which reads `persistentDomain`) doesn't start seeing phantom overrides.
+- **testAppearanceSizeRemembersProSelectionAcrossTheShift** — `proTransition.rememberedAppearanceSize` `3` → `5`, so unlocking Pro restores `.auto` and not `.large`.
 
 ### N. Shortcut key cleanup + index move
 - **testNextWindowShortcutStripsHoldModifierChars** — hold-modifier chars removed from `nextWindowShortcut` (`"⌥⇥"` → `"⇥"`).

--- a/src/preferences/PreferencesMigrationsTests.swift
+++ b/src/preferences/PreferencesMigrationsTests.swift
@@ -251,6 +251,46 @@ final class PreferencesMigrationsTests: XCTestCase {
         XCTAssertEqual(defaults.string(forKey: "maxHeightOnScreen"), "80")
     }
 
+    // MARK: - L2. AppearanceSizePreference gained XS + XL
+
+    func testAppearanceSizeIndexesShiftForInsertedExtraSmallAndExtraLarge() {
+        defaults.set("0", forKey: "appearanceSize") // small
+        PreferencesMigrations.migrateAppearanceSizeIndexes()
+        XCTAssertEqual(defaults.string(forKey: "appearanceSize"), "1")
+    }
+
+    func testAppearanceSizeAutoJumpsPastExtraLarge() {
+        defaults.set("3", forKey: "appearanceSize") // auto
+        PreferencesMigrations.migrateAppearanceSizeIndexes()
+        XCTAssertEqual(defaults.string(forKey: "appearanceSize"), "5")
+    }
+
+    func testAppearanceSizePerShortcutOverridesShiftToo() {
+        defaults.set("1", forKey: "appearanceSizeOverride")   // index 0's key has no suffix
+        defaults.set("2", forKey: "appearanceSizeOverride2")
+        defaults.set("3", forKey: "appearanceSizeOverride10") // the last slot
+        PreferencesMigrations.migrateAppearanceSizeIndexes()
+        XCTAssertEqual(defaults.string(forKey: "appearanceSizeOverride"), "2")
+        XCTAssertEqual(defaults.string(forKey: "appearanceSizeOverride2"), "3")
+        XCTAssertEqual(defaults.string(forKey: "appearanceSizeOverride10"), "5")
+    }
+
+    // an unset override must stay unset, else `hasOverride` (which reads `persistentDomain`) starts
+    // seeing every shortcut as explicitly overridden
+    func testAppearanceSizeLeavesUnsetKeysUnset() {
+        PreferencesMigrations.migrateAppearanceSizeIndexes()
+        XCTAssertNil(defaults.string(forKey: "appearanceSize"))
+        XCTAssertNil(defaults.string(forKey: "appearanceSizeOverride"))
+    }
+
+    func testAppearanceSizeRemembersProSelectionAcrossTheShift() {
+        let proDefaults = ProTransitionState.defaults
+        proDefaults.set(3, forKey: "proTransition.rememberedAppearanceSize") // auto
+        defer { proDefaults.removeObject(forKey: "proTransition.rememberedAppearanceSize") }
+        PreferencesMigrations.migrateAppearanceSizeIndexes()
+        XCTAssertEqual(proDefaults.object(forKey: "proTransition.rememberedAppearanceSize") as? Int, 5)
+    }
+
     // MARK: - N. nextWindowShortcut hold-modifier cleanup + index move
 
     func testNextWindowShortcutStripsHoldModifierChars() {
@@ -354,6 +394,9 @@ extension App {
 }
 
 enum ProTransitionState {
+    /// Isolated suite: production points at the license suite, which the tests must not touch.
+    static let defaults = UserDefaults(suiteName: "test-migrations-pro-transition")!
+
     static func markFreshInstallIfUnknown(_ value: Bool) {}
 }
 

--- a/src/preferences/settings-window/LabelAndControl.swift
+++ b/src/preferences/settings-window/LabelAndControl.swift
@@ -254,7 +254,35 @@ class LabelAndControl: NSObject {
         }
     }
 
-    static func makeSegmentedControl(_ rawName: String, _ macroPreferences: [MacroPreference], segmentWidth: CGFloat = -1, extraAction: ActionClosure? = nil) -> NSSegmentedControl {
+    /// Width each segment needs for its own localized label and symbol.
+    private static func naturalSegmentWidth(_ preference: MacroPreference) -> CGFloat {
+        let probe = NSSegmentedControl(labels: [preference.localizedString], trackingMode: .selectOne, target: nil, action: nil)
+        applySystemSelectedSegmentStyle(probe)
+        if let preference = preference as? SfSymbolMacroPreference {
+            probe.setImage(NSImage.fromSymbol(preference.symbol, pointSize: 13), forSegment: 0)
+        }
+        probe.sizeToFit()
+        return probe.frame.width
+    }
+
+    /// Per-segment widths measured from the localized labels, scaled down proportionally if they'd
+    /// overflow `maxTotal` (the width the row can give the control). `extraOnLast` reserves room for
+    /// an overlay on the trailing segment. Hardcoding widths instead would fit only English: "Auto"
+    /// is "Automatycznie" in Polish, "Medium" is "Middelgroot" in Dutch. Segments that still come out
+    /// too narrow truncate and get a tooltip, below.
+    static func fittedSegmentWidths(_ macroPreferences: [MacroPreference], extraOnLast: CGFloat = 0, maxTotal: CGFloat) -> [CGFloat] {
+        var widths = macroPreferences.map { naturalSegmentWidth($0) }
+        guard let last = widths.indices.last else { return [] }
+        widths[last] += extraOnLast
+        let total = widths.reduce(0, +)
+        guard total > maxTotal else { return widths }
+        return widths.map { ($0 * maxTotal / total).rounded(.down) }
+    }
+
+    /// `segmentWidths` overrides `segmentWidth` per segment. Widths must stay explicit either way:
+    /// `ProBadgeView.attach` positions its overlay from `width(forSegment:)`, which AppKit reports as
+    /// 0 for auto-sized segments.
+    static func makeSegmentedControl(_ rawName: String, _ macroPreferences: [MacroPreference], segmentWidth: CGFloat = -1, segmentWidths: [CGFloat]? = nil, extraAction: ActionClosure? = nil) -> NSSegmentedControl {
         let button = NSSegmentedControl(labels: macroPreferences.map {
             $0.localizedString
         }, trackingMode: .selectOne, target: nil, action: nil)
@@ -263,8 +291,9 @@ class LabelAndControl: NSObject {
         SettingsSearchIndex.registerTarget(SettingsWindow.highlightTarget(button))
         applySystemSelectedSegmentStyle(button)
         for (i, preference) in macroPreferences.enumerated() {
-            if segmentWidth > 0 {
-                button.setWidth(segmentWidth, forSegment: i)
+            let width = segmentWidths?[safe: i] ?? segmentWidth
+            if width > 0 {
+                button.setWidth(width, forSegment: i)
             }
             var hasImage = false
             if let preference = preference as? SfSymbolMacroPreference {
@@ -281,11 +310,11 @@ class LabelAndControl: NSObject {
             // again as a tooltip is annoying noise. The width math is approximate (AppKit doesn't
             // expose the exact text-drawing rect inside a segment): we subtract the typical
             // left+right segment padding plus the symbol image and its gap.
-            if segmentWidth > 0 {
+            if width > 0 {
                 let label = preference.localizedString
                 let textWidth = (label as NSString).size(withAttributes: [.font: button.font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)]).width
                 let imageWidth: CGFloat = hasImage ? 16 + 4 : 0
-                let availableTextWidth = segmentWidth - 12 - imageWidth
+                let availableTextWidth = width - 12 - imageWidth
                 if textWidth > availableTextWidth, #available(macOS 10.13, *) {
                     button.setToolTip(label, forSegment: i)
                 }

--- a/src/preferences/settings-window/tabs/appearance/AppearanceTab.swift
+++ b/src/preferences/settings-window/tabs/appearance/AppearanceTab.swift
@@ -406,6 +406,15 @@ class AppearanceTab: NSObject {
     static let labelShortcutStyle = NSLocalizedString("After keys are released", comment: "")
     static let labelPreviewSelectedWindow = NSLocalizedString("Preview selected window", comment: "")
 
+    /// Widths for the 6-segment Size control. `maxTotal` is what the row can spare for it: this tab's
+    /// table is `SettingsWindow.contentWidth` wide, so the control clears its label and override icon
+    /// with room over; the Controls tab's per-shortcut copy sits in a much narrower table and passes
+    /// its own. The reserve goes on the trailing segment because `.auto` is last and carries the badge.
+    static func sizeSegmentWidths(maxTotal: CGFloat = 560) -> [CGFloat] {
+        LabelAndControl.fittedSegmentWidths(AppearanceSizePreference.allCases,
+            extraOnLast: ProBadgeView.segmentReservedWidth, maxTotal: maxTotal)
+    }
+
     static var customizeStyleButton: NSButton!
     static var animationsButton: NSButton!
     static var customizeStyleSheet: CustomizeStyleSheet!
@@ -491,7 +500,7 @@ class AppearanceTab: NSObject {
         styleRow.alignment = .centerY
         styleRow.spacing = TableGroupView.padding
         table.addRow(secondaryViews: [styleRow], secondaryViewsAlignment: .centerX)
-        let sizeControl = LabelAndControl.makeSegmentedControl("appearanceSize", AppearanceSizePreference.allCases, segmentWidth: 105, extraAction: { control in
+        let sizeControl = LabelAndControl.makeSegmentedControl("appearanceSize", AppearanceSizePreference.allCases, segmentWidths: sizeSegmentWidths(), extraAction: { control in
             refreshAutoSegmentAppearance(control as! NSSegmentedControl)
             ControlsTab.syncOverrideControlsToGlobal()
             refreshAllOverrideInfoLabels()

--- a/src/preferences/settings-window/tabs/controls/ShortcutEditor.swift
+++ b/src/preferences/settings-window/tabs/controls/ShortcutEditor.swift
@@ -435,7 +435,9 @@ final class AppearancePane {
             cases: AppearanceSizePreference.allCases,
             globalIndex: { Preferences.appearanceSize.index },
             proGatedIndices: [AppearanceSizePreference.allCases.firstIndex(of: .auto)!],
-            segmentWidth: 100,
+            // this pane's table is much narrower than the Appearance tab's; 4 × 100 is what the row
+            // already carried here, so the 6 segments get scaled into the same budget
+            segmentWidths: AppearanceTab.sizeSegmentWidths(maxTotal: 400),
             attachBadge: { c in AppearanceTab.addProBadgeToAutoSegment(c) },
             refreshBadge: { c, overlay in
                 AppearanceTab.refreshTrailingSegmentBadge(c, proIndex: AppearanceSizePreference.allCases.firstIndex(of: .auto)!, overlay: overlay)
@@ -546,7 +548,8 @@ final class ShortcutOverrideSegmented {
          cases: [MacroPreference],
          globalIndex: @escaping () -> Int,
          proGatedIndices: Set<Int>,
-         segmentWidth: CGFloat,
+         segmentWidth: CGFloat = -1,
+         segmentWidths: [CGFloat]? = nil,
          attachBadge: ((NSSegmentedControl) -> ProBadgeView.SegmentOverlay)?,
          refreshBadge: ((NSSegmentedControl, ProBadgeView.SegmentOverlay) -> Void)?,
          onChange: (() -> Void)?) {
@@ -558,7 +561,7 @@ final class ShortcutOverrideSegmented {
         self.onChange = onChange
 
         segmented = LabelAndControl.makeSegmentedControl(
-            Preferences.indexToName(baseName, 0), cases, segmentWidth: segmentWidth, extraAction: nil)
+            Preferences.indexToName(baseName, 0), cases, segmentWidth: segmentWidth, segmentWidths: segmentWidths, extraAction: nil)
         badgeOverlay = attachBadge?(segmented)
         if let overlay = badgeOverlay {
             overlay.badge.onWindowKeyChanged = { [weak segmented] in

--- a/src/pro/ui/ProBadgeView.swift
+++ b/src/pro/ui/ProBadgeView.swift
@@ -216,6 +216,11 @@ class ProBadgeView: NSView {
     /// Inset between the badge and the segmented control's trailing edge.
     static let segmentTrailingPadding: CGFloat = 4
 
+    /// Width `attach` takes out of its segment: the badge itself plus the leading gap and the two
+    /// paddings around it. Callers sizing a segmented control add this to the badged segment so its
+    /// label keeps its own room.
+    static var segmentReservedWidth: CGFloat { ProBadgeView().fittingSize.width + 3 * segmentTrailingPadding }
+
     /// The literal text rendered on the badge. Exposed as a constant so the search index can
     /// reference the same string (e.g. `ShortcutsWhenActiveSheet.searchableStrings`) without
     /// duplicating the `NSLocalizedString` call.

--- a/src/switcher/Appearance.swift
+++ b/src/switcher/Appearance.swift
@@ -102,6 +102,10 @@ class Appearance {
             cellCornerRadius = 18
         }
         switch size {
+            case .extraSmall:
+                rowsCount = isHorizontalScreen ? 6 : 9
+                iconSize = 14
+                fontHeight = 12
             case .small:
                 rowsCount = isHorizontalScreen ? 5 : 8
                 iconSize = 16
@@ -114,6 +118,10 @@ class Appearance {
                 rowsCount = isHorizontalScreen ? 3 : 6
                 iconSize = 28
                 fontHeight = 16
+            case .extraLarge:
+                rowsCount = isHorizontalScreen ? 2 : 5
+                iconSize = 32
+                fontHeight = 18
         }
         let tilesPanelRatio = (NSScreen.preferred.frame.width * maxWidthOnScreen) / (NSScreen.preferred.frame.height * maxHeightOnScreen)
         (windowMinWidthInRow, windowMaxWidthInRow) = AppearanceTestable.goodValuesForThumbnailsWidthMinMax(tilesPanelRatio, rowsCount)
@@ -132,6 +140,13 @@ class Appearance {
         windowMaxWidthInRow = 0.3
         rowsCount = 1
         switch size {
+            case .extraSmall:
+                iconSize = 45
+                fontHeight = 12
+                if #available(macOS 26.0, *) {
+                    windowCornerRadius = 42
+                    cellCornerRadius = 18
+                }
             case .small:
                 iconSize = 70
                 fontHeight = 13
@@ -154,6 +169,14 @@ class Appearance {
                     windowCornerRadius = 75
                     cellCornerRadius = 45
                 }
+            case .extraLarge:
+                windowPadding = 28
+                iconSize = 190
+                fontHeight = 18
+                if #available(macOS 26.0, *) {
+                    windowCornerRadius = 85
+                    cellCornerRadius = 55
+                }
         }
     }
 
@@ -167,6 +190,9 @@ class Appearance {
         windowMaxWidthInRow = 0.9
         rowsCount = 1
         switch size {
+            case .extraSmall:
+                iconSize = 14
+                fontHeight = 12
             case .small:
                 iconSize = 18
                 fontHeight = 13
@@ -176,6 +202,9 @@ class Appearance {
             case .large, .auto:
                 iconSize = 30
                 fontHeight = 16
+            case .extraLarge:
+                iconSize = 36
+                fontHeight = 18
         }
     }
 

--- a/src/switcher/main-window/TileView.swift
+++ b/src/switcher/main-window/TileView.swift
@@ -237,10 +237,18 @@ class TileView: FlippedView {
         return maxLabelWidth - Appearance.intraCellPadding * 2
     }
 
+    private func appIconsLabelPaddingSteps() -> CGFloat {
+        switch Appearance.resolvedSize {
+            case .extraSmall, .small: return 0
+            case .medium: return 1
+            case .large, .extraLarge, .auto: return 2
+        }
+    }
+
     private func updateAppIconsLabelFrame() {
         let viewWidth = frame.width
         let labelWidth = fullTitleWidth
-        let padding = (Appearance.resolvedSize == .small ? 0 : (Appearance.resolvedSize == .medium ? 1 : 2)) * Appearance.intraCellPadding
+        let padding = appIconsLabelPaddingSteps() * Appearance.intraCellPadding
         let maxAllowedLabelWidth = getMaxAllowedLabelWidth()
         let sidesToOffset: CGFloat = (isFirstInRow ? 1 : 0) + (isLastInRow ? 1 : 0)
         let paddingForOffset = sidesToOffset * padding
@@ -566,7 +574,7 @@ class TileView: FlippedView {
 
     private func updateDockLabelIconPosition() {
         let iconSize = max(appIcon.frame.width, appIcon.frame.height)
-        let offset = (iconSize * (Preferences.effectiveAppearanceStyle(SwitcherSession.activeShortcutIndex) == .appIcons && Appearance.resolvedSize == .large ? 0.03 : 0.05)).rounded()
+        let offset = (iconSize * (Preferences.effectiveAppearanceStyle(SwitcherSession.activeShortcutIndex) == .appIcons && Appearance.resolvedSize.isLargeOrAbove ? 0.03 : 0.05)).rounded()
         let badgeTopRightX = appIcon.frame.maxX + offset
         let badgeTopRightY = appIcon.frame.minY - offset
         assignIfDifferent(&dockLabelIcon.frame.origin.x, badgeTopRightX - dockLabelIcon.frame.width)


### PR DESCRIPTION
Adds `XS` and `XL` to the Size setting, extending the range at both ends. This is the "Adding an XS and XL Appearance Size => sounds like we should add it" item from #3882.

Sizes are wired into all 3 styles, so Thumbnails / App Icons / Titles each get metrics for both new cases, continuing their existing progressions (including the Tahoe corner radii).

## Migrating existing settings

This is the part worth reviewing closely. Sizes are stored as their position in `AppearanceSizePreference.allCases` (via `MacroPreference.indexAsString`), so inserting `.extraSmall` at the front and `.extraLarge` before `.auto` shifts every stored index:

| | before | after |
|---|---|---|
| small | 0 | 1 |
| medium | 1 | 2 |
| large | 2 | 3 |
| auto | 3 | **5** |

`migrateAppearanceSizeIndexes` remaps three things:

* the global `appearanceSize`
* every per-shortcut `appearanceSizeOverride` (slots 0…9)
* `proTransition.rememberedAppearanceSize` / `…OverrideSize`, which the Pro gate snapshots as a raw index in the license suite — left unmapped, a locked Pro user on `Auto` would be restored to `Large` on unlock

It runs before `registerDefaults()`, so `string(forKey:)` only sees values the user actually stored and an unset override stays unset — `hasOverride(_:_:)` reads `persistentDomain`, so writing there would make every shortcut look explicitly overridden. There's a test pinning that.

Like the sibling index remaps in that file (e.g. `migrateGestures`), this is not idempotent; the version gate is what guarantees a single run.

## Sizing the Size control

Going from 4 to 6 segments meant the old uniform 105pt width no longer fit the row. I first hardcoded per-segment widths measured from the English labels — which was wrong, and worth flagging since it's the kind of thing that only shows up for other people: Dutch `Middelgroot` needs 109pt and Polish `Automatycznie` plus the Pro badge needs 164pt, so roughly half the shipped locales would have rendered truncated.

`LabelAndControl.fittedSegmentWidths` now measures each segment from its own localized label and scales proportionally into the width the row can spare. Verified across all 21 `.lproj` files: the Appearance tab has zero truncation in every language. The per-shortcut copy in the Controls tab sits in a much narrower table, so it keeps exactly the 400pt the row already carried; verbose locales truncate there and fall back to the existing tooltip, as they already do today.

Widths have to stay explicit either way — `ProBadgeView.attach` positions the Pro badge from `width(forSegment:)`, which AppKit reports as 0 for auto-sized segments. `ProBadgeView.segmentReservedWidth` now derives the badge's footprint from the view instead of a magic number.

## Non-obvious call sites

Three places compared `Appearance.resolvedSize == .large` rather than switching, so the new cases would have fallen through silently with no compiler error: the App Icons label padding (XS was getting Large's padding), the dock-badge offset, and the windowless indicator. Padding is now an exhaustive `switch`, so the next size added is a compile error there instead of a silent regression.

I deliberately left `TilesView.resolveAutoSize`'s ladder at Large → Medium → Small. Letting `Auto` shrink to XS would change an existing Pro feature's behaviour, which felt like a separate call for you to make.

## Checks

* `xcodebuild -scheme Debug` — succeeds
* `scripts/run_tests.sh` — full suite passes, including 5 new migration tests (spec updated alongside, per the triad convention)
* `scripts/l10n/extract_l10n_strings.sh` — regenerated `Localizable.strings` is byte-identical to what's committed
* The 2 new keys are English-only for now; they'll pick up translations on the next Crowdin batch

`XS` / `XL` are kept short deliberately so 6 segments stay readable; happy to switch to "Extra small" / "Extra large" if you'd rather, though it costs a fair bit of row width in the verbose locales.
