### PR TITLE
fix: switcher selected the window already on screen after closing a window

### DIFF
--- a/src/switcher/state/SelectionResolver.swift
+++ b/src/switcher/state/SelectionResolver.swift
@@ -63,6 +63,14 @@ struct SelectionInputs: Equatable {
     var currentWindowIsDrawn = true
 }
 
+/// One window of the frontmost app, as `currentWindowIsDrawn` sees it.
+struct FrontmostAppWindow: Equatable {
+    /// The placeholder tile an app with no windows gets, not a window the user can be looking at.
+    let isWindowlessApp: Bool
+    /// Passed `Windows.shouldDisplay`, i.e. survived this shortcut's filters.
+    let isDrawn: Bool
+}
+
 /// What the kernel recommends. Wrapper translates this into side effects (highlight redraws,
 /// scroll-to-visible, thumbnail preview, etc.).
 enum SelectionDecision: Equatable {
@@ -117,6 +125,28 @@ enum SelectionResolver {
         }
         // 6) Target gone — adapt to the closest visible.
         return adapt(i, visibleIndexes: visibleIndexes, lastVisible: visibleIndexes.last!)
+    }
+
+    /// Is the window the user is looking at among the drawn tiles? Pure half of
+    /// `Windows.currentWindowIsDrawn`, which passes the frontmost app's windows.
+    ///
+    /// Two different situations produce "the frontmost app owns no drawn tile", and only one of them means
+    /// the user's window is missing from the list:
+    ///
+    /// - Its windows are in the model but a filter dropped them (`Apps to show: Non-active apps`). The user
+    ///   is looking at one of them, it isn't drawn, and the front tile is already the previous window — so
+    ///   don't step over it (#5941).
+    /// - It has no window to draw at all, because its last one was just closed. Nothing was filtered. The
+    ///   window the user is now looking at belongs to a different app and sits at the front of the MRU, so
+    ///   the ordinary rule applies and the front tile must be stepped over (#5960). Answering `false` here
+    ///   selected the window the user was already on.
+    ///
+    /// A windowless app is the placeholder tile for the second case, never something the user is looking at,
+    /// so it doesn't count as a window the filters could have dropped.
+    static func currentWindowIsDrawn(_ frontmostAppWindows: [FrontmostAppWindow]) -> Bool {
+        let realWindows = frontmostAppWindows.filter { !$0.isWindowlessApp }
+        guard !realWindows.isEmpty else { return true }
+        return realWindows.contains { $0.isDrawn }
     }
 
     /// Mirrors `setInitialSelectedAndHoveredWindowIndex` — picks the index, defers reset to wrapper.

--- a/src/switcher/state/SelectionResolverTests.swift
+++ b/src/switcher/state/SelectionResolverTests.swift
@@ -519,4 +519,52 @@ final class SelectionResolverTests: XCTestCase {
         XCTAssertNil(SelectionResolver.findTarget(list, nil))
         XCTAssertNil(SelectionResolver.findTarget(list, "missing"))
     }
+
+    // MARK: - G. Frontmost app owns no drawn tile — filtered out vs has no windows (#5960)
+
+    private func fw(windowless: Bool = false, drawn: Bool) -> FrontmostAppWindow {
+        FrontmostAppWindow(isWindowlessApp: windowless, isDrawn: drawn)
+    }
+
+    /// #5941, unchanged: the frontmost app's windows exist but a filter dropped them, so the user IS on one
+    /// of them and the front tile is already the previous window.
+    func testCurrentWindowIsDrawnFalseWhenTheAppsWindowsAreFilteredOut() {
+        XCTAssertFalse(SelectionResolver.currentWindowIsDrawn([fw(drawn: false), fw(drawn: false)]))
+    }
+
+    /// #5960: the user closed the frontmost app's last window, so it has nothing to draw. Nothing was
+    /// filtered — the window they are looking at belongs to another app, at the front of the MRU — so the
+    /// ordinary rule applies and the front tile gets stepped over.
+    func testCurrentWindowIsDrawnTrueWhenTheAppHasNoWindows() {
+        XCTAssertTrue(SelectionResolver.currentWindowIsDrawn([]))
+    }
+
+    /// Same, when the app still occupies a windowless placeholder tile: a placeholder is never a window the
+    /// user is looking at, so it can't stand in for one the filters dropped.
+    func testCurrentWindowIsDrawnTrueWhenTheAppOnlyHasAWindowlessTile() {
+        XCTAssertTrue(SelectionResolver.currentWindowIsDrawn([fw(windowless: true, drawn: true)]))
+        XCTAssertTrue(SelectionResolver.currentWindowIsDrawn([fw(windowless: true, drawn: false)]))
+    }
+
+    /// The ordinary case: at least one of the app's real windows is drawn.
+    func testCurrentWindowIsDrawnTrueWhenOneOfTheAppsWindowsIsDrawn() {
+        XCTAssertTrue(SelectionResolver.currentWindowIsDrawn([fw(drawn: false), fw(drawn: true)]))
+    }
+
+    /// A windowless placeholder alongside real filtered-out windows must not flip the answer: the real
+    /// windows are what the filters dropped, so this is still the #5941 case.
+    func testCurrentWindowIsDrawnFalseWhenRealWindowsAreFilteredOutBesideAPlaceholder() {
+        XCTAssertFalse(SelectionResolver.currentWindowIsDrawn([fw(windowless: true, drawn: true), fw(drawn: false)]))
+    }
+
+    /// #5960 end to end. Terminal frontmost over Chrome/Google and Chrome/YouTube; close Terminal's last
+    /// window and summon. Terminal contributes no window, so the shell now answers `true` and the pick steps
+    /// over the front tile to Chrome/YouTube. Answering `false` selected Chrome/Google — the window already
+    /// on screen — so the shortcut appeared to do nothing.
+    func testInitialPickStepsOverFrontTileAfterTheFrontmostAppLostItsLastWindow() {
+        let list = [w("chromeGoogle"), w("chromeYouTube")]
+        let drawn = SelectionResolver.currentWindowIsDrawn([])
+        let i = inputs(list: list, currentWindowIsDrawn: drawn)
+        XCTAssertEqual(SelectionResolver.decide(i), .resetThenSelect(1))
+    }
 }

