### PR TITLE
fix: cycling backwards no longer stops at the first window

### DIFF
--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -38,6 +38,9 @@
 		5883F0A829A5182C0071DB65 /* TrackpadEvents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5883F0A729A5182C0071DB65 /* TrackpadEvents.swift */; };
 		5E1EC110000000000000C002 /* SelectionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1EC110000000000000C001 /* SelectionResolver.swift */; };
 		5E1EC110000000000000C003 /* SelectionResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1EC110000000000000C001 /* SelectionResolver.swift */; };
+		5E1EC110000000000000D002 /* CycleWrapResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1EC110000000000000D001 /* CycleWrapResolver.swift */; };
+		5E1EC110000000000000D003 /* CycleWrapResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1EC110000000000000D001 /* CycleWrapResolver.swift */; };
+		5E1EC110000000000000D102 /* CycleWrapResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1EC110000000000000D101 /* CycleWrapResolverTests.swift */; };
 		5E1EC110000000000000C102 /* SelectionResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E1EC110000000000000C101 /* SelectionResolverTests.swift */; };
 		5E9E570000000000000F1002 /* GestureTriggerKernel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9E570000000000000F1001 /* GestureTriggerKernel.swift */; };
 		5E9E570000000000000F1003 /* GestureTriggerKernel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E9E570000000000000F1001 /* GestureTriggerKernel.swift */; };
@@ -442,6 +445,8 @@
 		5883F0A729A5182C0071DB65 /* TrackpadEvents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackpadEvents.swift; sourceTree = "<group>"; };
 		5E1EC110000000000000C001 /* SelectionResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SelectionResolver.swift; sourceTree = "<group>"; };
 		5E1EC110000000000000C101 /* SelectionResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionResolverTests.swift; sourceTree = "<group>"; };
+		5E1EC110000000000000D001 /* CycleWrapResolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CycleWrapResolver.swift; sourceTree = "<group>"; };
+		5E1EC110000000000000D101 /* CycleWrapResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CycleWrapResolverTests.swift; sourceTree = "<group>"; };
 		5E9E570000000000000F1001 /* GestureTriggerKernel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureTriggerKernel.swift; sourceTree = "<group>"; };
 		5E9E570000000000000F1101 /* GestureTriggerKernelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GestureTriggerKernelTests.swift; sourceTree = "<group>"; };
 		5EA8E110000000000000F001 /* AxQueryRouting.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AxQueryRouting.swift; sourceTree = "<group>"; };
@@ -1075,6 +1080,8 @@
 				5E7C0F70000000000000E101 /* ExceptionMatcherTests.swift */,
 				5E0DE2A0000000000000D101 /* WindowOrderResolverTests.swift */,
 				5E1EC110000000000000C101 /* SelectionResolverTests.swift */,
+				5E1EC110000000000000D001 /* CycleWrapResolver.swift */,
+				5E1EC110000000000000D101 /* CycleWrapResolverTests.swift */,
 			);
 			path = state;
 			sourceTree = "<group>";
@@ -2014,6 +2021,8 @@
 				5FC5980000000000000A0102 /* NativeHotkeyResolverTests.swift in Sources */,
 				5E1EC110000000000000C003 /* SelectionResolver.swift in Sources */,
 				5E1EC110000000000000C102 /* SelectionResolverTests.swift in Sources */,
+				5E1EC110000000000000D003 /* CycleWrapResolver.swift in Sources */,
+				5E1EC110000000000000D102 /* CycleWrapResolverTests.swift in Sources */,
 				5E5EA12C0000000000000003 /* SearchModeResolver.swift in Sources */,
 				5E5EA12C0000000000000102 /* SearchModeResolverTests.swift in Sources */,
 				5E5EA12D0000000000000003 /* ShortcutModifierResolver.swift in Sources */,
@@ -2103,6 +2112,7 @@
 				D04BA8480A8FF466CA89DA5B /* main.swift in Sources */,
 				D04BAFB973C3D28718FAEB87 /* Windows.swift in Sources */,
 				5E1EC110000000000000C002 /* SelectionResolver.swift in Sources */,
+				5E1EC110000000000000D002 /* CycleWrapResolver.swift in Sources */,
 				5E5EA12C0000000000000002 /* SearchModeResolver.swift in Sources */,
 				5E5EA12D0000000000000002 /* ShortcutModifierResolver.swift in Sources */,
 				5F5849A900000000000000A2 /* BruteForceWindowMatch.swift in Sources */,

