### PR TITLE
test: compare the blamed shortcut when comparing ShortcutAcceptance

### DIFF
--- a/src/kit/CustomRecorderControlTestable.swift
+++ b/src/kit/CustomRecorderControlTestable.swift
@@ -152,18 +152,6 @@ enum ShortcutAcceptance: Equatable {
     case modifiersOnlyButContainsKeycode
     case conflictWithExistingShortcut(shortcutAlreadyAssigned: String)
     case reservedByMacos(shortcutUsingEscape: String)
-
-    static func == (lhs: ShortcutAcceptance, rhs: ShortcutAcceptance) -> Bool {
-        switch (lhs, rhs) {
-        case (.accepted, .accepted),
-             (.modifiersOnlyButContainsKeycode, .modifiersOnlyButContainsKeycode),
-             (.reservedByMacos, .reservedByMacos),
-             (.conflictWithExistingShortcut, .conflictWithExistingShortcut):
-            return true
-        default:
-            return false
-        }
-    }
 }
 /// Hard-set Force-Quit chords. macOS reserves these and they cannot be unbound, so AltTab refuses
 /// to assign them. (`⌘⎋` was previously listed here for Game Overlay; it's been removed because

--- a/src/kit/CustomRecorderControlTests.swift
+++ b/src/kit/CustomRecorderControlTests.swift
@@ -2,6 +2,23 @@ import XCTest
 import ShortcutRecorder
 
 final class CustomRecorderControlTests: XCTestCase {
+    /// Every `conflictWithExistingShortcut` / `reservedByMacos` assertion in this file names the
+    /// shortcut it expects to be blamed. A hand-written `==` that switched on the cases alone made
+    /// all of those names decorative — any two conflicts compared equal, so a wrong blame passed.
+    /// Pin that the payload is part of equality.
+    func testAcceptanceEqualityComparesTheBlamedShortcut() {
+        XCTAssertNotEqual(
+            ShortcutAcceptance.conflictWithExistingShortcut(shortcutAlreadyAssigned: "holdShortcut"),
+            ShortcutAcceptance.conflictWithExistingShortcut(shortcutAlreadyAssigned: "cancelShortcut"))
+        XCTAssertNotEqual(
+            ShortcutAcceptance.reservedByMacos(shortcutUsingEscape: "holdShortcut"),
+            ShortcutAcceptance.reservedByMacos(shortcutUsingEscape: "cancelShortcut"))
+        XCTAssertEqual(
+            ShortcutAcceptance.conflictWithExistingShortcut(shortcutAlreadyAssigned: "cancelShortcut"),
+            ShortcutAcceptance.conflictWithExistingShortcut(shortcutAlreadyAssigned: "cancelShortcut"))
+        XCTAssertNotEqual(ShortcutAcceptance.accepted, .modifiersOnlyButContainsKeycode)
+    }
+
     func testIsShortcutAcceptable_accepted() {
         XCTAssertEqual(CustomRecorderControlTestable.isShortcutAcceptable("previousWindowShortcut", Shortcut(keyEquivalent: "⇧⇥")!), .accepted)
         ControlsTab.shortcuts["holdShortcut"] = ATShortcut(Shortcut(keyEquivalent: "⌘⌥")!, "holdShortcut", .global, .up)


### PR DESCRIPTION
`ShortcutAcceptance` declares `Equatable` but hand-writes `==` to switch on the cases and ignore the associated values. So any two `.conflictWithExistingShortcut` compare equal regardless of which shortcut they blame, and likewise for `.reservedByMacos`.

`CustomRecorderControlTests` names the expected shortcut in about twenty assertions:

```swift
XCTAssertEqual(CustomRecorderControlTestable.isShortcutAcceptable("vimCycleLeft", Shortcut(keyEquivalent: "h")!),
               .conflictWithExistingShortcut(shortcutAlreadyAssigned: "hideShowAppShortcut"))
```

Those names are decorative today — the assertion holds as long as *some* conflict is returned, so a conflict blamed on the wrong shortcut passes. That name is what ends up in the dialog via `conflictLabel`, so it's the part worth pinning.

Deleting the operator restores the synthesized `Equatable`, which compares payloads. Nothing else needed changing: I ran the suite with real equality first, and every existing expectation was already correct, so this is only about the tests being able to catch a future regression rather than a bug being fixed now. Added one test so the payload-ignoring version can't come back.

`==` isn't used in production — `CustomRecorderControl` switches on the result and binds the payload — so this is test-only in effect.

933 tests pass, Xcode 26.6 on macOS 27.