### PR TITLE
fix: command+backtick shortcut had no effect

### DIFF
--- a/src/macos/api-wrappers/CGSSymbolicHotKey.swift
+++ b/src/macos/api-wrappers/CGSSymbolicHotKey.swift
@@ -5,8 +5,18 @@ import Foundation
 /// `NativeHotkeyResolver` that surface this enum can compile in the unit-tests target. See
 /// `setNativeCommandTabEnabled` / `CGSSetSymbolicHotKeyEnabled` in `SkyLight.framework.swift` for the
 /// runtime side of toggling them.
+/// IDs verified on macOS 27 by reading each one back with `CGSGetSymbolicHotKeyValue`, and
+/// cross-checked against the `AppleSymbolicHotKeys` entries in `com.apple.symbolichotkeys`:
+///
+///     id  1 → keyCode 48 (⇥), ⌘        "Move focus to next application"
+///     id  2 → keyCode 48 (⇥), ⇧⌘       "Move focus to previous application"
+///     id  6 → keyCode 53 (⎋), ⌥⇧⌘      "Force Quit the frontmost app"
+///     id 27 → keyCode 50 (`), ⌘        "Move focus to next window in the active application"
+///
+/// 27 is the one bound to the key above Tab. 6 is Force Quit — the same chord AltTab lists as
+/// `MacOsShortcuts.forceQuitActiveApp` — so it must never be toggled here.
 enum CGSSymbolicHotKey: Int, CaseIterable {
     case commandTab = 1
     case commandShiftTab = 2
-    case commandKeyAboveTab = 6 // see keyAboveTabDependingOnInputSource
+    case commandKeyAboveTab = 27 // see keyAboveTabDependingOnInputSource
 }


### PR DESCRIPTION
Binding ⌘\` in AltTab does nothing, and we've been switching off the wrong native shortcut.

`CGSSymbolicHotKey.commandKeyAboveTab` is 6. On macOS 27, reading the IDs back with `CGSGetSymbolicHotKeyValue` (the technique the comment above `CGSSetSymbolicHotKeyEnabled` already suggests) gives:

```
id  1 → keyCode 48 (⇥), ⌘      Move focus to next application
id  2 → keyCode 48 (⇥), ⇧⌘     Move focus to previous application
id  6 → keyCode 53 (⎋), ⌥⇧⌘    Force Quit the frontmost app
id 27 → keyCode 50 (`), ⌘      Move focus to next window in the active application
```

`com.apple.symbolichotkeys` agrees — the entry for ⌘\` is id 27, `parameters = (96, 50, 1048576)`, i.e. char `` ` ``, keyCode 50, modifier `0x100000`.

So 27 is the key-above-Tab one, and 6 is Force Quit — the same chord we already list as `MacOsShortcuts.forceQuitActiveApp`. Two consequences when someone binds ⌘\`: the native ⌘\` stays enabled and keeps eating the keystroke before our Carbon hotkey can see it, which is the reported symptom; and Force Quit gets switched off instead, and stays off after AltTab quits, since that state persists.

This also fits the history. The ID was introduced in 848ae5f for #2053, and shortly after the release @AfzalivE reported on that thread that ⌘\` was still broken for them on 6.49.0 with exactly this setup — which is what you'd expect if the toggle was landing on a different hotkey all along. #1734 looks like the same thing.

One line, plus the ID table in a comment so the next person doesn't have to re-derive it. 932 tests pass, Xcode 26.6 on macOS 27.

Two things I couldn't check. I don't have an ISO keyboard, and `matchesCommandKeyAboveTab` also hardcodes `kVK_ANSI_Grave` — the key above Tab isn't keyCode 50 on every layout, so that's probably still wrong there. Reading the keyCode off hotkey 27 with `CGSGetSymbolicHotKeyValue` instead of hardcoding it would fix that and handle a reassigned system shortcut too; happy to do that as a follow-up. And I only verified the ID table on macOS 27, not on older versions.

Independent of #5964, which is about not re-enabling hotkeys the user turned off; they touch different files.