--- a/src/switcher/KeyRepeatTimer.swift
+++ b/src/switcher/KeyRepeatTimer.swift
@@ -12,6 +12,10 @@ class KeyRepeatTimer {
     /// arm-relative schedule.
     static var armedAt: TimeInterval = 0
     static var currentInitialDelay: TimeInterval = 0
+    /// True only for the duration of a synthesized repeat tick. `CycleWrapResolver` gates wrap-around on
+    /// this rather than on `timerIsSuspended`: a modifier-only shortcut keeps its timer armed for the whole
+    /// time the key is held, so armed-ness cannot tell a repeat apart from a real press landing mid-hold.
+    static var isFiringArtificialRepeat = false
 
     static func startRepeatingKeyPreviousWindow() {
         if let shortcut = ControlsTab.shortcuts["previousWindowShortcut"],
@@ -67,6 +71,8 @@ class KeyRepeatTimer {
             } else if KeyRepeatTimerTestable.shouldApplyArtificialRepeat(now: ProcessInfo.processInfo.systemUptime,
                 armedAt: armedAt, panelBecameVisibleAt: SwitcherSession.current?.panelBecameVisibleAt,
                 panelShownAt: SwitcherSession.current?.panelShownAt, initialDelay: currentInitialDelay) {
+                isFiringArtificialRepeat = true
+                defer { isFiringArtificialRepeat = false }
                 block()
             }
             // else: the panel hasn't been VISIBLE for the initial-delay grace yet (a slow show swallowed it);

--- a/src/switcher/main-window/TilesView.swift
+++ b/src/switcher/main-window/TilesView.swift
@@ -367,8 +367,10 @@ class TilesView {
                     return nil
                 }
             }
-            if ((step > 0 && nextRow < currentRow) || (step < 0 && nextRow > currentRow)) &&
-                   (ATShortcut.lastEventIsARepeat || !KeyRepeatTimer.timerIsSuspended) {
+            if CycleWrapResolver.blocksWrap(CycleAdvance(
+                   isWrapping: (step > 0 && nextRow < currentRow) || (step < 0 && nextRow > currentRow),
+                   allowWrap: allowWrap, lastEventIsARepeat: ATShortcut.lastEventIsARepeat,
+                   isArtificialRepeatTick: KeyRepeatTimer.isFiringArtificialRepeat)) {
                 return nil
             }
             return rows[nextRow]

--- a/src/switcher/state/CycleWrapResolver.swift
+++ b/src/switcher/state/CycleWrapResolver.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// One selection advance, as seen by the wrap decision.
+struct CycleAdvance: Equatable {
+    /// This advance would leave the list by its end and land at the other end.
+    let isWrapping: Bool
+    /// The caller allows wrapping at all (row-bounded navigation passes false).
+    let allowWrap: Bool
+    /// The OS said the key event driving this advance was an auto-repeat (`NSEvent.isARepeat`).
+    let lastEventIsARepeat: Bool
+    /// This advance IS one of `KeyRepeatTimer`'s synthesized ticks, rather than a key event.
+    ///
+    /// Deliberately a fact about THIS advance, not about the timer. Asking instead whether a timer was
+    /// ARMED — as this rule used to — silently blocks real presses: a modifier-only shortcut (the default
+    /// `previousWindowShortcut` = ⇧) holds its timer armed for the entire time the key is down, so every
+    /// ⌥⇧+⇥ press during the hold read as a repeat and backwards cycling dead-ended at the first tile.
+    let isArtificialRepeatTick: Bool
+}
+
+/// Pure decision for "may this advance wrap around the end of the list?". Extracted from
+/// `Windows.cycleSelectedWindowIndex` and `TilesView.nextRow`, which carried the same rule twice.
+/// See `CycleWrapResolverSpecs.md`.
+enum CycleWrapResolver {
+    static func blocksWrap(_ advance: CycleAdvance) -> Bool {
+        guard advance.isWrapping else { return false }
+        return !advance.allowWrap || advance.lastEventIsARepeat || advance.isArtificialRepeatTick
+    }
+}

--- a/src/switcher/state/CycleWrapResolverSpecs.md
+++ b/src/switcher/state/CycleWrapResolverSpecs.md
@@ -1,0 +1,58 @@
+# CycleWrapResolver — Specs
+
+## Summary
+
+`CycleWrapResolver.blocksWrap` is the pure decision for "may this selection advance wrap around the end
+of the list?". `Windows.cycleSelectedWindowIndex` (index cycling) and `TilesView.nextRow` (row
+navigation) both ask it; the rule used to be written out twice, once in each, and neither copy was
+covered by a test.
+
+## The rule
+
+An advance is refused only when it would actually wrap, AND one of:
+
+1. the caller forbids wrapping (`allowWrap: false` — row-bounded navigation),
+2. the OS marked the driving key event as an auto-repeat (`NSEvent.isARepeat`),
+3. the advance is one of `KeyRepeatTimer`'s synthesized ticks.
+
+2 and 3 are the same intent from two sources: **holding** a key walks to the end and stops there, rather
+than looping under the user's fingers. Everything else — every discrete press — wraps.
+
+## Why the repeat signal is per-advance, not per-session
+
+The obvious signal for 3 is "does `KeyRepeatTimer` currently have a timer armed?" (`!timerIsSuspended`).
+It is wrong, and it broke backwards cycling.
+
+`KeyRepeatTimer` synthesizes repeats for shortcuts with **no keycode of their own**, which get no OS
+key-repeat. The default `previousWindowShortcut` is exactly that: the bare modifier `⇧`. A modifier-only
+shortcut's `state` is decided by `ATShortcut.matches` from the event's modifiers alone, so it stays
+`.down` for as long as ⇧ is physically held — `stopRepeatIfUp` never fires, and the timer stays armed for
+the whole hold.
+
+So during a ⇧ hold, "a timer is armed" is true for *every* backwards advance, including real ⌥⇧+⇥
+presses. Those presses were read as repeats and refused a wrap: backwards cycling dead-ended on the first
+tile, and the only way to get one more wrap was to release ⇧ and press it again.
+
+Forward cycling had no equivalent dead-end, which is what made the asymmetry visible. `nextWindowShortcut`
+carries a real keycode, so the local monitor reports `keyCode: nil` on key-up, `matches` flips its state
+to `.up`, and each ⇥ release suspends the timer — leaving it suspended when the next tap is handled.
+
+Armed-ness is a fact about the session. Being a repeat is a fact about a single advance, so
+`KeyRepeatTimer.isFiringArtificialRepeat` is set only for the duration of a tick's `block()` call.
+
+Note that the config lwouis recommends in #5924 / #5914 — rebinding *Select previous window* from `⇧` to
+`⇧⇥` — never hit this: a shortcut with a keycode gets real OS key-repeat, so
+`startRepeatingKeyPreviousWindow` declines to arm a timer at all.
+
+---
+
+## Test scenarios
+
+Mirrors `CycleWrapResolverTests.swift` 1:1.
+
+- **testADiscretePressWrapsWhileAHeldModifierKeepsTheRepeatTimerArmed** — the bug: a press is not a
+  repeat, whatever the timer is doing.
+- **testASynthesizedRepeatStopsAtTheEndInsteadOfWrapping** — hold-to-cycle still stops at the end.
+- **testAnOsKeyRepeatStopsAtTheEndInsteadOfWrapping** — same, for shortcuts that get real OS repeats.
+- **testAnAdvanceThatDoesNotReachTheEndIsNeverBlocked** — the rule only ever suppresses a wrap.
+- **testWrapIsRefusedWhenTheCallerForbidsIt** — `allowWrap: false` (row-bounded navigation).

--- a/src/switcher/state/CycleWrapResolverTests.swift
+++ b/src/switcher/state/CycleWrapResolverTests.swift
@@ -1,0 +1,39 @@
+import XCTest
+
+final class CycleWrapResolverTests: XCTestCase {
+    private func advance(wrapping: Bool = true, allowWrap: Bool = true,
+                         lastEventIsARepeat: Bool = false,
+                         isArtificialRepeatTick: Bool = false) -> CycleAdvance {
+        return CycleAdvance(isWrapping: wrapping, allowWrap: allowWrap,
+                            lastEventIsARepeat: lastEventIsARepeat,
+                            isArtificialRepeatTick: isArtificialRepeatTick)
+    }
+
+    // The bug. `previousWindowShortcut` defaults to the modifier-only ⇧, so it stays `.down` — and its
+    // artificial-repeat timer stays ARMED — for as long as the user holds ⇧. A ⌥⇧+⇥ press landing during
+    // that hold is a discrete user press, not a repeat, so it must wrap exactly as a forward ⌥+⇥ tap does.
+    // Armed-ness is a fact about the session; being a repeat is a fact about THIS advance.
+    func testADiscretePressWrapsWhileAHeldModifierKeepsTheRepeatTimerArmed() {
+        XCTAssertFalse(CycleWrapResolver.blocksWrap(advance()))
+    }
+
+    // Intent that must survive the fix: holding the key walks to the end and STOPS, rather than looping
+    // forever under the user's fingers.
+    func testASynthesizedRepeatStopsAtTheEndInsteadOfWrapping() {
+        XCTAssertTrue(CycleWrapResolver.blocksWrap(advance(isArtificialRepeatTick: true)))
+    }
+
+    func testAnOsKeyRepeatStopsAtTheEndInsteadOfWrapping() {
+        XCTAssertTrue(CycleWrapResolver.blocksWrap(advance(lastEventIsARepeat: true)))
+    }
+
+    func testAnAdvanceThatDoesNotReachTheEndIsNeverBlocked() {
+        XCTAssertFalse(CycleWrapResolver.blocksWrap(advance(wrapping: false, lastEventIsARepeat: true)))
+        XCTAssertFalse(CycleWrapResolver.blocksWrap(advance(wrapping: false, isArtificialRepeatTick: true)))
+        XCTAssertFalse(CycleWrapResolver.blocksWrap(advance(wrapping: false, allowWrap: false)))
+    }
+
+    func testWrapIsRefusedWhenTheCallerForbidsIt() {
+        XCTAssertTrue(CycleWrapResolver.blocksWrap(advance(allowWrap: false)))
+    }
+}

--- a/src/switcher/state/Windows.swift
+++ b/src/switcher/state/Windows.swift
@@ -374,9 +374,10 @@ class Windows {
         guard list.contains(where: { shouldDisplay($0) }) else { return }
         session.userPickedSelection = true  // from here the selection is the USER's pick, not the default
         let nextIndex = selectedWindowIndexAfterCycling(step)
-        // don't wrap-around at the end, if key-repeat
-        if (((step > 0 && nextIndex < session.selectedIndex) || (step < 0 && nextIndex > session.selectedIndex)) &&
-            (!allowWrap || ATShortcut.lastEventIsARepeat || !KeyRepeatTimer.timerIsSuspended))
+        let isWrapping = (step > 0 && nextIndex < session.selectedIndex) || (step < 0 && nextIndex > session.selectedIndex)
+        if CycleWrapResolver.blocksWrap(CycleAdvance(isWrapping: isWrapping, allowWrap: allowWrap,
+               lastEventIsARepeat: ATShortcut.lastEventIsARepeat,
+               isArtificialRepeatTick: KeyRepeatTimer.isFiringArtificialRepeat))
                // don't cycle to another row, if !allowWrap
                || (!allowWrap && list[nextIndex].rowIndex != list[session.selectedIndex].rowIndex) {
             return


### PR DESCRIPTION
## The bug

With the default `previousWindowShortcut` (the bare modifier `⇧`), backwards cycling dead-ends on the first window. Once you are there, further backwards input does nothing — you have to release ⇧ and press it again to get one more step. Forward cycling has no equivalent dead-end.

## Why

`KeyRepeatTimer` synthesizes repeats for shortcuts that have **no keycode of their own**, since those get no OS key-repeat. The default `previousWindowShortcut` is exactly that.

A modifier-only shortcut's `state` is decided by `ATShortcut.matches` from the event's modifiers alone, so it stays `.down` for as long as ⇧ is physically held. `stopRepeatIfUp` never fires, and the timer therefore stays armed for the whole hold.

The wrap-around rule used `!KeyRepeatTimer.timerIsSuspended` as its "this is a key repeat" signal. During a ⇧ hold that is true for *every* backwards advance, including real key presses, so each one was refused its wrap.

Forward cycling escapes this because `nextWindowShortcut` carries a real keycode: the local monitor reports `keyCode: nil` on key-up, `matches` flips the state to `.up`, and each release suspends the timer — leaving it suspended when the next press is handled.

## The fix

Gate wrap-around on whether an advance **is** one of the timer's synthesized ticks — a fact about that advance — instead of on whether a timer is armed, which is a fact about the session. `KeyRepeatTimer.isFiringArtificialRepeat` is set only for the duration of a tick's `block()` call.

Holding a key still walks to the end and stops there, unchanged. Only genuine presses regained their wrap.

This is the behaviour `docs/contributing.md` already specifies, under QA > Shortcuts:

> when navigating left/right/up/down, the repeating behavior should stop when hitting the last window in the list. The user can then manually do the shortcut once more to cycle to the other side; it then repeats again

The first sentence held. The second did not, for any shortcut without a keycode of its own: the manual press was suppressed by the same rule that stopped the repeat.

## Structure

The rule was written out twice — `Windows.cycleSelectedWindowIndex` and `TilesView.nextRow` — and neither copy had a test. It now lives in `CycleWrapResolver`, following the same pure-kernel pattern as `SelectionResolver` / `ShortcutModifierResolver`, with `CycleWrapResolverSpecs.md` and `CycleWrapResolverTests.swift`.

The test for the bug was written first and watched fail against a faithful port of the old rule, before the rule was changed.

## Verification

- `xcodebuild test -scheme Test` — 937 tests, 0 failures (932 before, + 5 new)
- Debug app target compiles clean

## Note

This does **not** address the separate "backwards cycling is too fast" report in #5914. That one is a different defect in `ATShortcut.matches` — modifier-only shortcuts re-fire on every key event while held, so one ⌥⇧+⇥ tap steps back three windows. It is tracked separately in #5991, with the measured counts and two possible directions. Related context: #5924.

