### PR TITLE
fix: a shortcut could not be assigned because of an unrelated conflict

### DIFF
--- a/src/kit/CustomRecorderControlTestable.swift
+++ b/src/kit/CustomRecorderControlTestable.swift
@@ -27,7 +27,7 @@ class CustomRecorderControlTestable {
         let oldCombos = oldCombinationsExcludingTargetOfCandidate(candidateId)
         // TODO: a user can assign a shortcut that's both .conflictWithExistingShortcut and .reservedByMacos
         // It's a mess to deal with. Current implem may let them bypass isReservedByMacos. Would be nice to think about what UX to do here
-        if let alreadyAssigned = isAlreadyUsedByAnotherShortcut(newCombos, oldCombos) {
+        if let alreadyAssigned = isAlreadyUsedByAnotherShortcut(newCombos, oldCombos, currentCombinations()) {
             return .conflictWithExistingShortcut(shortcutAlreadyAssigned: alreadyAssigned)
         }
         if let shortcutUsingEscape = isReservedByMacos(newCombos) {
@@ -88,10 +88,21 @@ class CustomRecorderControlTestable {
     }
 
     static func oldCombinationsExcludingTargetOfCandidate(_ candidateId: String) -> [(String, Shortcut)] {
+        combinations { isRecomputedInNewCombinations(candidateId, $0) }
+    }
+
+    /// Every chord the saved configuration already produces, with no candidate edit applied.
+    /// Used to tell a collision the edit introduces from one that was already there.
+    static func currentCombinations() -> [(String, Shortcut)] {
+        combinations { _ in false }
+    }
+
+    /// hold × non-hold chords over the shortcut registry, skipping the ids `isExcluded` rejects.
+    private static func combinations(_ isExcluded: (String) -> Bool) -> [(String, Shortcut)] {
         var holds = [ATShortcut]()
         var nonHolds = [ATShortcut]()
         for atShortcut in ControlsTab.shortcuts.values {
-            guard !isRecomputedInNewCombinations(candidateId, atShortcut.id)
+            guard !isExcluded(atShortcut.id)
                       && !(atShortcut.shortcut.keyCode == .none && atShortcut.shortcut.modifierFlags == []) else { continue }
             if atShortcut.id.starts(with: "holdShortcut") {
                 holds.append(atShortcut)
@@ -120,8 +131,12 @@ class CustomRecorderControlTestable {
         return nil
     }
 
-    static func isAlreadyUsedByAnotherShortcut(_ newCombos: [(String, Shortcut)] , _ oldCombos: [(String, Shortcut)]) -> String? {
+    static func isAlreadyUsedByAnotherShortcut(_ newCombos: [(String, Shortcut)] , _ oldCombos: [(String, Shortcut)], _ currentCombos: [(String, Shortcut)] = []) -> String? {
         for newCombo in newCombos {
+            // A chord this same id already produces isn't introduced by the edit. Reporting it anyway
+            // blocks an unrelated change with a collision the saved config already had, naming a
+            // shortcut the user isn't editing and can't fix from that dialog (issue #5455).
+            if currentCombos.contains(where: { $0.0 == newCombo.0 && sameChord($0.1, newCombo.1) }) { continue }
             for oldCombo in oldCombos {
                 guard !(newCombo.0 == oldCombo.0) else { continue }
                 if (newCombo.1.keyCode == oldCombo.1.keyCode && newCombo.1.modifierFlags == oldCombo.1.modifierFlags)
@@ -133,6 +148,10 @@ class CustomRecorderControlTestable {
             }
         }
         return nil
+    }
+
+    private static func sameChord(_ a: Shortcut, _ b: Shortcut) -> Bool {
+        a.carbonKeyCode == b.carbonKeyCode && a.carbonModifierFlags == b.carbonModifierFlags
     }
 
     /// commandTab and commandKeyAboveTab are self-contained in the "nextWindowShortcut" shortcuts

--- a/src/kit/CustomRecorderControlTests.swift
+++ b/src/kit/CustomRecorderControlTests.swift
@@ -71,6 +71,29 @@ final class CustomRecorderControlTests: XCTestCase {
         XCTAssertEqual(CustomRecorderControlTestable.isShortcutAcceptable("nextWindowShortcut", Shortcut(keyEquivalent: "t")!), .accepted)
     }
 
+    /// Issue #5455. The reporter's config (from their `defaults read`): S1 = hold ⌘ + press ⎋,
+    /// S2 = hold ⌥ + press `. That config already double-assigns ⌘⎋ — Cancel is ⎋, and under S1's
+    /// own ⌘ hold that is S1's trigger. Nothing re-validates a saved config, so it sits there.
+    ///
+    /// Giving another shortcut a ⌘ hold (how you reach ⌘` from here) recomputes Cancel under ⌘,
+    /// hits that same ⌘⎋, and was rejected with "already assigned to Shortcut 1 - Trigger" — a
+    /// collision the edit doesn't create, naming a shortcut the user isn't touching. Only chords
+    /// the edit actually introduces should be reported.
+    func testIsShortcutAcceptable_preExistingCollisionDoesNotBlockAnUnrelatedEdit() {
+        ControlsTab.shortcuts = ControlsTab.defaultShortcuts
+        ControlsTab.shortcuts["holdShortcut"] = ATShortcut(Shortcut(keyEquivalent: "⌘")!, "holdShortcut", .global, .up, 0)
+        ControlsTab.shortcuts["nextWindowShortcut"] = ATShortcut(Shortcut(keyEquivalent: "⌘⎋")!, "nextWindowShortcut", .global, .down)
+        ControlsTab.shortcuts["holdShortcut2"] = ATShortcut(Shortcut(keyEquivalent: "⌥")!, "holdShortcut2", .global, .up, 1)
+        ControlsTab.shortcuts["nextWindowShortcut2"] = ATShortcut(Shortcut(keyEquivalent: "⌥`")!, "nextWindowShortcut2", .global, .down)
+        defer { ControlsTab.shortcuts = ControlsTab.defaultShortcuts }
+        // the edit the reporter couldn't make: S2's hold ⌥ -> ⌘, giving them ⌘`
+        XCTAssertEqual(CustomRecorderControlTestable.isShortcutAcceptable("holdShortcut2", Shortcut(keyEquivalent: "⌘")!), .accepted)
+        // a collision the edit DOES introduce is still reported: ⌥⎋ is free today, so giving S2 the
+        // press ⎋ newly clashes with Cancel under S2's own ⌥ hold
+        XCTAssertEqual(CustomRecorderControlTestable.isShortcutAcceptable("nextWindowShortcut2", Shortcut(keyEquivalent: "⎋")!),
+            .conflictWithExistingShortcut(shortcutAlreadyAssigned: "cancelShortcut"))
+    }
+
     func testIsShortcutAcceptable_reservedByMacos() {
         XCTAssertEqual(CustomRecorderControlTestable.isShortcutAcceptable("previousWindowShortcut", Shortcut(keyEquivalent: "⌘⇧")!), .accepted) // ⌘⎋
         XCTAssertEqual(CustomRecorderControlTestable.isShortcutAcceptable("previousWindowShortcut", Shortcut(keyEquivalent: "⌘⌃⇧")!), .accepted) // ⌘⎋


### PR DESCRIPTION
Closes #5455.

I rebuilt the reporter's registry from the `defaults read` they posted — S1 = hold ⌘ + press ⎋, S2 = hold ⌥ + press ` — and ran `isShortcutAcceptable` over the edits that get you to ⌘\`:

```
holdShortcut2       <- ⌘    =>  CONFLICT blaming 'nextWindowShortcut'
holdShortcut3       <- ⌘    =>  CONFLICT blaming 'nextWindowShortcut'
```

So the dialog they hit is the plain conflict one, blaming "Shortcut 1 - Trigger". It's nothing to do with the macOS ⌘\` shortcut, which is why reassigning that in System Settings didn't help them.

The reason is a collision their config already had. Cancel is ⎋, and S1's hold is ⌘, so Cancel already produces ⌘⎋ — which is also S1's own trigger. Dumping every chord the saved config produces:

```
PRE-EXISTING COLLISION on kc53/mods256: ["cancelShortcut", "nextWindowShortcut"]
```

A saved config is never re-validated, so that just sits there. But the only way to get ⌘\` is to give another shortcut a ⌘ hold, and that recomputes Cancel under ⌘, lands on the same ⌘⎋, and gets reported. The chord isn't introduced by the edit and isn't made worse by it, and the user can't act on the message — they're editing Shortcut 2 and being told about Shortcut 1.

So: only report a chord the edit actually introduces. `isAlreadyUsedByAnotherShortcut` now skips a candidate combination when that same id already produces that same chord in the current config. `oldCombinationsExcludingTargetOfCandidate` and the new `currentCombinations` are the same walk with a different exclusion, so I pulled the body into one `combinations(_:)`.

A collision the edit *does* introduce still reports, and the new test pins both directions. It fails on master with exactly the reported error:

```
XCTAssertEqual failed: ("conflictWithExistingShortcut(shortcutAlreadyAssigned: "nextWindowShortcut")") is not equal to ("accepted")
```

933 tests pass, Xcode 26.6 on macOS 27.

Two things I'd flag. This doesn't clean up a pre-existing collision, it just stops it blocking unrelated edits — their ⌘⎋ stays ambiguous between Cancel and S1's trigger until they change one. And `isAlreadyUsedByAnotherShortcut` still only compares candidate chords against existing ones, never against each other, so two chords introduced by the same edit can still collide silently; that's unchanged here, but it's the reason my first attempt at the "still reports" assertion didn't fire.