--- a/src/switcher/state/Windows.swift
+++ b/src/switcher/state/Windows.swift
@@ -264,21 +264,22 @@ class Windows {
             currentWindowIsDrawn: currentWindowIsDrawn())
     }
 
-    /// Is the window the user is on among the drawn tiles? Asked of the APP, not of the window: if any tile
-    /// belongs to the frontmost app then the window they are looking at is either that tile or one the
-    /// filters kept out for a reason of its own, and either way the front of the list is not the window they
-    /// want to land on. Only when no tile at all belongs to the frontmost app is it certain the current
-    /// window is missing from the list — which is exactly what `Non-active apps` does on purpose (#5941).
+    /// Is the window the user is on among the drawn tiles? Collects the frontmost app's windows and lets
+    /// `SelectionResolver.currentWindowIsDrawn` decide; that is where the rule and its two cases live.
     ///
-    /// Asking the app rather than `application.focusedWindow` is deliberate: that AX read can be stale or
-    /// nil, and answering `false` while the user's window IS drawn would make the default select the window
-    /// they are already on. The app-level question cannot fail that way.
+    /// Asked of the APP, not of `application.focusedWindow`: that AX read can be stale or nil, and answering
+    /// `false` while the user's window IS drawn would make the default select the window they are already
+    /// on. The app-level question cannot fail that way.
     ///
     /// No frontmost app (nothing active, or AltTab launched into an empty front) means nothing is being
     /// filtered against it either, so the ordinary rule applies.
     private static func currentWindowIsDrawn() -> Bool {
         guard let frontmostPid = Applications.frontmostPid else { return true }
-        return list.contains { $0.application.pid == frontmostPid && shouldDisplay($0) }
+        return SelectionResolver.currentWindowIsDrawn(list.compactMap {
+            $0.application.pid == frontmostPid
+                ? FrontmostAppWindow(isWindowlessApp: $0.isWindowlessApp, isDrawn: shouldDisplay($0))
+                : nil
+        })
     }
 
     /// Project `list` into the kernel's window view (just the fields selection needs).


### PR DESCRIPTION
Closes #5960.

Following the reporter's steps — Terminal frontmost over Chrome/Google and Chrome/YouTube, close Terminal's window, summon — the pick lands on the front tile instead of stepping over it. That's Chrome/Google, the window already on screen, so the shortcut looks like it does nothing.

`currentWindowIsDrawn` decides whether the default steps over the front tile, and `defaultPickIndexAsOfSummon` returns `front` when it's false. Two different situations make the frontmost app own no drawn tile, and they want opposite answers:

- Its windows are in the model but a filter dropped them (`Apps to show: Non-active apps`). The user is on one of them, the front tile is already the previous window, don't step over it — #5941.
- It has no window to draw at all, because its last one was just closed. Nothing was filtered. The window now on screen belongs to a different app and sits at the front of the MRU, so the front tile *should* be stepped over.

`list.contains { $0.application.pid == frontmostPid && shouldDisplay($0) }` is false in both, so the second inherited the first's answer. Closing an app's last window doesn't quit it on macOS, so it stays frontmost with nothing to contribute to the list, and every summon after that lands one tile short until you focus something else.

That also fits it being new in 11.5.0: `currentWindowIsDrawn` arrived with the #5941 fix a few days before the release.

I moved the decision into `SelectionResolver` so it can be tested — the shell version reads `Applications.frontmostPid` and `Windows.list` and had no coverage. Only real windows count now: a windowless app is the placeholder tile for exactly the "no windows" case, so letting it stand in for a window the filters dropped would put us back where we started. My own test caught that one, which is why it's spelled out.

Five kernel cases plus the reporter's scenario end to end. The three existing #5941 tests (F1–F3) pass unmodified. 938 tests, 0 failures, Xcode 26.6 on macOS 27.

One thing I couldn't check: I don't have a way to run this against the real WindowServer, so the reasoning about which situation produces which answer is from the code, not from watching it. The `Applications.frontmostPid` timing after an app actually *quits* (rather than just losing its last window) is the part I'd most want a second opinion on — if it updates promptly then that path was never broken, and only the closed-last-window path is.