### PR TITLE
fix: preserve capture state after service failures

### DIFF
--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -381,6 +381,9 @@
 		5F20BB00000000000000B002 /* ScreenCaptureCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20BB00000000000000B001 /* ScreenCaptureCoordinatorTests.swift */; };
 		5F20BB00000000000000B005 /* ScreenCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20BB00000000000000B004 /* ScreenCaptureCoordinator.swift */; };
 		5F20BB00000000000000B006 /* ScreenCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20BB00000000000000B004 /* ScreenCaptureCoordinator.swift */; };
+		5F20CC00000000000000C002 /* WindowCaptureRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20CC00000000000000C001 /* WindowCaptureRoutingTests.swift */; };
+		5F20CC00000000000000C005 /* WindowCaptureRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20CC00000000000000C004 /* WindowCaptureRouting.swift */; };
+		5F20CC00000000000000C006 /* WindowCaptureRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20CC00000000000000C004 /* WindowCaptureRouting.swift */; };
 		D04BADE4DDF7597749FB13BD /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA099FA155FB4D517D66B /* SettingsWindow.swift */; };
 		D04BAF12DF5D15B9D7D316A4 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D04BA61693F710CD7BD054D7 /* InfoPlist.strings */; };
 		D04BAFB217F9F8E58C3B09AD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D04BA82BB17B85A88A5D2B87 /* InfoPlist.strings */; };
@@ -781,6 +784,9 @@
 		5F20BB00000000000000B001 /* ScreenCaptureCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureCoordinatorTests.swift; sourceTree = "<group>"; };
 		5F20BB00000000000000B003 /* ScreenCaptureCoordinatorSpecs.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ScreenCaptureCoordinatorSpecs.md; sourceTree = "<group>"; };
 		5F20BB00000000000000B004 /* ScreenCaptureCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureCoordinator.swift; sourceTree = "<group>"; };
+		5F20CC00000000000000C001 /* WindowCaptureRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureRoutingTests.swift; sourceTree = "<group>"; };
+		5F20CC00000000000000C003 /* WindowCaptureRoutingSpecs.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = WindowCaptureRoutingSpecs.md; sourceTree = "<group>"; };
+		5F20CC00000000000000C004 /* WindowCaptureRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureRouting.swift; sourceTree = "<group>"; };
 		D04BA7C836A8CE8C0B8D128B /* TextArea.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextArea.swift; sourceTree = "<group>"; };
 		D04BA7CF9C2D1BEC7C05AB24 /* Spaces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spaces.swift; sourceTree = "<group>"; };
 		D04BA7E3EA104941FE76DA70 /* AppCenterCrashes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppCenterCrashes.swift; sourceTree = "<group>"; };
@@ -989,6 +995,9 @@
 				5F20BB00000000000000B001 /* ScreenCaptureCoordinatorTests.swift */,
 				5F20BB00000000000000B003 /* ScreenCaptureCoordinatorSpecs.md */,
 				5F20BB00000000000000B004 /* ScreenCaptureCoordinator.swift */,
+				5F20CC00000000000000C001 /* WindowCaptureRoutingTests.swift */,
+				5F20CC00000000000000C003 /* WindowCaptureRoutingSpecs.md */,
+				5F20CC00000000000000C004 /* WindowCaptureRouting.swift */,
 				D04BA4A621A8A15660F973C1 /* KeyboardEvents.swift */,
 				BF0C8643F524515224BF1618 /* KeyboardEventsTestable.swift */,
 				BF0C899905524253DC170B56 /* KeyboardEventsTests.swift */,
@@ -2139,6 +2148,8 @@
 				5F20AA00000000000000A006 /* ScreenRecordingAuthorization.swift in Sources */,
 				5F20BB00000000000000B002 /* ScreenCaptureCoordinatorTests.swift in Sources */,
 				5F20BB00000000000000B006 /* ScreenCaptureCoordinator.swift in Sources */,
+				5F20CC00000000000000C002 /* WindowCaptureRoutingTests.swift in Sources */,
+				5F20CC00000000000000C006 /* WindowCaptureRouting.swift in Sources */,
 				5E7C0F70000000000000E003 /* ExceptionMatcher.swift in Sources */,
 				5E7C0F70000000000000E102 /* ExceptionMatcherTests.swift in Sources */,
 				5E0DE2A0000000000000D003 /* WindowOrderResolver.swift in Sources */,
@@ -2371,6 +2382,7 @@
 				BF0C83578F7292F307E30751 /* PopupButtonLikeSystemSettings.swift in Sources */,
 				5F04852E2F09AC9700235D4A /* WindowCaptureEvents.swift in Sources */,
 				5F20BB00000000000000B005 /* ScreenCaptureCoordinator.swift in Sources */,
+				5F20CC00000000000000C005 /* WindowCaptureRouting.swift in Sources */,
 				1C961F9CF4F1BEDF04ACAEE0 /* Switch.swift in Sources */,
 				1C96182D2ECA735740ED474E /* ImageTextButtonView.swift in Sources */,
 				BF0C860F1779DDE8C0171EA0 /* WindowlessAppIndicator.swift in Sources */,

--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -378,6 +378,9 @@
 		5F20AA00000000000000A002 /* ScreenRecordingAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20AA00000000000000A001 /* ScreenRecordingAuthorizationTests.swift */; };
 		5F20AA00000000000000A005 /* ScreenRecordingAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20AA00000000000000A004 /* ScreenRecordingAuthorization.swift */; };
 		5F20AA00000000000000A006 /* ScreenRecordingAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20AA00000000000000A004 /* ScreenRecordingAuthorization.swift */; };
+		5F20BB00000000000000B002 /* ScreenCaptureCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20BB00000000000000B001 /* ScreenCaptureCoordinatorTests.swift */; };
+		5F20BB00000000000000B005 /* ScreenCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20BB00000000000000B004 /* ScreenCaptureCoordinator.swift */; };
+		5F20BB00000000000000B006 /* ScreenCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20BB00000000000000B004 /* ScreenCaptureCoordinator.swift */; };
 		D04BADE4DDF7597749FB13BD /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA099FA155FB4D517D66B /* SettingsWindow.swift */; };
 		D04BAF12DF5D15B9D7D316A4 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D04BA61693F710CD7BD054D7 /* InfoPlist.strings */; };
 		D04BAFB217F9F8E58C3B09AD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D04BA82BB17B85A88A5D2B87 /* InfoPlist.strings */; };
@@ -775,6 +778,9 @@
 		5F20AA00000000000000A001 /* ScreenRecordingAuthorizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenRecordingAuthorizationTests.swift; sourceTree = "<group>"; };
 		5F20AA00000000000000A003 /* ScreenRecordingAuthorizationSpecs.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ScreenRecordingAuthorizationSpecs.md; sourceTree = "<group>"; };
 		5F20AA00000000000000A004 /* ScreenRecordingAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenRecordingAuthorization.swift; sourceTree = "<group>"; };
+		5F20BB00000000000000B001 /* ScreenCaptureCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureCoordinatorTests.swift; sourceTree = "<group>"; };
+		5F20BB00000000000000B003 /* ScreenCaptureCoordinatorSpecs.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ScreenCaptureCoordinatorSpecs.md; sourceTree = "<group>"; };
+		5F20BB00000000000000B004 /* ScreenCaptureCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureCoordinator.swift; sourceTree = "<group>"; };
 		D04BA7C836A8CE8C0B8D128B /* TextArea.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextArea.swift; sourceTree = "<group>"; };
 		D04BA7CF9C2D1BEC7C05AB24 /* Spaces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spaces.swift; sourceTree = "<group>"; };
 		D04BA7E3EA104941FE76DA70 /* AppCenterCrashes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppCenterCrashes.swift; sourceTree = "<group>"; };
@@ -980,6 +986,9 @@
 				BF0C8B5D1A9658E64F8ECB56 /* SystemScrollerStyleEvents.swift */,
 				BF0C8F8E1B7A3C4D5E6F7081 /* ContextMenuEvents.swift */,
 				5F04852D2F09AC9700235D4A /* WindowCaptureEvents.swift */,
+				5F20BB00000000000000B001 /* ScreenCaptureCoordinatorTests.swift */,
+				5F20BB00000000000000B003 /* ScreenCaptureCoordinatorSpecs.md */,
+				5F20BB00000000000000B004 /* ScreenCaptureCoordinator.swift */,
 				D04BA4A621A8A15660F973C1 /* KeyboardEvents.swift */,
 				BF0C8643F524515224BF1618 /* KeyboardEventsTestable.swift */,
 				BF0C899905524253DC170B56 /* KeyboardEventsTests.swift */,
@@ -2128,6 +2137,8 @@
 				5F117E40000000000000F212 /* PermissionCalloutResolverTests.swift in Sources */,
 				5F20AA00000000000000A002 /* ScreenRecordingAuthorizationTests.swift in Sources */,
 				5F20AA00000000000000A006 /* ScreenRecordingAuthorization.swift in Sources */,
+				5F20BB00000000000000B002 /* ScreenCaptureCoordinatorTests.swift in Sources */,
+				5F20BB00000000000000B006 /* ScreenCaptureCoordinator.swift in Sources */,
 				5E7C0F70000000000000E003 /* ExceptionMatcher.swift in Sources */,
 				5E7C0F70000000000000E102 /* ExceptionMatcherTests.swift in Sources */,
 				5E0DE2A0000000000000D003 /* WindowOrderResolver.swift in Sources */,
@@ -2359,6 +2370,7 @@
 				AA0C8B000000000000000003 /* UsageStatsTestable.swift in Sources */,
 				BF0C83578F7292F307E30751 /* PopupButtonLikeSystemSettings.swift in Sources */,
 				5F04852E2F09AC9700235D4A /* WindowCaptureEvents.swift in Sources */,
+				5F20BB00000000000000B005 /* ScreenCaptureCoordinator.swift in Sources */,
 				1C961F9CF4F1BEDF04ACAEE0 /* Switch.swift in Sources */,
 				1C96182D2ECA735740ED474E /* ImageTextButtonView.swift in Sources */,
 				BF0C860F1779DDE8C0171EA0 /* WindowlessAppIndicator.swift in Sources */,

--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -382,6 +382,7 @@
 		5F20BB00000000000000B005 /* ScreenCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20BB00000000000000B004 /* ScreenCaptureCoordinator.swift */; };
 		5F20BB00000000000000B006 /* ScreenCaptureCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20BB00000000000000B004 /* ScreenCaptureCoordinator.swift */; };
 		5F20CC00000000000000C002 /* WindowCaptureRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20CC00000000000000C001 /* WindowCaptureRoutingTests.swift */; };
+		5F20CC00000000000000D002 /* WindowServerCaptureFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20CC00000000000000D001 /* WindowServerCaptureFallbackTests.swift */; };
 		5F20CC00000000000000C005 /* WindowCaptureRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20CC00000000000000C004 /* WindowCaptureRouting.swift */; };
 		5F20CC00000000000000C006 /* WindowCaptureRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20CC00000000000000C004 /* WindowCaptureRouting.swift */; };
 		D04BADE4DDF7597749FB13BD /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA099FA155FB4D517D66B /* SettingsWindow.swift */; };
@@ -785,6 +786,7 @@
 		5F20BB00000000000000B003 /* ScreenCaptureCoordinatorSpecs.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ScreenCaptureCoordinatorSpecs.md; sourceTree = "<group>"; };
 		5F20BB00000000000000B004 /* ScreenCaptureCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenCaptureCoordinator.swift; sourceTree = "<group>"; };
 		5F20CC00000000000000C001 /* WindowCaptureRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureRoutingTests.swift; sourceTree = "<group>"; };
+		5F20CC00000000000000D001 /* WindowServerCaptureFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowServerCaptureFallbackTests.swift; sourceTree = "<group>"; };
 		5F20CC00000000000000C003 /* WindowCaptureRoutingSpecs.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = WindowCaptureRoutingSpecs.md; sourceTree = "<group>"; };
 		5F20CC00000000000000C004 /* WindowCaptureRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureRouting.swift; sourceTree = "<group>"; };
 		D04BA7C836A8CE8C0B8D128B /* TextArea.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextArea.swift; sourceTree = "<group>"; };
@@ -996,6 +998,7 @@
 				5F20BB00000000000000B003 /* ScreenCaptureCoordinatorSpecs.md */,
 				5F20BB00000000000000B004 /* ScreenCaptureCoordinator.swift */,
 				5F20CC00000000000000C001 /* WindowCaptureRoutingTests.swift */,
+				5F20CC00000000000000D001 /* WindowServerCaptureFallbackTests.swift */,
 				5F20CC00000000000000C003 /* WindowCaptureRoutingSpecs.md */,
 				5F20CC00000000000000C004 /* WindowCaptureRouting.swift */,
 				D04BA4A621A8A15660F973C1 /* KeyboardEvents.swift */,
@@ -2149,6 +2152,7 @@
 				5F20BB00000000000000B002 /* ScreenCaptureCoordinatorTests.swift in Sources */,
 				5F20BB00000000000000B006 /* ScreenCaptureCoordinator.swift in Sources */,
 				5F20CC00000000000000C002 /* WindowCaptureRoutingTests.swift in Sources */,
+				5F20CC00000000000000D002 /* WindowServerCaptureFallbackTests.swift in Sources */,
 				5F20CC00000000000000C006 /* WindowCaptureRouting.swift in Sources */,
 				5E7C0F70000000000000E003 /* ExceptionMatcher.swift in Sources */,
 				5E7C0F70000000000000E102 /* ExceptionMatcherTests.swift in Sources */,

--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -375,6 +375,9 @@
 		5F117E40000000000000F202 /* PermissionCalloutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F117E40000000000000F201 /* PermissionCalloutResolver.swift */; };
 		5F117E40000000000000F203 /* PermissionCalloutResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F117E40000000000000F201 /* PermissionCalloutResolver.swift */; };
 		5F117E40000000000000F212 /* PermissionCalloutResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F117E40000000000000F211 /* PermissionCalloutResolverTests.swift */; };
+		5F20AA00000000000000A002 /* ScreenRecordingAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20AA00000000000000A001 /* ScreenRecordingAuthorizationTests.swift */; };
+		5F20AA00000000000000A005 /* ScreenRecordingAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20AA00000000000000A004 /* ScreenRecordingAuthorization.swift */; };
+		5F20AA00000000000000A006 /* ScreenRecordingAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F20AA00000000000000A004 /* ScreenRecordingAuthorization.swift */; };
 		D04BADE4DDF7597749FB13BD /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D04BA099FA155FB4D517D66B /* SettingsWindow.swift */; };
 		D04BAF12DF5D15B9D7D316A4 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D04BA61693F710CD7BD054D7 /* InfoPlist.strings */; };
 		D04BAFB217F9F8E58C3B09AD /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = D04BA82BB17B85A88A5D2B87 /* InfoPlist.strings */; };
@@ -769,6 +772,9 @@
 		D04BA7C6F2519091717F4B4E /* SystemPermissions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SystemPermissions.swift; sourceTree = "<group>"; };
 		5F117E40000000000000F201 /* PermissionCalloutResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionCalloutResolver.swift; sourceTree = "<group>"; };
 		5F117E40000000000000F211 /* PermissionCalloutResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionCalloutResolverTests.swift; sourceTree = "<group>"; };
+		5F20AA00000000000000A001 /* ScreenRecordingAuthorizationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenRecordingAuthorizationTests.swift; sourceTree = "<group>"; };
+		5F20AA00000000000000A003 /* ScreenRecordingAuthorizationSpecs.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = ScreenRecordingAuthorizationSpecs.md; sourceTree = "<group>"; };
+		5F20AA00000000000000A004 /* ScreenRecordingAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenRecordingAuthorization.swift; sourceTree = "<group>"; };
 		D04BA7C836A8CE8C0B8D128B /* TextArea.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TextArea.swift; sourceTree = "<group>"; };
 		D04BA7CF9C2D1BEC7C05AB24 /* Spaces.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Spaces.swift; sourceTree = "<group>"; };
 		D04BA7E3EA104941FE76DA70 /* AppCenterCrashes.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppCenterCrashes.swift; sourceTree = "<group>"; };
@@ -1286,6 +1292,9 @@
 				D04BA7C6F2519091717F4B4E /* SystemPermissions.swift */,
 				5F117E40000000000000F201 /* PermissionCalloutResolver.swift */,
 				5F117E40000000000000F211 /* PermissionCalloutResolverTests.swift */,
+				5F20AA00000000000000A001 /* ScreenRecordingAuthorizationTests.swift */,
+				5F20AA00000000000000A003 /* ScreenRecordingAuthorizationSpecs.md */,
+				5F20AA00000000000000A004 /* ScreenRecordingAuthorization.swift */,
 				5FA001000000000000000019 /* LoginItem.swift */,
 				AA0C8A000000000000000001 /* AXCallScheduler.swift */,
 				AA0C8A0000000000000000B1 /* CGSCallScheduler.swift */,
@@ -2117,6 +2126,8 @@
 				5F5790DE7EC7000000000C02 /* PreferencesPersistenceProbeTests.swift in Sources */,
 				5F117E40000000000000F203 /* PermissionCalloutResolver.swift in Sources */,
 				5F117E40000000000000F212 /* PermissionCalloutResolverTests.swift in Sources */,
+				5F20AA00000000000000A002 /* ScreenRecordingAuthorizationTests.swift in Sources */,
+				5F20AA00000000000000A006 /* ScreenRecordingAuthorization.swift in Sources */,
 				5E7C0F70000000000000E003 /* ExceptionMatcher.swift in Sources */,
 				5E7C0F70000000000000E102 /* ExceptionMatcherTests.swift in Sources */,
 				5E0DE2A0000000000000D003 /* WindowOrderResolver.swift in Sources */,
@@ -2218,6 +2229,7 @@
 				F00DCAFE0000000000001003 /* SearchTestable.swift in Sources */,
 				D04BAC011A71E0418154F8CD /* Preferences.swift in Sources */,
 				D04BADCDA9F9A6C3D6499877 /* SystemPermissions.swift in Sources */,
+				5F20AA00000000000000A005 /* ScreenRecordingAuthorization.swift in Sources */,
 				5F117E40000000000000F202 /* PermissionCalloutResolver.swift in Sources */,
 				D04BABEECBC6D922298BC93A /* Spaces.swift in Sources */,
 				D04BA6187A91A847844B6ABB /* Window.swift in Sources */,

--- a/src/Menubar.swift
+++ b/src/Menubar.swift
@@ -5,6 +5,7 @@ class Menubar {
     static var menu: NSMenu!
     static var permissionCalloutMenuItems: [NSMenuItem]?
     private static var permissionCallout: PermissionCallout?
+    private static var captureRecoveryMenuItem: NSMenuItem?
     private static var upgradeToProMenuItem: NSMenuItem!
     private static var supportProjectMenuItem: NSMenuItem!
     private static var myAccountMenuItem: NSMenuItem!
@@ -39,6 +40,9 @@ class Menubar {
         addMenuItem(NSLocalizedString("Settings…", comment: "Menubar option"), #selector(App.showSettingsWindow), ",", "gear", nil, App.self)
         addMenuItem(NSLocalizedString("Check for updates…", comment: "Menubar option"), #selector(App.checkForUpdatesNow), "", "checkmark.arrow.trianglehead.clockwise", nil, App.self)
         addMenuItem(NSLocalizedString("Check permissions…", comment: "Menubar option"), #selector(App.checkPermissions), "", "hand.raised", nil, App.self)
+        captureRecoveryMenuItem = addMenuItem(NSLocalizedString("Screen capture paused — Restart AltTab…", comment: "Recovery for a capture request that did not complete"), #selector(restartCapture), "", "arrow.clockwise", nil, self)
+        captureRecoveryMenuItem?.isHidden = true
+        captureRecoveryMenuItem?.toolTip = NSLocalizedString("A screen capture request did not finish. Restart AltTab to restore capture without changing permissions.", comment: "Capture recovery help")
         menu.addItem(NSMenuItem.separator())
         addMenuItem(String(format: NSLocalizedString("About %@", comment: "Menubar option. %@ is AltTab"), App.name), #selector(App.showAboutWindow), "", "info.circle", nil, App.self)
         addMenuItem(NSLocalizedString("Debug tools", comment: "Menubar option"), #selector(App.showDebugWindow), "", "scope", nil, App.self)
@@ -123,6 +127,7 @@ class Menubar {
     // refresh the text before showing it. Re-evaluated on permission ticks and on each menu open
     // (settings can change). Decision logic lives in `PermissionCalloutResolver` (unit-tested).
     static func refreshPermissionCallout() {
+        captureRecoveryMenuItem?.isHidden = !ScreenCaptureCoordinator.shared.isCircuitOpen
         let dependentFeatures = Preferences.screenRecordingDependentFeatures
         let show = PermissionCalloutResolver.shouldShowCallout(
             screenRecordingGranted: !ScreenRecordingPermission.shouldShowPassiveReview,
@@ -141,6 +146,10 @@ class Menubar {
                 menu.removeItem(element)
             }
         }
+    }
+
+    @objc private static func restartCapture() {
+        App.restart()
     }
 
     @objc static func statusItemOnClick() {

--- a/src/Menubar.swift
+++ b/src/Menubar.swift
@@ -125,7 +125,7 @@ class Menubar {
     static func refreshPermissionCallout() {
         let dependentFeatures = Preferences.screenRecordingDependentFeatures
         let show = PermissionCalloutResolver.shouldShowCallout(
-            screenRecordingGranted: ScreenRecordingPermission.status == .granted,
+            screenRecordingGranted: !ScreenRecordingPermission.shouldShowPassiveReview,
             dependentFeatures: dependentFeatures)
         if show { permissionCallout?.update(dependentFeatures) }
         togglePermissionCallout(show)
@@ -435,7 +435,7 @@ class PermissionCallout: StackView {
         label.addOrUpdateConstraint(label.widthAnchor, 250)
         let button = NSButton()
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.attributedTitle = NSAttributedString(string: NSLocalizedString("Grant permission", comment: "Menubar callout button"), attributes: [NSAttributedString.Key.foregroundColor: NSColor.white])
+        button.attributedTitle = NSAttributedString(string: NSLocalizedString("Review permission", comment: "Menubar callout button"), attributes: [NSAttributedString.Key.foregroundColor: NSColor.white])
         self.init([label, button], .vertical, true, top: 8, right: 15, bottom: 10, left: 15)
         self.label = label
         self.button = button
@@ -455,7 +455,11 @@ class PermissionCallout: StackView {
         let location = convert(event.locationInWindow, from: nil)
         guard button.frame.contains(location) else { return }
         enclosingMenuItem?.menu?.cancelTracking()
-        Preferences.remove("screenRecordingPermissionSkipped")
+        // CGPreflightScreenCaptureAccess is cached for this process. The explicit Review action clears
+        // the trusted-history shortcut so the new process uses the live ScreenCaptureKit onboarding check.
+        Preferences.remove("screenRecordingPermissionSkipped", false)
+        Preferences.set("screenRecordingPermissionWasGranted", "false", false)
+        NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!)
         App.restart()
     }
 

--- a/src/Menubar.swift
+++ b/src/Menubar.swift
@@ -40,9 +40,20 @@ class Menubar {
         addMenuItem(NSLocalizedString("Settings…", comment: "Menubar option"), #selector(App.showSettingsWindow), ",", "gear", nil, App.self)
         addMenuItem(NSLocalizedString("Check for updates…", comment: "Menubar option"), #selector(App.checkForUpdatesNow), "", "checkmark.arrow.trianglehead.clockwise", nil, App.self)
         addMenuItem(NSLocalizedString("Check permissions…", comment: "Menubar option"), #selector(App.checkPermissions), "", "hand.raised", nil, App.self)
-        captureRecoveryMenuItem = addMenuItem(NSLocalizedString("Screen capture paused — Restart AltTab…", comment: "Recovery for a capture request that did not complete"), #selector(restartCapture), "", "arrow.clockwise", nil, self)
+        captureRecoveryMenuItem = addMenuItem(
+            NSLocalizedString("Screen capture paused — Restart AltTab…",
+                              comment: "Recovery for a capture request that did not complete"),
+            #selector(restartCapture),
+            "",
+            "arrow.clockwise",
+            nil,
+            self
+        )
         captureRecoveryMenuItem?.isHidden = true
-        captureRecoveryMenuItem?.toolTip = NSLocalizedString("A screen capture request did not finish. Restart AltTab to restore capture without changing permissions.", comment: "Capture recovery help")
+        captureRecoveryMenuItem?.toolTip = NSLocalizedString(
+            "A screen capture request did not finish. Restart AltTab to restore capture without changing permissions.",
+            comment: "Capture recovery help"
+        )
         menu.addItem(NSMenuItem.separator())
         addMenuItem(String(format: NSLocalizedString("About %@", comment: "Menubar option. %@ is AltTab"), App.name), #selector(App.showAboutWindow), "", "info.circle", nil, App.self)
         addMenuItem(NSLocalizedString("Debug tools", comment: "Menubar option"), #selector(App.showDebugWindow), "", "scope", nil, App.self)
@@ -444,7 +455,10 @@ class PermissionCallout: StackView {
         label.addOrUpdateConstraint(label.widthAnchor, 250)
         let button = NSButton()
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.attributedTitle = NSAttributedString(string: NSLocalizedString("Review permission", comment: "Menubar callout button"), attributes: [NSAttributedString.Key.foregroundColor: NSColor.white])
+        button.attributedTitle = NSAttributedString(
+            string: NSLocalizedString("Review permission", comment: "Menubar callout button"),
+            attributes: [NSAttributedString.Key.foregroundColor: NSColor.white]
+        )
         self.init([label, button], .vertical, true, top: 8, right: 15, bottom: 10, left: 15)
         self.label = label
         self.button = button
@@ -468,7 +482,9 @@ class PermissionCallout: StackView {
         // the trusted-history shortcut so the new process uses the live ScreenCaptureKit onboarding check.
         Preferences.remove("screenRecordingPermissionSkipped", false)
         Preferences.set("screenRecordingPermissionWasGranted", "false", false)
-        NSWorkspace.shared.open(URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!)
+        NSWorkspace.shared.open(
+            URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture")!
+        )
         App.restart()
     }
 

--- a/src/events/ScreenCaptureCoordinator.swift
+++ b/src/events/ScreenCaptureCoordinator.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 final class ScreenCaptureCoordinator {
+    enum Priority {
+        case normal
+        case focusedPreview
+    }
+
     typealias Completion = () -> Void
     typealias Operation = (@escaping Completion) -> Void
     typealias Scheduler = (TimeInterval, @escaping () -> Void) -> Void
@@ -11,6 +16,7 @@ final class ScreenCaptureCoordinator {
         let operation: Operation
         let queue: DispatchQueue?
         let shouldStart: () -> Bool
+        let priority: Priority
     }
 
     private struct ActiveOperation {
@@ -51,14 +57,16 @@ final class ScreenCaptureCoordinator {
         return circuitOpen
     }
 
-    func submit(on queue: DispatchQueue? = nil, if shouldStart: @escaping () -> Bool = { true },
+    func submit(on queue: DispatchQueue? = nil, priority: Priority = .normal,
+                if shouldStart: @escaping () -> Bool = { true },
                 _ operation: @escaping Operation) {
         lock.lock()
         guard !circuitOpen else {
             lock.unlock()
             return
         }
-        pending.append(PendingOperation(operation: operation, queue: queue, shouldStart: shouldStart))
+        pending.append(PendingOperation(operation: operation, queue: queue,
+                                        shouldStart: shouldStart, priority: priority))
         let next = reserveNextLocked()
         lock.unlock()
         if let next {
@@ -69,7 +77,8 @@ final class ScreenCaptureCoordinator {
     private func reserveNextLocked() -> ActiveOperation? {
         guard !circuitOpen, activeIds.count + timedOutIds.count < maximumInFlight,
               !pending.isEmpty else { return nil }
-        let pendingOperation = pending.removeFirst()
+        let index = pending.firstIndex { $0.priority == .focusedPreview } ?? pending.startIndex
+        let pendingOperation = pending.remove(at: index)
         let id = UUID()
         activeIds.insert(id)
         return ActiveOperation(id: id, operation: pendingOperation.operation,

--- a/src/events/ScreenCaptureCoordinator.swift
+++ b/src/events/ScreenCaptureCoordinator.swift
@@ -10,11 +10,12 @@ final class ScreenCaptureCoordinator {
     typealias Operation = (@escaping Completion) -> Void
     typealias Scheduler = (TimeInterval, @escaping () -> Void) -> Void
 
-    static let shared = ScreenCaptureCoordinator()
+    static let shared = ScreenCaptureCoordinator(submissionQueue: DispatchQueue(
+        label: "com.lwouis.alt-tab-macos.capture-submission", qos: .userInitiated, attributes: .concurrent
+    ))
 
     private struct PendingOperation {
         let operation: Operation
-        let queue: DispatchQueue?
         let shouldStart: () -> Bool
         let priority: Priority
     }
@@ -22,13 +23,13 @@ final class ScreenCaptureCoordinator {
     private struct ActiveOperation {
         let id: UUID
         let operation: Operation
-        let queue: DispatchQueue?
         let shouldStart: () -> Bool
     }
 
     private let maximumInFlight: Int
     private let watchdogSeconds: TimeInterval
     private let schedule: Scheduler
+    private let submissionQueue: DispatchQueue?
     private let lock = NSLock()
     private var activeIds = Set<UUID>()
     private var timedOutIds = Set<UUID>()
@@ -36,6 +37,7 @@ final class ScreenCaptureCoordinator {
     private var circuitOpen = false
 
     init(maximumInFlight: Int = 2, watchdogSeconds: TimeInterval = 10,
+         submissionQueue: DispatchQueue? = nil,
          schedule: @escaping Scheduler = { delay, action in
              DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + delay, execute: action)
          }) {
@@ -43,6 +45,7 @@ final class ScreenCaptureCoordinator {
         self.maximumInFlight = maximumInFlight
         self.watchdogSeconds = watchdogSeconds
         self.schedule = schedule
+        self.submissionQueue = submissionQueue
     }
 
     var inFlightCount: Int {
@@ -57,7 +60,7 @@ final class ScreenCaptureCoordinator {
         return circuitOpen
     }
 
-    func submit(on queue: DispatchQueue? = nil, priority: Priority = .normal,
+    func submit(priority: Priority = .normal,
                 if shouldStart: @escaping () -> Bool = { true },
                 _ operation: @escaping Operation) {
         lock.lock()
@@ -65,7 +68,7 @@ final class ScreenCaptureCoordinator {
             lock.unlock()
             return
         }
-        pending.append(PendingOperation(operation: operation, queue: queue,
+        pending.append(PendingOperation(operation: operation,
                                         shouldStart: shouldStart, priority: priority))
         let next = reserveNextLocked()
         lock.unlock()
@@ -82,16 +85,17 @@ final class ScreenCaptureCoordinator {
         let id = UUID()
         activeIds.insert(id)
         return ActiveOperation(id: id, operation: pendingOperation.operation,
-                               queue: pendingOperation.queue, shouldStart: pendingOperation.shouldStart)
+                               shouldStart: pendingOperation.shouldStart)
     }
 
     private func start(_ active: ActiveOperation) {
         let submit = { [self] in
-            guard !isCircuitOpen, active.shouldStart() else { completed(active.id); return }
+            guard !isCircuitOpen else { completed(active.id); return }
             schedule(watchdogSeconds) { [weak self] in self?.watchdogFired(active.id) }
+            guard active.shouldStart(), !isCircuitOpen else { completed(active.id); return }
             active.operation { [weak self] in self?.completed(active.id) }
         }
-        if let queue = active.queue {
+        if let queue = submissionQueue {
             queue.async(execute: submit)
         } else {
             submit()

--- a/src/events/ScreenCaptureCoordinator.swift
+++ b/src/events/ScreenCaptureCoordinator.swift
@@ -1,0 +1,97 @@
+import Foundation
+
+final class ScreenCaptureCoordinator {
+    typealias Completion = () -> Void
+    typealias Operation = (@escaping Completion) -> Void
+    typealias Scheduler = (TimeInterval, @escaping () -> Void) -> Void
+
+    static let shared = ScreenCaptureCoordinator()
+
+    private struct PendingOperation {
+        let operation: Operation
+    }
+
+    private struct ActiveOperation {
+        let id: UUID
+        let operation: Operation
+    }
+
+    private let maximumInFlight: Int
+    private let watchdogSeconds: TimeInterval
+    private let schedule: Scheduler
+    private let lock = NSLock()
+    private var activeIds = Set<UUID>()
+    private var timedOutIds = Set<UUID>()
+    private var pending = [PendingOperation]()
+    private var circuitOpen = false
+
+    init(maximumInFlight: Int = 2, watchdogSeconds: TimeInterval = 10,
+         schedule: @escaping Scheduler = { delay, action in
+             DispatchQueue.global(qos: .userInitiated).asyncAfter(deadline: .now() + delay, execute: action)
+         }) {
+        precondition(maximumInFlight > 0)
+        self.maximumInFlight = maximumInFlight
+        self.watchdogSeconds = watchdogSeconds
+        self.schedule = schedule
+    }
+
+    var inFlightCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return activeIds.count + timedOutIds.count
+    }
+
+    var isCircuitOpen: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return circuitOpen
+    }
+
+    func submit(_ operation: @escaping Operation) {
+        lock.lock()
+        guard !circuitOpen else {
+            lock.unlock()
+            return
+        }
+        pending.append(PendingOperation(operation: operation))
+        let next = reserveNextLocked()
+        lock.unlock()
+        if let next { start(next) }
+    }
+
+    private func reserveNextLocked() -> ActiveOperation? {
+        guard !circuitOpen, activeIds.count + timedOutIds.count < maximumInFlight,
+              !pending.isEmpty else { return nil }
+        let pendingOperation = pending.removeFirst()
+        let id = UUID()
+        activeIds.insert(id)
+        return ActiveOperation(id: id, operation: pendingOperation.operation)
+    }
+
+    private func start(_ active: ActiveOperation) {
+        schedule(watchdogSeconds) { [weak self] in self?.watchdogFired(active.id) }
+        active.operation { [weak self] in self?.completed(active.id) }
+    }
+
+    private func completed(_ id: UUID) {
+        lock.lock()
+        if timedOutIds.remove(id) != nil {
+            circuitOpen = !timedOutIds.isEmpty
+            lock.unlock()
+            return
+        }
+        guard activeIds.remove(id) != nil else { lock.unlock(); return }
+        let next = reserveNextLocked()
+        lock.unlock()
+        if let next { start(next) }
+    }
+
+    private func watchdogFired(_ id: UUID) {
+        lock.lock()
+        guard activeIds.remove(id) != nil else { lock.unlock(); return }
+        timedOutIds.insert(id)
+        circuitOpen = true
+        pending.removeAll()
+        lock.unlock()
+    }
+}

--- a/src/events/ScreenCaptureCoordinator.swift
+++ b/src/events/ScreenCaptureCoordinator.swift
@@ -6,12 +6,17 @@ final class ScreenCaptureCoordinator {
         case focusedPreview
     }
 
+    private enum Stage {
+        case checkingPermission
+        case submitted
+    }
+
     typealias Completion = () -> Void
     typealias Operation = (@escaping Completion) -> Void
     typealias Scheduler = (TimeInterval, @escaping () -> Void) -> Void
 
     static let shared = ScreenCaptureCoordinator(submissionQueue: DispatchQueue(
-        label: "com.lwouis.alt-tab-macos.capture-submission", qos: .userInitiated, attributes: .concurrent
+        label: "com.lwouis.alt-tab-macos.capture-submission", qos: .userInitiated
     ))
 
     private struct PendingOperation {
@@ -31,7 +36,7 @@ final class ScreenCaptureCoordinator {
     private let schedule: Scheduler
     private let submissionQueue: DispatchQueue?
     private let lock = NSLock()
-    private var activeIds = Set<UUID>()
+    private var activeStages = [UUID: Stage]()
     private var timedOutIds = Set<UUID>()
     private var pending = [PendingOperation]()
     private var circuitOpen = false
@@ -51,7 +56,7 @@ final class ScreenCaptureCoordinator {
     var inFlightCount: Int {
         lock.lock()
         defer { lock.unlock() }
-        return activeIds.count + timedOutIds.count
+        return activeStages.count + timedOutIds.count
     }
 
     var isCircuitOpen: Bool {
@@ -70,36 +75,51 @@ final class ScreenCaptureCoordinator {
         }
         pending.append(PendingOperation(operation: operation,
                                         shouldStart: shouldStart, priority: priority))
-        let next = reserveNextLocked()
+        let next = enqueueNextLocked()
         lock.unlock()
         if let next {
             start(next)
         }
     }
 
+    private func enqueueNextLocked() -> ActiveOperation? {
+        guard let next = reserveNextLocked() else { return nil }
+        guard let submissionQueue else { return next }
+        // Enqueue in reservation order, even when two OS callbacks release slots concurrently.
+        submissionQueue.async { self.start(next) }
+        return nil
+    }
+
     private func reserveNextLocked() -> ActiveOperation? {
-        guard !circuitOpen, activeIds.count + timedOutIds.count < maximumInFlight,
+        guard !circuitOpen, activeStages.count + timedOutIds.count < maximumInFlight,
               !pending.isEmpty else { return nil }
         let index = pending.firstIndex { $0.priority == .focusedPreview } ?? pending.startIndex
         let pendingOperation = pending.remove(at: index)
         let id = UUID()
-        activeIds.insert(id)
+        activeStages[id] = .checkingPermission
         return ActiveOperation(id: id, operation: pendingOperation.operation,
                                shouldStart: pendingOperation.shouldStart)
     }
 
     private func start(_ active: ActiveOperation) {
-        let submit = { [self] in
-            guard !isCircuitOpen else { completed(active.id); return }
-            schedule(watchdogSeconds) { [weak self] in self?.watchdogFired(active.id) }
-            guard active.shouldStart(), !isCircuitOpen else { completed(active.id); return }
-            active.operation { [weak self] in self?.completed(active.id) }
+        guard !isCircuitOpen else { completed(active.id); return }
+        schedule(watchdogSeconds) { [weak self] in
+            self?.watchdogFired(active.id, stage: .checkingPermission)
         }
-        if let queue = submissionQueue {
-            queue.async(execute: submit)
-        } else {
-            submit()
+        guard active.shouldStart(), claimSubmission(active.id) else { completed(active.id); return }
+        schedule(watchdogSeconds) { [weak self] in
+            self?.watchdogFired(active.id, stage: .submitted)
         }
+        active.operation { [weak self] in self?.completed(active.id) }
+    }
+
+    private func claimSubmission(_ id: UUID) -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !circuitOpen, activeStages[id] == .checkingPermission else { return false }
+        // This transition and preflight expiry share the same lock. Exactly one wins.
+        activeStages[id] = .submitted
+        return true
     }
 
     private func completed(_ id: UUID) {
@@ -109,17 +129,18 @@ final class ScreenCaptureCoordinator {
             lock.unlock()
             return
         }
-        guard activeIds.remove(id) != nil else { lock.unlock(); return }
-        let next = reserveNextLocked()
+        guard activeStages.removeValue(forKey: id) != nil else { lock.unlock(); return }
+        let next = enqueueNextLocked()
         lock.unlock()
         if let next {
             start(next)
         }
     }
 
-    private func watchdogFired(_ id: UUID) {
+    private func watchdogFired(_ id: UUID, stage: Stage) {
         lock.lock()
-        guard activeIds.remove(id) != nil else { lock.unlock(); return }
+        guard activeStages[id] == stage else { lock.unlock(); return }
+        activeStages.removeValue(forKey: id)
         timedOutIds.insert(id)
         circuitOpen = true
         pending.removeAll()

--- a/src/events/ScreenCaptureCoordinator.swift
+++ b/src/events/ScreenCaptureCoordinator.swift
@@ -9,11 +9,15 @@ final class ScreenCaptureCoordinator {
 
     private struct PendingOperation {
         let operation: Operation
+        let queue: DispatchQueue?
+        let shouldStart: () -> Bool
     }
 
     private struct ActiveOperation {
         let id: UUID
         let operation: Operation
+        let queue: DispatchQueue?
+        let shouldStart: () -> Bool
     }
 
     private let maximumInFlight: Int
@@ -47,13 +51,14 @@ final class ScreenCaptureCoordinator {
         return circuitOpen
     }
 
-    func submit(_ operation: @escaping Operation) {
+    func submit(on queue: DispatchQueue? = nil, if shouldStart: @escaping () -> Bool = { true },
+                _ operation: @escaping Operation) {
         lock.lock()
         guard !circuitOpen else {
             lock.unlock()
             return
         }
-        pending.append(PendingOperation(operation: operation))
+        pending.append(PendingOperation(operation: operation, queue: queue, shouldStart: shouldStart))
         let next = reserveNextLocked()
         lock.unlock()
         if let next { start(next) }
@@ -65,12 +70,21 @@ final class ScreenCaptureCoordinator {
         let pendingOperation = pending.removeFirst()
         let id = UUID()
         activeIds.insert(id)
-        return ActiveOperation(id: id, operation: pendingOperation.operation)
+        return ActiveOperation(id: id, operation: pendingOperation.operation,
+            queue: pendingOperation.queue, shouldStart: pendingOperation.shouldStart)
     }
 
     private func start(_ active: ActiveOperation) {
-        schedule(watchdogSeconds) { [weak self] in self?.watchdogFired(active.id) }
-        active.operation { [weak self] in self?.completed(active.id) }
+        let submit = { [self] in
+            guard !isCircuitOpen, active.shouldStart() else { completed(active.id); return }
+            schedule(watchdogSeconds) { [weak self] in self?.watchdogFired(active.id) }
+            active.operation { [weak self] in self?.completed(active.id) }
+        }
+        if let queue = active.queue {
+            queue.async(execute: submit)
+        } else {
+            submit()
+        }
     }
 
     private func completed(_ id: UUID) {

--- a/src/events/ScreenCaptureCoordinator.swift
+++ b/src/events/ScreenCaptureCoordinator.swift
@@ -61,7 +61,9 @@ final class ScreenCaptureCoordinator {
         pending.append(PendingOperation(operation: operation, queue: queue, shouldStart: shouldStart))
         let next = reserveNextLocked()
         lock.unlock()
-        if let next { start(next) }
+        if let next {
+            start(next)
+        }
     }
 
     private func reserveNextLocked() -> ActiveOperation? {
@@ -71,7 +73,7 @@ final class ScreenCaptureCoordinator {
         let id = UUID()
         activeIds.insert(id)
         return ActiveOperation(id: id, operation: pendingOperation.operation,
-            queue: pendingOperation.queue, shouldStart: pendingOperation.shouldStart)
+                               queue: pendingOperation.queue, shouldStart: pendingOperation.shouldStart)
     }
 
     private func start(_ active: ActiveOperation) {
@@ -97,7 +99,9 @@ final class ScreenCaptureCoordinator {
         guard activeIds.remove(id) != nil else { lock.unlock(); return }
         let next = reserveNextLocked()
         lock.unlock()
-        if let next { start(next) }
+        if let next {
+            start(next)
+        }
     }
 
     private func watchdogFired(_ id: UUID) {

--- a/src/events/ScreenCaptureCoordinatorSpecs.md
+++ b/src/events/ScreenCaptureCoordinatorSpecs.md
@@ -9,8 +9,10 @@ protects the queue from a system request that never calls its completion handler
 
 - At most two requests can be active.
 - A request gets a slot before it calls ScreenCaptureKit.
-- Eligibility is checked again on the submission queue after a slot is available. Ineligible work releases its reserved slot without starting a watchdog or calling the OS.
-- Window captures submit on main, where switcher visibility, preferences, lock state, and non-prompting preflight are checked without a queue hop before the OS call.
+- Eligibility is checked again on the submission queue after a slot is available. Ineligible work releases its reserved slot without calling a capture API.
+- The shared coordinator submits on a concurrent worker queue. Permission preflight and capture submission must not block the main UI thread.
+- Window captures read switcher visibility, preferences, and lock state on main before and after the non-prompting preflight. A closed switcher drops pending work when background capture is disabled.
+- The watchdog starts before preflight. A check that returns after its timeout releases the slot without starting a late capture.
 - The normal completion handler releases the slot.
 - A completion handler can release its slot only one time.
 - A ten-second watchdog opens a circuit and drops queued work when ScreenCaptureKit loses a completion.
@@ -28,3 +30,5 @@ protects the queue from a system request that never calls its completion handler
 - `testQueuedCaptureIsDroppedWhenEligibilityChanges`
 - `testLostCompletionsKeepCircuitClosedToNewWork`
 - `testFocusedPreviewStartsBeforeQueuedThumbnails`
+- `testSharedCoordinatorSubmitsOutsideMainQueue`
+- `testWatchdogCoversPreflightWithoutStartingLateCapture`

--- a/src/events/ScreenCaptureCoordinatorSpecs.md
+++ b/src/events/ScreenCaptureCoordinatorSpecs.md
@@ -9,6 +9,8 @@ protects the queue from a system request that never calls its completion handler
 
 - At most two requests can be active.
 - A request gets a slot before it calls ScreenCaptureKit.
+- Eligibility is checked again on the submission queue after a slot is available. Ineligible work releases its reserved slot without starting a watchdog or calling the OS.
+- Window captures submit on main, where switcher visibility, preferences, lock state, and non-prompting preflight are checked without a queue hop before the OS call.
 - The normal completion handler releases the slot.
 - A completion handler can release its slot only one time.
 - A ten-second watchdog opens a circuit and drops queued work when ScreenCaptureKit loses a completion.
@@ -21,3 +23,4 @@ protects the queue from a system request that never calls its completion handler
 - `testMaximumOfTwoCapturesCanRun`
 - `testWatchdogOpensCircuitUntilLateCompletion`
 - `testCompletionCanReleaseOnlyOneSlot`
+- `testQueuedCaptureIsDroppedWhenEligibilityChanges`

--- a/src/events/ScreenCaptureCoordinatorSpecs.md
+++ b/src/events/ScreenCaptureCoordinatorSpecs.md
@@ -1,0 +1,23 @@
+# ScreenCaptureCoordinator — Specs
+
+## Summary
+
+The coordinator limits all active ScreenCaptureKit requests in the process. It queues excess work and
+protects the queue from a system request that never calls its completion handler.
+
+## Behavior
+
+- At most two requests can be active.
+- A request gets a slot before it calls ScreenCaptureKit.
+- The normal completion handler releases the slot.
+- A completion handler can release its slot only one time.
+- A ten-second watchdog opens a circuit and drops queued work when ScreenCaptureKit loses a completion.
+- A timed-out request still counts as physically active, so no replacement request can exceed the limit.
+- A late completion closes the circuit. A request submitted after that can start.
+- Thumbnail and focused-preview requests use the same process-wide coordinator.
+
+## Test scenarios
+
+- `testMaximumOfTwoCapturesCanRun`
+- `testWatchdogOpensCircuitUntilLateCompletion`
+- `testCompletionCanReleaseOnlyOneSlot`

--- a/src/events/ScreenCaptureCoordinatorSpecs.md
+++ b/src/events/ScreenCaptureCoordinatorSpecs.md
@@ -18,6 +18,7 @@ protects the queue from a system request that never calls its completion handler
 - A late completion closes the circuit. A request submitted after that can start.
 - If completion never arrives, the menu shows a passive restart action. Only the user's action restarts AltTab; permissions are not reset. A restart releases the old process and its outstanding requests.
 - Thumbnail and focused-preview requests use the same process-wide coordinator.
+- A queued focused preview starts before queued thumbnails when a slot becomes available. It does not cancel a request already submitted to the OS.
 
 ## Test scenarios
 
@@ -26,3 +27,4 @@ protects the queue from a system request that never calls its completion handler
 - `testCompletionCanReleaseOnlyOneSlot`
 - `testQueuedCaptureIsDroppedWhenEligibilityChanges`
 - `testLostCompletionsKeepCircuitClosedToNewWork`
+- `testFocusedPreviewStartsBeforeQueuedThumbnails`

--- a/src/events/ScreenCaptureCoordinatorSpecs.md
+++ b/src/events/ScreenCaptureCoordinatorSpecs.md
@@ -10,9 +10,10 @@ protects the queue from a system request that never calls its completion handler
 - At most two requests can be active.
 - A request gets a slot before it calls ScreenCaptureKit.
 - Eligibility is checked again on the submission queue after a slot is available. Ineligible work releases its reserved slot without calling a capture API.
-- The shared coordinator submits on a concurrent worker queue. Permission preflight and capture submission must not block the main UI thread.
+- The shared coordinator submits on a serial worker queue. Permission preflight and capture submission must not block the main UI thread. Slot reservation and enqueue share a lock, so concurrent completions cannot reorder queued work. Asynchronous OS requests can still overlap, up to the two-request limit.
 - Window captures read switcher visibility, preferences, and lock state on main before and after the non-prompting preflight. A closed switcher drops pending work when background capture is disabled.
-- The watchdog starts before preflight. A check that returns after its timeout releases the slot without starting a late capture.
+- A ten-second watchdog starts before preflight. A check that returns after its timeout releases the slot without starting a late capture.
+- Submission is claimed atomically against preflight expiry. An accepted submission has its own ten-second completion watchdog; its old preflight deadline no longer applies.
 - The normal completion handler releases the slot.
 - A completion handler can release its slot only one time.
 - A ten-second watchdog opens a circuit and drops queued work when ScreenCaptureKit loses a completion.
@@ -32,3 +33,5 @@ protects the queue from a system request that never calls its completion handler
 - `testFocusedPreviewStartsBeforeQueuedThumbnails`
 - `testSharedCoordinatorSubmitsOutsideMainQueue`
 - `testWatchdogCoversPreflightWithoutStartingLateCapture`
+- `testFocusedPreviewSubmissionIsNotOvertaken`
+- `testPreflightDeadlineCannotExpireSubmittedCapture`

--- a/src/events/ScreenCaptureCoordinatorSpecs.md
+++ b/src/events/ScreenCaptureCoordinatorSpecs.md
@@ -16,6 +16,7 @@ protects the queue from a system request that never calls its completion handler
 - A ten-second watchdog opens a circuit and drops queued work when ScreenCaptureKit loses a completion.
 - A timed-out request still counts as physically active, so no replacement request can exceed the limit.
 - A late completion closes the circuit. A request submitted after that can start.
+- If completion never arrives, the menu shows a passive restart action. Only the user's action restarts AltTab; permissions are not reset. A restart releases the old process and its outstanding requests.
 - Thumbnail and focused-preview requests use the same process-wide coordinator.
 
 ## Test scenarios
@@ -24,3 +25,4 @@ protects the queue from a system request that never calls its completion handler
 - `testWatchdogOpensCircuitUntilLateCompletion`
 - `testCompletionCanReleaseOnlyOneSlot`
 - `testQueuedCaptureIsDroppedWhenEligibilityChanges`
+- `testLostCompletionsKeepCircuitClosedToNewWork`

--- a/src/events/ScreenCaptureCoordinatorTests.swift
+++ b/src/events/ScreenCaptureCoordinatorTests.swift
@@ -20,7 +20,7 @@ final class ScreenCaptureCoordinatorTests: XCTestCase {
         XCTAssertTrue(captured)
     }
 
-    func testSharedCoordinatorSubmitsOutsideMainQueue() async {
+    func testSharedCoordinatorSubmitsOutsideMainQueue() {
         let submitted = expectation(description: "capture submitted off main")
         DispatchQueue.main.async {
             ScreenCaptureCoordinator.shared.submit { completion in
@@ -29,7 +29,7 @@ final class ScreenCaptureCoordinatorTests: XCTestCase {
                 submitted.fulfill()
             }
         }
-        await fulfillment(of: [submitted], timeout: 2)
+        wait(for: [submitted], timeout: 2)
     }
 
     func testFocusedPreviewStartsBeforeQueuedThumbnails() {

--- a/src/events/ScreenCaptureCoordinatorTests.swift
+++ b/src/events/ScreenCaptureCoordinatorTests.swift
@@ -1,6 +1,18 @@
 import XCTest
 
 final class ScreenCaptureCoordinatorTests: XCTestCase {
+    func testLostCompletionsKeepCircuitClosedToNewWork() {
+        var watchdogs = [() -> Void]()
+        let coordinator = ScreenCaptureCoordinator { _, action in watchdogs.append(action) }
+        var starts = 0
+        for _ in 0..<2 { coordinator.submit { _ in starts += 1 } }
+        watchdogs.forEach { $0() }
+        for _ in 0..<20 { coordinator.submit { _ in starts += 1 } }
+        XCTAssertEqual(starts, 2)
+        XCTAssertEqual(coordinator.inFlightCount, 2)
+        XCTAssertTrue(coordinator.isCircuitOpen)
+    }
+
     func testQueuedCaptureIsDroppedWhenEligibilityChanges() {
         let coordinator = ScreenCaptureCoordinator(maximumInFlight: 1) { _, _ in }
         var release: (() -> Void)!

--- a/src/events/ScreenCaptureCoordinatorTests.swift
+++ b/src/events/ScreenCaptureCoordinatorTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+
+final class ScreenCaptureCoordinatorTests: XCTestCase {
+    func testMaximumOfTwoCapturesCanRun() {
+        var watchdogs = [() -> Void]()
+        let coordinator = ScreenCaptureCoordinator(maximumInFlight: 2) { _, action in watchdogs.append(action) }
+        var started = [Int]()
+        var completions = [() -> Void]()
+
+        for id in 1...3 {
+            coordinator.submit { completion in
+                started.append(id)
+                completions.append(completion)
+            }
+        }
+
+        XCTAssertEqual(started, [1, 2])
+        XCTAssertEqual(coordinator.inFlightCount, 2)
+        completions[0]()
+        XCTAssertEqual(started, [1, 2, 3])
+        XCTAssertEqual(coordinator.inFlightCount, 2)
+        XCTAssertEqual(watchdogs.count, 3)
+    }
+
+    func testWatchdogOpensCircuitUntilLateCompletion() {
+        var watchdogs = [() -> Void]()
+        let coordinator = ScreenCaptureCoordinator(maximumInFlight: 1, watchdogSeconds: 10) { _, action in watchdogs.append(action) }
+        var started = [Int]()
+        var firstCompletion: (() -> Void)!
+
+        coordinator.submit { completion in
+            started.append(1)
+            firstCompletion = completion
+        }
+        coordinator.submit { _ in started.append(2) }
+        XCTAssertEqual(started, [1])
+
+        watchdogs[0]()
+
+        XCTAssertEqual(started, [1])
+        XCTAssertEqual(coordinator.inFlightCount, 1)
+        XCTAssertTrue(coordinator.isCircuitOpen)
+        coordinator.submit { _ in started.append(3) }
+        XCTAssertEqual(started, [1])
+
+        firstCompletion()
+        coordinator.submit { _ in started.append(4) }
+
+        XCTAssertEqual(started, [1, 4])
+        XCTAssertFalse(coordinator.isCircuitOpen)
+    }
+
+    func testCompletionCanReleaseOnlyOneSlot() {
+        let coordinator = ScreenCaptureCoordinator(maximumInFlight: 1) { _, _ in }
+        var firstCompletion: (() -> Void)!
+        var starts = 0
+
+        coordinator.submit { completion in
+            starts += 1
+            firstCompletion = completion
+        }
+        coordinator.submit { _ in starts += 1 }
+
+        firstCompletion()
+        firstCompletion()
+
+        XCTAssertEqual(starts, 2)
+        XCTAssertEqual(coordinator.inFlightCount, 1)
+    }
+}

--- a/src/events/ScreenCaptureCoordinatorTests.swift
+++ b/src/events/ScreenCaptureCoordinatorTests.swift
@@ -1,6 +1,37 @@
 import XCTest
 
 final class ScreenCaptureCoordinatorTests: XCTestCase {
+    func testWatchdogCoversPreflightWithoutStartingLateCapture() {
+        var watchdogs = [() -> Void]()
+        let coordinator = ScreenCaptureCoordinator { _, action in watchdogs.append(action) }
+        var captured = false
+        coordinator.submit(if: {
+            XCTAssertEqual(watchdogs.count, 1)
+            watchdogs.first?()
+            return true
+        }) { _ in captured = true }
+        XCTAssertFalse(captured)
+        XCTAssertEqual(coordinator.inFlightCount, 0)
+        XCTAssertFalse(coordinator.isCircuitOpen)
+        coordinator.submit { completion in
+            captured = true
+            completion()
+        }
+        XCTAssertTrue(captured)
+    }
+
+    func testSharedCoordinatorSubmitsOutsideMainQueue() async {
+        let submitted = expectation(description: "capture submitted off main")
+        DispatchQueue.main.async {
+            ScreenCaptureCoordinator.shared.submit { completion in
+                XCTAssertFalse(Thread.isMainThread)
+                completion()
+                submitted.fulfill()
+            }
+        }
+        await fulfillment(of: [submitted], timeout: 2)
+    }
+
     func testFocusedPreviewStartsBeforeQueuedThumbnails() {
         let coordinator = ScreenCaptureCoordinator(maximumInFlight: 1) { _, _ in }
         var release: (() -> Void)!

--- a/src/events/ScreenCaptureCoordinatorTests.swift
+++ b/src/events/ScreenCaptureCoordinatorTests.swift
@@ -1,6 +1,65 @@
 import XCTest
 
 final class ScreenCaptureCoordinatorTests: XCTestCase {
+    func testPreflightDeadlineCannotExpireSubmittedCapture() {
+        var watchdogs = [() -> Void]()
+        let coordinator = ScreenCaptureCoordinator { _, action in watchdogs.append(action) }
+        coordinator.submit { completion in
+            XCTAssertEqual(watchdogs.count, 2)
+            watchdogs[0]()
+            XCTAssertFalse(coordinator.isCircuitOpen)
+            watchdogs.last?()
+            XCTAssertTrue(coordinator.isCircuitOpen)
+            completion()
+        }
+        XCTAssertFalse(coordinator.isCircuitOpen)
+        XCTAssertEqual(coordinator.inFlightCount, 0)
+    }
+
+    func testFocusedPreviewSubmissionIsNotOvertaken() {
+        let coordinator = ScreenCaptureCoordinator.shared
+        let initialSubmissions = expectation(description: "both slots occupied")
+        initialSubmissions.expectedFulfillmentCount = 2
+        let lock = NSLock()
+        var completions = [() -> Void]()
+        for _ in 0 ..< 2 {
+            coordinator.submit { completion in
+                lock.lock()
+                completions.append(completion)
+                lock.unlock()
+                initialSubmissions.fulfill()
+            }
+        }
+        wait(for: [initialSubmissions], timeout: 2)
+        let previewChecking = expectation(description: "preview reaches preflight")
+        let releasePreview = DispatchSemaphore(value: 0)
+        let thumbnailStarted = DispatchSemaphore(value: 0)
+        let finished = expectation(description: "both queued requests finish")
+        finished.expectedFulfillmentCount = 2
+        coordinator.submit { completion in
+            thumbnailStarted.signal()
+            completion()
+            finished.fulfill()
+        }
+        coordinator.submit(priority: .focusedPreview, if: {
+            previewChecking.fulfill()
+            return releasePreview.wait(timeout: .now() + 2) == .success
+        }) { completion in
+            completion()
+            finished.fulfill()
+        }
+        lock.lock()
+        let releases = completions
+        lock.unlock()
+        guard releases.count == 2 else { XCTFail("missing occupied slots"); return }
+        releases[0]()
+        wait(for: [previewChecking], timeout: 2)
+        releases[1]()
+        XCTAssertEqual(thumbnailStarted.wait(timeout: .now() + 0.1), .timedOut)
+        releasePreview.signal()
+        wait(for: [finished], timeout: 2)
+    }
+
     func testWatchdogCoversPreflightWithoutStartingLateCapture() {
         var watchdogs = [() -> Void]()
         let coordinator = ScreenCaptureCoordinator { _, action in watchdogs.append(action) }
@@ -97,7 +156,7 @@ final class ScreenCaptureCoordinatorTests: XCTestCase {
         completions[0]()
         XCTAssertEqual(started, [1, 2, 3])
         XCTAssertEqual(coordinator.inFlightCount, 2)
-        XCTAssertEqual(watchdogs.count, 3)
+        XCTAssertEqual(watchdogs.count, 6)
     }
 
     func testWatchdogOpensCircuitUntilLateCompletion() {
@@ -115,7 +174,7 @@ final class ScreenCaptureCoordinatorTests: XCTestCase {
         coordinator.submit { _ in started.append(2) }
         XCTAssertEqual(started, [1])
 
-        watchdogs[0]()
+        watchdogs.last?()
 
         XCTAssertEqual(started, [1])
         XCTAssertEqual(coordinator.inFlightCount, 1)

--- a/src/events/ScreenCaptureCoordinatorTests.swift
+++ b/src/events/ScreenCaptureCoordinatorTests.swift
@@ -1,6 +1,23 @@
 import XCTest
 
 final class ScreenCaptureCoordinatorTests: XCTestCase {
+    func testFocusedPreviewStartsBeforeQueuedThumbnails() {
+        let coordinator = ScreenCaptureCoordinator(maximumInFlight: 1) { _, _ in }
+        var release: (() -> Void)!
+        var started = [String]()
+        coordinator.submit { release = $0 }
+        coordinator.submit { completion in
+            started.append("thumbnail")
+            completion()
+        }
+        coordinator.submit(priority: .focusedPreview) { completion in
+            started.append("preview")
+            completion()
+        }
+        release()
+        XCTAssertEqual(started, ["preview", "thumbnail"])
+    }
+
     func testLostCompletionsKeepCircuitClosedToNewWork() {
         var watchdogs = [() -> Void]()
         let coordinator = ScreenCaptureCoordinator { _, action in watchdogs.append(action) }

--- a/src/events/ScreenCaptureCoordinatorTests.swift
+++ b/src/events/ScreenCaptureCoordinatorTests.swift
@@ -5,9 +5,9 @@ final class ScreenCaptureCoordinatorTests: XCTestCase {
         var watchdogs = [() -> Void]()
         let coordinator = ScreenCaptureCoordinator { _, action in watchdogs.append(action) }
         var starts = 0
-        for _ in 0..<2 { coordinator.submit { _ in starts += 1 } }
+        for _ in 0 ..< 2 { coordinator.submit { _ in starts += 1 } }
         watchdogs.forEach { $0() }
-        for _ in 0..<20 { coordinator.submit { _ in starts += 1 } }
+        for _ in 0 ..< 20 { coordinator.submit { _ in starts += 1 } }
         XCTAssertEqual(starts, 2)
         XCTAssertEqual(coordinator.inFlightCount, 2)
         XCTAssertTrue(coordinator.isCircuitOpen)
@@ -31,11 +31,13 @@ final class ScreenCaptureCoordinatorTests: XCTestCase {
 
     func testMaximumOfTwoCapturesCanRun() {
         var watchdogs = [() -> Void]()
-        let coordinator = ScreenCaptureCoordinator(maximumInFlight: 2) { _, action in watchdogs.append(action) }
+        let coordinator = ScreenCaptureCoordinator(maximumInFlight: 2) { _, action in
+            watchdogs.append(action)
+        }
         var started = [Int]()
         var completions = [() -> Void]()
 
-        for id in 1...3 {
+        for id in 1 ... 3 {
             coordinator.submit { completion in
                 started.append(id)
                 completions.append(completion)
@@ -52,7 +54,9 @@ final class ScreenCaptureCoordinatorTests: XCTestCase {
 
     func testWatchdogOpensCircuitUntilLateCompletion() {
         var watchdogs = [() -> Void]()
-        let coordinator = ScreenCaptureCoordinator(maximumInFlight: 1, watchdogSeconds: 10) { _, action in watchdogs.append(action) }
+        let coordinator = ScreenCaptureCoordinator(maximumInFlight: 1, watchdogSeconds: 10) { _, action in
+            watchdogs.append(action)
+        }
         var started = [Int]()
         var firstCompletion: (() -> Void)!
 

--- a/src/events/ScreenCaptureCoordinatorTests.swift
+++ b/src/events/ScreenCaptureCoordinatorTests.swift
@@ -1,6 +1,22 @@
 import XCTest
 
 final class ScreenCaptureCoordinatorTests: XCTestCase {
+    func testQueuedCaptureIsDroppedWhenEligibilityChanges() {
+        let coordinator = ScreenCaptureCoordinator(maximumInFlight: 1) { _, _ in }
+        var release: (() -> Void)!
+        var switcherOpen = true
+        var captured = false
+        coordinator.submit { release = $0 }
+        coordinator.submit(if: { switcherOpen }) { completion in
+            captured = true
+            completion()
+        }
+        switcherOpen = false
+        release()
+        XCTAssertFalse(captured)
+        XCTAssertEqual(coordinator.inFlightCount, 0)
+    }
+
     func testMaximumOfTwoCapturesCanRun() {
         var watchdogs = [() -> Void]()
         let coordinator = ScreenCaptureCoordinator(maximumInFlight: 2) { _, action in watchdogs.append(action) }

--- a/src/events/WindowCaptureEvents.swift
+++ b/src/events/WindowCaptureEvents.swift
@@ -128,11 +128,15 @@ class WindowCaptureScreenshots {
             guard !App.isTerminating, !ScreenLockEvents.isScreenLocked, let window else { return }
             let config = SCStreamConfiguration.forWindow(scWindow, size, scaleFactor, request.fullRes, false)
             let filter = SCContentFilter(desktopIndependentWindow: scWindow)
-            // captureSampleBuffer spins up a short-lived capture stream per call; on some macOS 26 machines that
+            // captureSampleBuffer spins up a short-lived capture stream per call; on some macOS 26 machines
+            // that
             // churn leaks WindowServer memory until the session is force-logged-out (#5786), and the per-call
-            // replayd attribution work can wedge screenshots machine-wide under bursts (#5861). captureScreenshot
-            // avoids the churn but fails (SCStreamError -3811) on fullscreen windows whose Space is inactive, so
-            // that one case stays on captureSampleBuffer. Its CGImage copy (vs a shared IOSurface) is acceptable
+            // replayd attribution work can wedge screenshots machine-wide under bursts (#5861).
+            // captureScreenshot
+            // avoids the churn but fails (SCStreamError -3811) on fullscreen windows whose Space is inactive,
+            // so
+            // that one case stays on captureSampleBuffer. Its CGImage copy (vs a shared IOSurface) is
+            // acceptable
             // even at full resolution now that Preview frames are fetched lazily, a few per session (#5861).
             if #available(macOS 26.0, *), !request.isFullscreen {
                 captureScreenshot(filter, config, window, source, request.fullRes)
@@ -143,7 +147,13 @@ class WindowCaptureScreenshots {
     }
 
     @available(macOS 26.0, *)
-    private static func captureScreenshot(_ filter: SCContentFilter, _ streamConfig: SCStreamConfiguration, _ window: Window, _ source: RefreshCausedBy, _ fullRes: Bool) {
+    private static func captureScreenshot(
+        _ filter: SCContentFilter,
+        _ streamConfig: SCStreamConfiguration,
+        _ window: Window,
+        _ source: RefreshCausedBy,
+        _ fullRes: Bool
+    ) {
         let config = SCScreenshotConfiguration()
         config.width = streamConfig.width
         config.height = streamConfig.height
@@ -173,7 +183,13 @@ class WindowCaptureScreenshots {
         }
     }
 
-    private static func captureSampleBuffer(_ filter: SCContentFilter, _ config: SCStreamConfiguration, _ window: Window, _ source: RefreshCausedBy, _ fullRes: Bool) {
+    private static func captureSampleBuffer(
+        _ filter: SCContentFilter,
+        _ config: SCStreamConfiguration,
+        _ window: Window,
+        _ source: RefreshCausedBy,
+        _ fullRes: Bool
+    ) {
         ScreenCaptureCoordinator.shared.submit(priority: fullRes ? .focusedPreview : .normal,
                                                if: { canSubmit(fullRes: fullRes) }) { completion in
             SCScreenshotManager.captureSampleBuffer(contentFilter: filter,
@@ -278,6 +294,7 @@ class WindowCaptureScreenshotsPrivateApi {
         ActiveWindowCaptures.increment()
         defer { ActiveWindowCaptures.decrement() }
         return WindowServerCaptureFallback.capture(
+            if: canSubmit,
             primary: {
                 var windowId_ = wid
                 let list = CGSHWCaptureWindowList(
@@ -297,6 +314,22 @@ class WindowCaptureScreenshotsPrivateApi {
                 )?.takeRetainedValue()
             }
         )
+    }
+
+    private static func canSubmit() -> Bool {
+        dispatchPrecondition(condition: .notOnQueue(.main))
+        func isEligible() -> Bool {
+            DispatchQueue.main.sync {
+                !App.isTerminating && !ScreenLockEvents.isScreenLocked &&
+                    (SwitcherSession.isActive || Preferences.captureWindowsInBackground)
+            }
+        }
+        guard isEligible() else { return false }
+        if #available(macOS 10.15, *), !CGPreflightScreenCaptureAccess() {
+            return false
+        }
+        // Preflight can block; use current UI state when the capture actually starts.
+        return isEligible()
     }
 }
 
@@ -483,8 +516,14 @@ extension CMSampleBuffer {
 class ActiveWindowCaptures {
     private static var _count: Int32 = 0
 
-    static func increment() { OSAtomicIncrement32(&_count) }
-    static func decrement() { OSAtomicDecrement32(&_count) }
+    static func increment() {
+        OSAtomicIncrement32(&_count)
+    }
+
+    static func decrement() {
+        OSAtomicDecrement32(&_count)
+    }
+
     static func value() -> Int {
         Int(OSAtomicAdd32(0, &_count)) +
             ScreenCaptureCoordinator.shared.inFlightCount

--- a/src/events/WindowCaptureEvents.swift
+++ b/src/events/WindowCaptureEvents.swift
@@ -60,8 +60,7 @@ class WindowCaptureScreenshots {
 
     private static func handleNotCachedWindows(_ notCachedWindows: [CGWindowID], _ requests: [CGWindowID: CaptureRequest], _ source: RefreshCausedBy, _ prioritized: Set<CGWindowID>) {
         guard !notCachedWindows.isEmpty else { return }
-        ScreenCaptureCoordinator.shared.submit { completion in
-            guard !isCoolingDown else { completion(); return }
+        ScreenCaptureCoordinator.shared.submit(on: .main, if: { canSubmit(fullRes: requests.values.contains { $0.fullRes }) }) { completion in
             SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
                 completion()
                 guard let shareableContent, error == nil else {
@@ -135,8 +134,7 @@ class WindowCaptureScreenshots {
         config.height = streamConfig.height
         config.showsCursor = false
         config.dynamicRange = .sdr
-        ScreenCaptureCoordinator.shared.submit { completion in
-            guard !isCoolingDown else { completion(); return }
+        ScreenCaptureCoordinator.shared.submit(on: .main, if: { canSubmit(fullRes: fullRes) }) { completion in
             SCScreenshotManager.captureScreenshot(contentFilter: filter, configuration: config) { [weak window] output, error in
                 completion()
                 guard let window else { return }
@@ -155,8 +153,7 @@ class WindowCaptureScreenshots {
     }
 
     private static func captureSampleBuffer(_ filter: SCContentFilter, _ config: SCStreamConfiguration, _ window: Window, _ source: RefreshCausedBy, _ fullRes: Bool) {
-        ScreenCaptureCoordinator.shared.submit { completion in
-            guard !isCoolingDown else { completion(); return }
+        ScreenCaptureCoordinator.shared.submit(on: .main, if: { canSubmit(fullRes: fullRes) }) { completion in
             SCScreenshotManager.captureSampleBuffer(contentFilter: filter, configuration: config) { [weak window] sampleBuffer, error in
                 completion()
                 guard let window else { return }
@@ -191,6 +188,13 @@ class WindowCaptureScreenshots {
                 window.refreshThumbnail(contents)
             }
         }
+    }
+
+    private static func canSubmit(fullRes: Bool) -> Bool {
+        dispatchPrecondition(condition: .onQueue(.main))
+        guard !App.isTerminating, !ScreenLockEvents.isScreenLocked, !isCoolingDown,
+              SwitcherSession.isActive || (!fullRes && Preferences.captureWindowsInBackground) else { return false }
+        return CGPreflightScreenCaptureAccess()
     }
 
     private static var isCoolingDown: Bool {

--- a/src/events/WindowCaptureEvents.swift
+++ b/src/events/WindowCaptureEvents.swift
@@ -61,7 +61,6 @@ class WindowCaptureScreenshots {
     private static func handleNotCachedWindows(_ notCachedWindows: [CGWindowID], _ requests: [CGWindowID: CaptureRequest], _ source: RefreshCausedBy, _ prioritized: Set<CGWindowID>) {
         guard !notCachedWindows.isEmpty else { return }
         ScreenCaptureCoordinator.shared.submit(
-            on: .main,
             priority: requests.values.contains { $0.fullRes } ? .focusedPreview : .normal,
             if: { canSubmit(fullRes: requests.values.contains { $0.fullRes }) }
         ) { completion in
@@ -150,7 +149,7 @@ class WindowCaptureScreenshots {
         config.height = streamConfig.height
         config.showsCursor = false
         config.dynamicRange = .sdr
-        ScreenCaptureCoordinator.shared.submit(on: .main, priority: fullRes ? .focusedPreview : .normal,
+        ScreenCaptureCoordinator.shared.submit(priority: fullRes ? .focusedPreview : .normal,
                                                if: { canSubmit(fullRes: fullRes) }) { completion in
             SCScreenshotManager.captureScreenshot(contentFilter: filter,
                                                   configuration: config) { [weak window] output, error in
@@ -175,7 +174,7 @@ class WindowCaptureScreenshots {
     }
 
     private static func captureSampleBuffer(_ filter: SCContentFilter, _ config: SCStreamConfiguration, _ window: Window, _ source: RefreshCausedBy, _ fullRes: Bool) {
-        ScreenCaptureCoordinator.shared.submit(on: .main, priority: fullRes ? .focusedPreview : .normal,
+        ScreenCaptureCoordinator.shared.submit(priority: fullRes ? .focusedPreview : .normal,
                                                if: { canSubmit(fullRes: fullRes) }) { completion in
             SCScreenshotManager.captureSampleBuffer(contentFilter: filter,
                                                     configuration: config) { [
@@ -220,11 +219,19 @@ class WindowCaptureScreenshots {
     }
 
     private static func canSubmit(fullRes: Bool) -> Bool {
+        dispatchPrecondition(condition: .notOnQueue(.main))
+        guard DispatchQueue.main.sync(execute: { isCaptureEligible(fullRes: fullRes) }),
+              CGPreflightScreenCaptureAccess() else { return false }
+        // Preflight can block in macOS. Recheck UI state before submitting the capture.
+        return DispatchQueue.main.sync { isCaptureEligible(fullRes: fullRes) }
+    }
+
+    private static func isCaptureEligible(fullRes: Bool) -> Bool {
         dispatchPrecondition(condition: .onQueue(.main))
         guard !App.isTerminating, !ScreenLockEvents.isScreenLocked, !isCoolingDown,
               SwitcherSession.isActive || (!fullRes && Preferences.captureWindowsInBackground)
         else { return false }
-        return CGPreflightScreenCaptureAccess()
+        return true
     }
 
     private static var isCoolingDown: Bool {

--- a/src/events/WindowCaptureEvents.swift
+++ b/src/events/WindowCaptureEvents.swift
@@ -56,19 +56,26 @@ class WindowCaptureScreenshots {
 
     private static func handleNotCachedWindows(_ notCachedWindows: [CGWindowID], _ requests: [CGWindowID: CaptureRequest], _ source: RefreshCausedBy, _ prioritized: Set<CGWindowID>) {
         guard !notCachedWindows.isEmpty else { return }
-        SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
-            guard let shareableContent, error == nil else { Logger.error { "\(shareableContent == nil) \(error)" }; return }
-            guard source != .refreshOnlyThumbnailsAfterShowUi || SwitcherSession.isActive else { return }
-            // this callback is executed on an undetermined queue; we move execution to screenshotsQueue
-            BackgroundWork.screenshotsQueue.addOperation {
-                cachedSCWindows.withLock { $0 = shareableContent.windows }
+        ScreenCaptureCoordinator.shared.submit { completion in
+            SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
+                completion()
+                guard let shareableContent, error == nil else {
+                    Logger.error { "\(shareableContent == nil) \(error)" }
+                    if let error { ScreenRecordingPermission.reportCaptureFailure(error) }
+                    return
+                }
                 guard source != .refreshOnlyThumbnailsAfterShowUi || SwitcherSession.isActive else { return }
-                for notCachedWindow in notCachedWindows {
-                    guard let request = requests[notCachedWindow] else { continue }
-                    if let cachedWindow = (shareableContent.windows.first { $0.windowID == notCachedWindow }) {
-                        oneTimeCapture(cachedWindow, request, source, prioritized.contains(notCachedWindow))
-                    } else {
-                        Logger.debug { "wid:\(notCachedWindow) was not found in SCShareableContent windows" }
+                // this callback is executed on an undetermined queue; we move execution to screenshotsQueue
+                BackgroundWork.screenshotsQueue.addOperation {
+                    cachedSCWindows.withLock { $0 = shareableContent.windows }
+                    guard source != .refreshOnlyThumbnailsAfterShowUi || SwitcherSession.isActive else { return }
+                    for notCachedWindow in notCachedWindows {
+                        guard let request = requests[notCachedWindow] else { continue }
+                        if let cachedWindow = (shareableContent.windows.first { $0.windowID == notCachedWindow }) {
+                            oneTimeCapture(cachedWindow, request, source, prioritized.contains(notCachedWindow))
+                        } else {
+                            Logger.debug { "wid:\(notCachedWindow) was not found in SCShareableContent windows" }
+                        }
                     }
                 }
             }
@@ -101,50 +108,57 @@ class WindowCaptureScreenshots {
             guard !App.isTerminating, !ScreenLockEvents.isScreenLocked, let window else { return }
             let config = SCStreamConfiguration.forWindow(scWindow, size, scaleFactor, request.fullRes, false)
             let filter = SCContentFilter(desktopIndependentWindow: scWindow)
-            // Through the gate, not merely counted: these APIs are ASYNCHRONOUS, so the `screenshotsQueue`
-            // slot frees the moment the request is handed to the OS, and a show of 60 windows fired 60
-            // simultaneous requests — the burst #5861 blames for wedging replayd machine-wide.
-            ActiveWindowCaptures.run { finish in
-                // captureSampleBuffer spins up a short-lived capture stream per call; on some macOS 26 machines that
-                // churn leaks WindowServer memory until the session is force-logged-out (#5786), and the per-call
-                // replayd attribution work can wedge screenshots machine-wide under bursts (#5861). captureScreenshot
-                // avoids the churn but fails (SCStreamError -3811) on fullscreen windows whose Space is inactive, so
-                // that one case stays on captureSampleBuffer. Its CGImage copy (vs a shared IOSurface) is acceptable
-                // even at full resolution now that Preview frames are fetched lazily, a few per session (#5861).
-                if #available(macOS 26.0, *), !request.isFullscreen {
-                    captureScreenshot(filter, config, window, source, request.fullRes, finish)
-                } else {
-                    captureSampleBuffer(filter, config, window, source, request.fullRes, finish)
-                }
+            // captureSampleBuffer spins up a short-lived capture stream per call; on some macOS 26 machines that
+            // churn leaks WindowServer memory until the session is force-logged-out (#5786), and the per-call
+            // replayd attribution work can wedge screenshots machine-wide under bursts (#5861). captureScreenshot
+            // avoids the churn but fails (SCStreamError -3811) on fullscreen windows whose Space is inactive, so
+            // that one case stays on captureSampleBuffer. Its CGImage copy (vs a shared IOSurface) is acceptable
+            // even at full resolution now that Preview frames are fetched lazily, a few per session (#5861).
+            if #available(macOS 26.0, *), !request.isFullscreen {
+                captureScreenshot(filter, config, window, source, request.fullRes)
+            } else {
+                captureSampleBuffer(filter, config, window, source, request.fullRes)
             }
         }
     }
 
     @available(macOS 26.0, *)
-    private static func captureScreenshot(_ filter: SCContentFilter, _ streamConfig: SCStreamConfiguration, _ window: Window, _ source: RefreshCausedBy, _ fullRes: Bool, _ finish: @escaping () -> Void) {
+    private static func captureScreenshot(_ filter: SCContentFilter, _ streamConfig: SCStreamConfiguration, _ window: Window, _ source: RefreshCausedBy, _ fullRes: Bool) {
         let config = SCScreenshotConfiguration()
         config.width = streamConfig.width
         config.height = streamConfig.height
         config.showsCursor = false
         config.dynamicRange = .sdr
-        SCScreenshotManager.captureScreenshot(contentFilter: filter, configuration: config) { [weak window] output, error in
-            finish()
-            guard let window else { return }
-            // no captureSampleBuffer fallback: the only known failure is a stale isFullscreen snapshot during a
-            // fullscreen transition, and the next refresh re-routes it. Retrying here would silently reintroduce
-            // the stream churn this path exists to avoid, and would hide new failure modes from the logs.
-            guard let cgImage = output?.sdrImage, error == nil else { Logger.error { "\(window.debugId) \(output == nil) \(error)" }; return }
-            deliver(window, source, .cgImage(cgImage), fullRes)
+        ScreenCaptureCoordinator.shared.submit { completion in
+            SCScreenshotManager.captureScreenshot(contentFilter: filter, configuration: config) { [weak window] output, error in
+                completion()
+                guard let window else { return }
+                // no captureSampleBuffer fallback: the only known failure is a stale isFullscreen snapshot during a
+                // fullscreen transition, and the next refresh re-routes it. Retrying here would silently reintroduce
+                // the stream churn this path exists to avoid, and would hide new failure modes from the logs.
+                guard let cgImage = output?.sdrImage, error == nil else {
+                    Logger.error { "\(window.debugId) \(output == nil) \(error)" }
+                    if let error { ScreenRecordingPermission.reportCaptureFailure(error) }
+                    return
+                }
+                deliver(window, source, .cgImage(cgImage), fullRes)
+            }
         }
     }
 
-    private static func captureSampleBuffer(_ filter: SCContentFilter, _ config: SCStreamConfiguration, _ window: Window, _ source: RefreshCausedBy, _ fullRes: Bool, _ finish: @escaping () -> Void) {
-        SCScreenshotManager.captureSampleBuffer(contentFilter: filter, configuration: config) { [weak window] sampleBuffer, error in
-            finish()
-            guard let window else { return }
-            guard let sampleBuffer, error == nil else { Logger.error { "\(window.debugId) \(sampleBuffer == nil) \(error)" }; return }
-            guard let pixelBuffer = sampleBuffer.pixelBuffer() ?? sampleBuffer.imageBuffer else { Logger.error { "\(window.debugId) no pixelBuffer" }; return }
-            deliver(window, source, .pixelBuffer(pixelBuffer), fullRes)
+    private static func captureSampleBuffer(_ filter: SCContentFilter, _ config: SCStreamConfiguration, _ window: Window, _ source: RefreshCausedBy, _ fullRes: Bool) {
+        ScreenCaptureCoordinator.shared.submit { completion in
+            SCScreenshotManager.captureSampleBuffer(contentFilter: filter, configuration: config) { [weak window] sampleBuffer, error in
+                completion()
+                guard let window else { return }
+                guard let sampleBuffer, error == nil else {
+                    Logger.error { "\(window.debugId) \(sampleBuffer == nil) \(error)" }
+                    if let error { ScreenRecordingPermission.reportCaptureFailure(error) }
+                    return
+                }
+                guard let pixelBuffer = sampleBuffer.pixelBuffer() ?? sampleBuffer.imageBuffer else { Logger.error { "\(window.debugId) no pixelBuffer" }; return }
+                deliver(window, source, .pixelBuffer(pixelBuffer), fullRes)
+            }
         }
     }
 
@@ -198,12 +212,9 @@ class WindowCaptureScreenshotsPrivateApi {
         guard !App.isTerminating, !ScreenLockEvents.isScreenLocked else { return nil }
         // we use CGSHWCaptureWindowList because it can screenshot minimized windows, which CGWindowListCreateImage can't
         var windowId_ = wid
-        // Synchronous, so it was already bounded by the 8-wide `screenshotsQueue`; through the same gate
-        // anyway, so in-flight captures have ONE accounting whichever path took them.
-        var list = [CGImage]()
-        ActiveWindowCaptures.runSync {
-            list = CGSHWCaptureWindowList(CGS_CONNECTION, &windowId_, 1, [.ignoreGlobalClipShape, .bestResolution, .fullSize]).takeRetainedValue() as! [CGImage]
-        }
+        ActiveWindowCaptures.increment()
+        let list = CGSHWCaptureWindowList(CGS_CONNECTION, &windowId_, 1, [.ignoreGlobalClipShape, .bestResolution, .fullSize]).takeRetainedValue() as! [CGImage]
+        ActiveWindowCaptures.decrement()
         return list.first
     }
 }
@@ -388,96 +399,10 @@ extension CMSampleBuffer {
     }
 }
 
-/// **The gate on in-flight window captures**, and the counter `main.swift` drains at quit (macOS pops
-/// permission dialogs for a capture still outstanding when the process dies, #5106).
-///
-/// It became a gate because the ScreenCaptureKit path is ASYNCHRONOUS: `SCScreenshotManager` hands the
-/// request to the OS and returns, freeing its `screenshotsQueue` slot at once, so the 8-wide queue bounded
-/// nothing and a show of 60 windows fired 60 simultaneous requests. The private-API path never had that
-/// problem — `CGSHWCaptureWindowList` blocks, so the queue width WAS its bound — and the bound was simply
-/// never carried over when ScreenCaptureKit became the macOS 26 path. `maxInFlight` restores it.
 class ActiveWindowCaptures {
-    /// Parity with the `screenshotsQueue` width, which is the bound the synchronous path always had.
-    private static let maxInFlight = 8
-    /// A capture the OS never answers must not hold its slot for the life of the session: #5861 has replayd
-    /// wedging machine-wide under bursts, which is exactly when a lost callback is likeliest and exactly when
-    /// the remaining slots matter most. Generous, because a slow capture is not a lost one — this is the
-    /// pathological case only, and it matches the drain budget `makeSureAllCapturesAreFinished` allows.
-    private static let watchdogSeconds = 5.0
+    private static var _count: Int32 = 0
 
-    private static let lock = NSLock()
-    private static var inFlight = 0
-    private static var waiting = [(@escaping () -> Void) -> Void]()
-
-    /// Run `capture` once a slot is free. `capture` receives a `finish` closure it MUST call when the OS
-    /// answers; calling it more than once is safe and calling it late (after the watchdog fired) is a no-op.
-    static func run(_ capture: @escaping (@escaping () -> Void) -> Void) {
-        lock.lock()
-        guard inFlight < maxInFlight else {
-            waiting.append(capture)
-            lock.unlock()
-            return
-        }
-        inFlight += 1
-        lock.unlock()
-        start(capture)
-    }
-
-    /// For the synchronous private-API path: counts, runs, releases. It does not WAIT for a slot and does
-    /// not need a watchdog — a blocking call cannot lose its answer, and the 8-wide queue it runs on is
-    /// already the bound. Here only so both paths report through one counter at quit.
-    static func runSync(_ capture: () -> Void) {
-        lock.lock()
-        inFlight += 1
-        lock.unlock()
-        capture()
-        release()
-    }
-
-    private static func start(_ capture: @escaping (@escaping () -> Void) -> Void) {
-        // one-shot: whoever gets there first (the OS callback or the watchdog) releases the slot exactly once
-        let done = FinishOnce()
-        let finish = { if done.claim() { release() } }
-        DispatchQueue.global().asyncAfter(deadline: .now() + watchdogSeconds) {
-            guard done.claim() else { return }
-            Logger.warning { "a window capture never answered after \(Int(watchdogSeconds))s; releasing its slot" }
-            release()
-        }
-        capture(finish)
-    }
-
-    private static func release() {
-        lock.lock()
-        inFlight -= 1
-        var next: ((@escaping () -> Void) -> Void)?
-        // Nothing queued may still be started once we are shutting down: the whole reason quit drains this
-        // counter is that macOS pops permission dialogs for a capture outstanding when the process dies.
-        if App.isTerminating {
-            waiting.removeAll()
-        } else if !waiting.isEmpty {
-            next = waiting.removeFirst()
-            inFlight += 1
-        }
-        lock.unlock()
-        if let next { start(next) }
-    }
-
-    static func value() -> Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return inFlight
-    }
-
-    private class FinishOnce {
-        private let lock = NSLock()
-        private var claimed = false
-
-        func claim() -> Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            if claimed { return false }
-            claimed = true
-            return true
-        }
-    }
+    static func increment() { OSAtomicIncrement32(&_count) }
+    static func decrement() { OSAtomicDecrement32(&_count) }
+    static func value() -> Int { Int(OSAtomicAdd32(0, &_count)) + ScreenCaptureCoordinator.shared.inFlightCount }
 }

--- a/src/events/WindowCaptureEvents.swift
+++ b/src/events/WindowCaptureEvents.swift
@@ -62,6 +62,7 @@ class WindowCaptureScreenshots {
         guard !notCachedWindows.isEmpty else { return }
         ScreenCaptureCoordinator.shared.submit(
             on: .main,
+            priority: requests.values.contains { $0.fullRes } ? .focusedPreview : .normal,
             if: { canSubmit(fullRes: requests.values.contains { $0.fullRes }) }
         ) { completion in
             SCShareableContent.getExcludingDesktopWindows(true,
@@ -149,7 +150,8 @@ class WindowCaptureScreenshots {
         config.height = streamConfig.height
         config.showsCursor = false
         config.dynamicRange = .sdr
-        ScreenCaptureCoordinator.shared.submit(on: .main, if: { canSubmit(fullRes: fullRes) }) { completion in
+        ScreenCaptureCoordinator.shared.submit(on: .main, priority: fullRes ? .focusedPreview : .normal,
+                                               if: { canSubmit(fullRes: fullRes) }) { completion in
             SCScreenshotManager.captureScreenshot(contentFilter: filter,
                                                   configuration: config) { [weak window] output, error in
                 completion()
@@ -173,7 +175,8 @@ class WindowCaptureScreenshots {
     }
 
     private static func captureSampleBuffer(_ filter: SCContentFilter, _ config: SCStreamConfiguration, _ window: Window, _ source: RefreshCausedBy, _ fullRes: Bool) {
-        ScreenCaptureCoordinator.shared.submit(on: .main, if: { canSubmit(fullRes: fullRes) }) { completion in
+        ScreenCaptureCoordinator.shared.submit(on: .main, priority: fullRes ? .focusedPreview : .normal,
+                                               if: { canSubmit(fullRes: fullRes) }) { completion in
             SCScreenshotManager.captureSampleBuffer(contentFilter: filter,
                                                     configuration: config) { [
                 weak window

--- a/src/events/WindowCaptureEvents.swift
+++ b/src/events/WindowCaptureEvents.swift
@@ -60,26 +60,41 @@ class WindowCaptureScreenshots {
 
     private static func handleNotCachedWindows(_ notCachedWindows: [CGWindowID], _ requests: [CGWindowID: CaptureRequest], _ source: RefreshCausedBy, _ prioritized: Set<CGWindowID>) {
         guard !notCachedWindows.isEmpty else { return }
-        ScreenCaptureCoordinator.shared.submit(on: .main, if: { canSubmit(fullRes: requests.values.contains { $0.fullRes }) }) { completion in
-            SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
+        ScreenCaptureCoordinator.shared.submit(
+            on: .main,
+            if: { canSubmit(fullRes: requests.values.contains { $0.fullRes }) }
+        ) { completion in
+            SCShareableContent.getExcludingDesktopWindows(true,
+                                                          onScreenWindowsOnly: false) { shareableContent, error in
                 completion()
                 guard let shareableContent, error == nil else {
                     Logger.error { "\(shareableContent == nil) \(error)" }
                     beginFailureCooldown()
-                    if let error { ScreenRecordingPermission.reportCaptureFailure(error) }
+                    if let error {
+                        ScreenRecordingPermission.reportCaptureFailure(error)
+                    }
                     return
                 }
                 guard source != .refreshOnlyThumbnailsAfterShowUi || SwitcherSession.isActive else { return }
                 // this callback is executed on an undetermined queue; we move execution to screenshotsQueue
                 BackgroundWork.screenshotsQueue.addOperation {
                     cachedSCWindows.withLock { $0 = shareableContent.windows }
-                    guard source != .refreshOnlyThumbnailsAfterShowUi || SwitcherSession.isActive else { return }
+                    guard source != .refreshOnlyThumbnailsAfterShowUi || SwitcherSession.isActive
+                    else { return }
                     for notCachedWindow in notCachedWindows {
                         guard let request = requests[notCachedWindow] else { continue }
-                        if let cachedWindow = (shareableContent.windows.first { $0.windowID == notCachedWindow }) {
-                            oneTimeCapture(cachedWindow, request, source, prioritized.contains(notCachedWindow))
+                        if let cachedWindow =
+                            (shareableContent.windows.first { $0.windowID == notCachedWindow }) {
+                            oneTimeCapture(
+                                cachedWindow,
+                                request,
+                                source,
+                                prioritized.contains(notCachedWindow)
+                            )
                         } else {
-                            Logger.debug { "wid:\(notCachedWindow) was not found in SCShareableContent windows" }
+                            Logger.debug {
+                                "wid:\(notCachedWindow) was not found in SCShareableContent windows"
+                            }
                         }
                     }
                 }
@@ -135,16 +150,21 @@ class WindowCaptureScreenshots {
         config.showsCursor = false
         config.dynamicRange = .sdr
         ScreenCaptureCoordinator.shared.submit(on: .main, if: { canSubmit(fullRes: fullRes) }) { completion in
-            SCScreenshotManager.captureScreenshot(contentFilter: filter, configuration: config) { [weak window] output, error in
+            SCScreenshotManager.captureScreenshot(contentFilter: filter,
+                                                  configuration: config) { [weak window] output, error in
                 completion()
                 guard let window else { return }
-                // no captureSampleBuffer fallback: the only known failure is a stale isFullscreen snapshot during a
-                // fullscreen transition, and the next refresh re-routes it. Retrying here would silently reintroduce
+                // no captureSampleBuffer fallback: the only known failure is a stale isFullscreen snapshot
+                // during a
+                // fullscreen transition, and the next refresh re-routes it. Retrying here would silently
+                // reintroduce
                 // the stream churn this path exists to avoid, and would hide new failure modes from the logs.
                 guard let cgImage = output?.sdrImage, error == nil else {
                     Logger.error { "\(window.debugId) \(output == nil) \(error)" }
                     beginFailureCooldown()
-                    if let error { ScreenRecordingPermission.reportCaptureFailure(error) }
+                    if let error {
+                        ScreenRecordingPermission.reportCaptureFailure(error)
+                    }
                     return
                 }
                 deliver(window, source, .cgImage(cgImage), fullRes)
@@ -154,16 +174,22 @@ class WindowCaptureScreenshots {
 
     private static func captureSampleBuffer(_ filter: SCContentFilter, _ config: SCStreamConfiguration, _ window: Window, _ source: RefreshCausedBy, _ fullRes: Bool) {
         ScreenCaptureCoordinator.shared.submit(on: .main, if: { canSubmit(fullRes: fullRes) }) { completion in
-            SCScreenshotManager.captureSampleBuffer(contentFilter: filter, configuration: config) { [weak window] sampleBuffer, error in
+            SCScreenshotManager.captureSampleBuffer(contentFilter: filter,
+                                                    configuration: config) { [
+                weak window
+            ] sampleBuffer, error in
                 completion()
                 guard let window else { return }
                 guard let sampleBuffer, error == nil else {
                     Logger.error { "\(window.debugId) \(sampleBuffer == nil) \(error)" }
                     beginFailureCooldown()
-                    if let error { ScreenRecordingPermission.reportCaptureFailure(error) }
+                    if let error {
+                        ScreenRecordingPermission.reportCaptureFailure(error)
+                    }
                     return
                 }
-                guard let pixelBuffer = sampleBuffer.pixelBuffer() ?? sampleBuffer.imageBuffer else { Logger.error { "\(window.debugId) no pixelBuffer" }; return }
+                guard let pixelBuffer = sampleBuffer.pixelBuffer() ?? sampleBuffer.imageBuffer
+                else { Logger.error { "\(window.debugId) no pixelBuffer" }; return }
                 deliver(window, source, .pixelBuffer(pixelBuffer), fullRes)
             }
         }
@@ -193,7 +219,8 @@ class WindowCaptureScreenshots {
     private static func canSubmit(fullRes: Bool) -> Bool {
         dispatchPrecondition(condition: .onQueue(.main))
         guard !App.isTerminating, !ScreenLockEvents.isScreenLocked, !isCoolingDown,
-              SwitcherSession.isActive || (!fullRes && Preferences.captureWindowsInBackground) else { return false }
+              SwitcherSession.isActive || (!fullRes && Preferences.captureWindowsInBackground)
+        else { return false }
         return CGPreflightScreenCaptureAccess()
     }
 
@@ -258,7 +285,8 @@ class WindowCaptureScreenshotsPrivateApi {
                     .null, .optionIncludingWindow, wid,
                     [.boundsIgnoreFraming, .bestResolution]
                 )?.takeRetainedValue()
-            })
+            }
+        )
     }
 }
 
@@ -447,5 +475,8 @@ class ActiveWindowCaptures {
 
     static func increment() { OSAtomicIncrement32(&_count) }
     static func decrement() { OSAtomicDecrement32(&_count) }
-    static func value() -> Int { Int(OSAtomicAdd32(0, &_count)) + ScreenCaptureCoordinator.shared.inFlightCount }
+    static func value() -> Int {
+        Int(OSAtomicAdd32(0, &_count)) +
+            ScreenCaptureCoordinator.shared.inFlightCount
+    }
 }

--- a/src/events/WindowCaptureEvents.swift
+++ b/src/events/WindowCaptureEvents.swift
@@ -7,6 +7,9 @@ class WindowCaptureScreenshots {
     // Wrapped in ConcurrentArray because reads and writes happen from different operations on
     // BackgroundWork.screenshotsQueue, which is concurrent (maxConcurrentOperationCount = 8).
     static let cachedSCWindows = ConcurrentArray<SCWindow>()
+    private static let cooldownLock = NSLock()
+    private static var cooldownUntil = Date.distantPast
+    private static let failureCooldown: TimeInterval = 15
 
     struct CaptureRequest {
         let window: Window
@@ -19,6 +22,7 @@ class WindowCaptureScreenshots {
     /// `fullRes: false` = thumbnail-scale captures, delivered to `Window.thumbnail`.
     /// `fullRes: true` = full-resolution Preview frames, delivered to the session's capped cache (#5861).
     static func oneTimeScreenshots(_ windowsToScreenshot: [Window], _ source: RefreshCausedBy, prioritizedIds: Set<CGWindowID>? = nil, fullRes: Bool = false) {
+        guard !isCoolingDown else { return }
         // Snapshot Window state on the main thread before hopping to screenshotsQueue. Windows.byWindowId,
         // Window.size, Window.screenId, Screens.all, and NSScreen.preferred are plain (lock-free) dictionaries
         // and mutable properties touched only on main; reading them from screenshotsQueue (8-way concurrent)
@@ -57,10 +61,12 @@ class WindowCaptureScreenshots {
     private static func handleNotCachedWindows(_ notCachedWindows: [CGWindowID], _ requests: [CGWindowID: CaptureRequest], _ source: RefreshCausedBy, _ prioritized: Set<CGWindowID>) {
         guard !notCachedWindows.isEmpty else { return }
         ScreenCaptureCoordinator.shared.submit { completion in
+            guard !isCoolingDown else { completion(); return }
             SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
                 completion()
                 guard let shareableContent, error == nil else {
                     Logger.error { "\(shareableContent == nil) \(error)" }
+                    beginFailureCooldown()
                     if let error { ScreenRecordingPermission.reportCaptureFailure(error) }
                     return
                 }
@@ -130,6 +136,7 @@ class WindowCaptureScreenshots {
         config.showsCursor = false
         config.dynamicRange = .sdr
         ScreenCaptureCoordinator.shared.submit { completion in
+            guard !isCoolingDown else { completion(); return }
             SCScreenshotManager.captureScreenshot(contentFilter: filter, configuration: config) { [weak window] output, error in
                 completion()
                 guard let window else { return }
@@ -138,6 +145,7 @@ class WindowCaptureScreenshots {
                 // the stream churn this path exists to avoid, and would hide new failure modes from the logs.
                 guard let cgImage = output?.sdrImage, error == nil else {
                     Logger.error { "\(window.debugId) \(output == nil) \(error)" }
+                    beginFailureCooldown()
                     if let error { ScreenRecordingPermission.reportCaptureFailure(error) }
                     return
                 }
@@ -148,11 +156,13 @@ class WindowCaptureScreenshots {
 
     private static func captureSampleBuffer(_ filter: SCContentFilter, _ config: SCStreamConfiguration, _ window: Window, _ source: RefreshCausedBy, _ fullRes: Bool) {
         ScreenCaptureCoordinator.shared.submit { completion in
+            guard !isCoolingDown else { completion(); return }
             SCScreenshotManager.captureSampleBuffer(contentFilter: filter, configuration: config) { [weak window] sampleBuffer, error in
                 completion()
                 guard let window else { return }
                 guard let sampleBuffer, error == nil else {
                     Logger.error { "\(window.debugId) \(sampleBuffer == nil) \(error)" }
+                    beginFailureCooldown()
                     if let error { ScreenRecordingPermission.reportCaptureFailure(error) }
                     return
                 }
@@ -182,6 +192,20 @@ class WindowCaptureScreenshots {
             }
         }
     }
+
+    private static var isCoolingDown: Bool {
+        cooldownLock.lock()
+        defer { cooldownLock.unlock() }
+        return cooldownUntil > Date()
+    }
+
+    private static func beginFailureCooldown() {
+        guard ProcessInfo.processInfo.operatingSystemVersion.majorVersion >= 27 else { return }
+        cooldownLock.lock()
+        cooldownUntil = Date().addingTimeInterval(failureCooldown)
+        cooldownLock.unlock()
+        Logger.warning { "ScreenCaptureKit capture paused for \(failureCooldown)s after an error" }
+    }
 }
 
 class WindowCaptureScreenshotsPrivateApi {
@@ -210,12 +234,27 @@ class WindowCaptureScreenshotsPrivateApi {
 
     private static func oneTimeCapture(_ wid: CGWindowID) -> CGImage? {
         guard !App.isTerminating, !ScreenLockEvents.isScreenLocked else { return nil }
-        // we use CGSHWCaptureWindowList because it can screenshot minimized windows, which CGWindowListCreateImage can't
-        var windowId_ = wid
         ActiveWindowCaptures.increment()
-        let list = CGSHWCaptureWindowList(CGS_CONNECTION, &windowId_, 1, [.ignoreGlobalClipShape, .bestResolution, .fullSize]).takeRetainedValue() as! [CGImage]
-        ActiveWindowCaptures.decrement()
-        return list.first
+        defer { ActiveWindowCaptures.decrement() }
+        return WindowServerCaptureFallback.capture(
+            primary: {
+                var windowId_ = wid
+                let list = CGSHWCaptureWindowList(
+                    CGS_CONNECTION, &windowId_, 1,
+                    [.ignoreGlobalClipShape, .bestResolution, .fullSize]
+                ).takeRetainedValue() as! [CGImage]
+                return list.first
+            },
+            fallback: {
+                Logger.debug {
+                    "CGSHWCaptureWindowList returned no image for wid:\(wid); " +
+                        "using legacy WindowServer capture"
+                }
+                return CGWindowListCreateImageLegacy(
+                    .null, .optionIncludingWindow, wid,
+                    [.boundsIgnoreFraming, .bestResolution]
+                )?.takeRetainedValue()
+            })
     }
 }
 

--- a/src/events/WindowCaptureEventsSpecs.md
+++ b/src/events/WindowCaptureEventsSpecs.md
@@ -2,12 +2,11 @@
 
 ## Summary
 
-One-shot window screenshots for thumbnails and Preview. macOS 26+ captures through ScreenCaptureKit
-(`WindowCaptureScreenshots`); older versions capture through the private `CGSHWCaptureWindowList`
-(`WindowCaptureScreenshotsPrivateApi`), because SCK is unreliable there (macOS 14 crashes inside Apple's
-code, macOS 15 leaks).
+One-shot window screenshots for thumbnails and Preview. macOS 27 routes trusted thumbnails through
+the private `CGSHWCaptureWindowList` path. It keeps ScreenCaptureKit only for full-size Preview frames.
+macOS 26 keeps ScreenCaptureKit for both uses. Older versions use `CGSHWCaptureWindowList`.
 
-## SCK API selection (macOS 26+)
+## SCK API selection
 
 Two public one-shot APIs exist, each broken differently:
 
@@ -26,6 +25,10 @@ Routing: `captureScreenshot` for every window, except fullscreen windows and, wh
 effective settings enable preview-selected-window, all windows (full-resolution path) — those use
 `captureSampleBuffer`.
 
+On macOS 27, this routing applies only to full-size Preview frames. Trusted thumbnails use WindowServer
+to avoid repeated replayd identity resolution. An SCK error keeps the prior image and starts a 15-second
+cooldown. A successful non-prompting preflight does not convert that error into a permission prompt.
+
 ## Edge cases
 
 - **Stale fullscreen state**: `isFullscreen` is snapshotted on the main thread when the burst is built, so
@@ -38,6 +41,8 @@ effective settings enable preview-selected-window, all windows (full-resolution 
 - **Privacy attribution cost is API-independent**: both APIs flip replayd's screen-capture attribution
   (~4 `updateScreenCaptureDidStart` events per capture) and cost systemstatusd the same CPU (measured
   within 2%). Switching APIs fixes the WindowServer leak, not the per-capture attribution overhead.
+- **Background capture disabled**: a closed switcher submits no capture request. Focused-window
+  background capture follows the same setting.
 
 ## Measurements (2026-07-11, macOS 26.5.1, M-series, 29-window payload, 10 switcher cycles per run)
 

--- a/src/events/WindowCaptureRouting.swift
+++ b/src/events/WindowCaptureRouting.swift
@@ -1,0 +1,30 @@
+enum WindowCaptureBackend: Equatable {
+    case screenCaptureKit
+    case windowServer
+}
+
+enum WindowCaptureKind: Equatable {
+    case thumbnail
+    case focusedPreview
+}
+
+enum WindowCaptureRouting {
+    static func backend(macOSMajorVersion: Int, kind: WindowCaptureKind,
+                        hasTrustedGrantHistory: Bool, switcherIsActive: Bool,
+                        backgroundCaptureIsEnabled: Bool) -> WindowCaptureBackend? {
+        guard switcherIsActive || (kind == .thumbnail && backgroundCaptureIsEnabled) else { return nil }
+        if kind == .focusedPreview {
+            return macOSMajorVersion >= 26 ? .screenCaptureKit : .windowServer
+        }
+        if macOSMajorVersion >= 27 && hasTrustedGrantHistory {
+            return .windowServer
+        }
+        return macOSMajorVersion >= 26 ? .screenCaptureKit : .windowServer
+    }
+}
+
+enum WindowServerCaptureFallback {
+    static func capture<Image>(primary: () -> Image?, fallback: () -> Image?) -> Image? {
+        primary() ?? fallback()
+    }
+}

--- a/src/events/WindowCaptureRouting.swift
+++ b/src/events/WindowCaptureRouting.swift
@@ -24,7 +24,13 @@ enum WindowCaptureRouting {
 }
 
 enum WindowServerCaptureFallback {
-    static func capture<Image>(primary: () -> Image?, fallback: () -> Image?) -> Image? {
-        primary() ?? fallback()
+    static func capture<Image>(if isEligible: () -> Bool = { true },
+                               primary: () -> Image?, fallback: () -> Image?) -> Image? {
+        guard isEligible() else { return nil }
+        if let image = primary() {
+            return image
+        }
+        guard isEligible() else { return nil }
+        return fallback()
     }
 }

--- a/src/events/WindowCaptureRoutingSpecs.md
+++ b/src/events/WindowCaptureRoutingSpecs.md
@@ -1,0 +1,25 @@
+# WindowCaptureRouting — Specs
+
+## Summary
+
+The routing policy selects the lowest-risk capture backend for a thumbnail or a focused-window preview.
+It also rejects background work when the user disables background capture.
+
+## Behavior
+
+- macOS 27 uses WindowServer for thumbnails after a trusted Screen Recording grant.
+- macOS 27 uses ScreenCaptureKit for a focused-window preview because that feature needs a full-size frame.
+- macOS 26 keeps the existing ScreenCaptureKit thumbnail backend.
+- macOS 25 and older keep the existing WindowServer thumbnail backend.
+- A closed switcher with background capture disabled gets no backend and submits no capture request.
+- A focused-window preview needs an active switcher.
+
+## Test scenarios
+
+- `testMacOS27UsesWindowServerForTrustedThumbnails`
+- `testMacOS27UsesScreenCaptureKitForFocusedPreview`
+- `testMacOS26KeepsScreenCaptureKitThumbnailBackend`
+- `testOlderMacOSKeepsWindowServerThumbnailBackend`
+- `testBackgroundCaptureDisabledReturnsNoBackend`
+- `testBackgroundCaptureEnabledUsesSafeMacOS27Backend`
+- `testFocusedPreviewNeedsAnActiveSwitcher`

--- a/src/events/WindowCaptureRoutingSpecs.md
+++ b/src/events/WindowCaptureRoutingSpecs.md
@@ -13,6 +13,10 @@ It also rejects background work when the user disables background capture.
 - macOS 25 and older keep the existing WindowServer thumbnail backend.
 - A closed switcher with background capture disabled gets no backend and submits no capture request.
 - A focused-window preview needs an active switcher.
+- A queued WindowServer capture rechecks current switcher, background preference, termination,
+  lock, and non-prompting permission state immediately before calling the capture backend.
+- An empty primary result rechecks the same state before trying the fallback, because the
+  first capture can block while the switcher closes.
 
 ## Test scenarios
 
@@ -23,3 +27,5 @@ It also rejects background work when the user disables background capture.
 - `testBackgroundCaptureDisabledReturnsNoBackend`
 - `testBackgroundCaptureEnabledUsesSafeMacOS27Backend`
 - `testFocusedPreviewNeedsAnActiveSwitcher`
+- `testQueuedCaptureChecksCurrentEligibility`
+- `testFallbackRechecksEligibilityAfterPrimaryReturns`

--- a/src/events/WindowCaptureRoutingTests.swift
+++ b/src/events/WindowCaptureRoutingTests.swift
@@ -1,6 +1,26 @@
 import XCTest
 
 final class WindowCaptureRoutingTests: XCTestCase {
+    func testSwitcherSessionActivityStateTracksUpdates() {
+        let activity = SwitcherSessionActivity()
+
+        XCTAssertFalse(activity.isActive)
+        activity.setActive(true)
+        XCTAssertTrue(activity.isActive)
+        activity.setActive(false)
+        XCTAssertFalse(activity.isActive)
+    }
+
+    func testSwitcherSessionActivityStateIsVisibleAcrossQueues() {
+        let activity = SwitcherSessionActivity()
+        let queue = DispatchQueue(label: "SwitcherSessionActivityTests")
+
+        activity.setActive(true)
+        XCTAssertTrue(queue.sync { activity.isActive })
+        queue.sync { activity.setActive(false) }
+        XCTAssertFalse(activity.isActive)
+    }
+
     func testWindowServerCaptureUsesPrimaryImage() {
         var fallbackCalls = 0
 

--- a/src/events/WindowCaptureRoutingTests.swift
+++ b/src/events/WindowCaptureRoutingTests.swift
@@ -29,7 +29,8 @@ final class WindowCaptureRoutingTests: XCTestCase {
             fallback: {
                 fallbackCalls += 1
                 return "fallback"
-            })
+            }
+        )
 
         XCTAssertEqual(image, "primary")
         XCTAssertEqual(fallbackCalls, 0)
@@ -43,7 +44,8 @@ final class WindowCaptureRoutingTests: XCTestCase {
             fallback: {
                 fallbackCalls += 1
                 return "fallback"
-            })
+            }
+        )
 
         XCTAssertEqual(image, "fallback")
         XCTAssertEqual(fallbackCalls, 1)
@@ -52,7 +54,8 @@ final class WindowCaptureRoutingTests: XCTestCase {
     func testWindowServerCaptureStaysEmptyWhenBothMethodsFail() {
         let image = WindowServerCaptureFallback.capture(
             primary: { nil as String? },
-            fallback: { nil as String? })
+            fallback: { nil as String? }
+        )
 
         XCTAssertNil(image)
     }
@@ -63,7 +66,8 @@ final class WindowCaptureRoutingTests: XCTestCase {
             kind: .thumbnail,
             hasTrustedGrantHistory: true,
             switcherIsActive: true,
-            backgroundCaptureIsEnabled: false), .windowServer)
+            backgroundCaptureIsEnabled: false
+        ), .windowServer)
     }
 
     func testMacOS27UsesScreenCaptureKitForFocusedPreview() {
@@ -72,7 +76,8 @@ final class WindowCaptureRoutingTests: XCTestCase {
             kind: .focusedPreview,
             hasTrustedGrantHistory: true,
             switcherIsActive: true,
-            backgroundCaptureIsEnabled: false), .screenCaptureKit)
+            backgroundCaptureIsEnabled: false
+        ), .screenCaptureKit)
     }
 
     func testMacOS26KeepsScreenCaptureKitThumbnailBackend() {
@@ -81,7 +86,8 @@ final class WindowCaptureRoutingTests: XCTestCase {
             kind: .thumbnail,
             hasTrustedGrantHistory: true,
             switcherIsActive: true,
-            backgroundCaptureIsEnabled: false), .screenCaptureKit)
+            backgroundCaptureIsEnabled: false
+        ), .screenCaptureKit)
     }
 
     func testOlderMacOSKeepsWindowServerThumbnailBackend() {
@@ -90,7 +96,8 @@ final class WindowCaptureRoutingTests: XCTestCase {
             kind: .thumbnail,
             hasTrustedGrantHistory: true,
             switcherIsActive: true,
-            backgroundCaptureIsEnabled: false), .windowServer)
+            backgroundCaptureIsEnabled: false
+        ), .windowServer)
     }
 
     func testBackgroundCaptureDisabledReturnsNoBackend() {
@@ -99,7 +106,8 @@ final class WindowCaptureRoutingTests: XCTestCase {
             kind: .thumbnail,
             hasTrustedGrantHistory: true,
             switcherIsActive: false,
-            backgroundCaptureIsEnabled: false))
+            backgroundCaptureIsEnabled: false
+        ))
     }
 
     func testBackgroundCaptureEnabledUsesSafeMacOS27Backend() {
@@ -108,7 +116,8 @@ final class WindowCaptureRoutingTests: XCTestCase {
             kind: .thumbnail,
             hasTrustedGrantHistory: true,
             switcherIsActive: false,
-            backgroundCaptureIsEnabled: true), .windowServer)
+            backgroundCaptureIsEnabled: true
+        ), .windowServer)
     }
 
     func testFocusedPreviewNeedsAnActiveSwitcher() {
@@ -117,6 +126,7 @@ final class WindowCaptureRoutingTests: XCTestCase {
             kind: .focusedPreview,
             hasTrustedGrantHistory: true,
             switcherIsActive: false,
-            backgroundCaptureIsEnabled: true))
+            backgroundCaptureIsEnabled: true
+        ))
     }
 }

--- a/src/events/WindowCaptureRoutingTests.swift
+++ b/src/events/WindowCaptureRoutingTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+
+final class WindowCaptureRoutingTests: XCTestCase {
+    func testWindowServerCaptureUsesPrimaryImage() {
+        var fallbackCalls = 0
+
+        let image = WindowServerCaptureFallback.capture(
+            primary: { "primary" },
+            fallback: {
+                fallbackCalls += 1
+                return "fallback"
+            })
+
+        XCTAssertEqual(image, "primary")
+        XCTAssertEqual(fallbackCalls, 0)
+    }
+
+    func testWindowServerCaptureUsesFallbackWhenPrimaryIsEmpty() {
+        var fallbackCalls = 0
+
+        let image = WindowServerCaptureFallback.capture(
+            primary: { nil as String? },
+            fallback: {
+                fallbackCalls += 1
+                return "fallback"
+            })
+
+        XCTAssertEqual(image, "fallback")
+        XCTAssertEqual(fallbackCalls, 1)
+    }
+
+    func testWindowServerCaptureStaysEmptyWhenBothMethodsFail() {
+        let image = WindowServerCaptureFallback.capture(
+            primary: { nil as String? },
+            fallback: { nil as String? })
+
+        XCTAssertNil(image)
+    }
+
+    func testMacOS27UsesWindowServerForTrustedThumbnails() {
+        XCTAssertEqual(WindowCaptureRouting.backend(
+            macOSMajorVersion: 27,
+            kind: .thumbnail,
+            hasTrustedGrantHistory: true,
+            switcherIsActive: true,
+            backgroundCaptureIsEnabled: false), .windowServer)
+    }
+
+    func testMacOS27UsesScreenCaptureKitForFocusedPreview() {
+        XCTAssertEqual(WindowCaptureRouting.backend(
+            macOSMajorVersion: 27,
+            kind: .focusedPreview,
+            hasTrustedGrantHistory: true,
+            switcherIsActive: true,
+            backgroundCaptureIsEnabled: false), .screenCaptureKit)
+    }
+
+    func testMacOS26KeepsScreenCaptureKitThumbnailBackend() {
+        XCTAssertEqual(WindowCaptureRouting.backend(
+            macOSMajorVersion: 26,
+            kind: .thumbnail,
+            hasTrustedGrantHistory: true,
+            switcherIsActive: true,
+            backgroundCaptureIsEnabled: false), .screenCaptureKit)
+    }
+
+    func testOlderMacOSKeepsWindowServerThumbnailBackend() {
+        XCTAssertEqual(WindowCaptureRouting.backend(
+            macOSMajorVersion: 25,
+            kind: .thumbnail,
+            hasTrustedGrantHistory: true,
+            switcherIsActive: true,
+            backgroundCaptureIsEnabled: false), .windowServer)
+    }
+
+    func testBackgroundCaptureDisabledReturnsNoBackend() {
+        XCTAssertNil(WindowCaptureRouting.backend(
+            macOSMajorVersion: 27,
+            kind: .thumbnail,
+            hasTrustedGrantHistory: true,
+            switcherIsActive: false,
+            backgroundCaptureIsEnabled: false))
+    }
+
+    func testBackgroundCaptureEnabledUsesSafeMacOS27Backend() {
+        XCTAssertEqual(WindowCaptureRouting.backend(
+            macOSMajorVersion: 27,
+            kind: .thumbnail,
+            hasTrustedGrantHistory: true,
+            switcherIsActive: false,
+            backgroundCaptureIsEnabled: true), .windowServer)
+    }
+
+    func testFocusedPreviewNeedsAnActiveSwitcher() {
+        XCTAssertNil(WindowCaptureRouting.backend(
+            macOSMajorVersion: 27,
+            kind: .focusedPreview,
+            hasTrustedGrantHistory: true,
+            switcherIsActive: false,
+            backgroundCaptureIsEnabled: true))
+    }
+}

--- a/src/events/WindowServerCaptureFallbackTests.swift
+++ b/src/events/WindowServerCaptureFallbackTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+final class WindowServerCaptureFallbackTests: XCTestCase {
+    func testQueuedCaptureChecksCurrentEligibility() {
+        var isEligible = true
+        var captures = 0
+        let queuedCapture = {
+            WindowServerCaptureFallback.capture(
+                if: { isEligible },
+                primary: { captures += 1; return "primary" },
+                fallback: { captures += 1; return "fallback" }
+            )
+        }
+        isEligible = false
+        XCTAssertNil(queuedCapture())
+        XCTAssertEqual(captures, 0)
+    }
+
+    func testFallbackRechecksEligibilityAfterPrimaryReturns() {
+        var isEligible = true
+        var fallbackCalls = 0
+        let image = WindowServerCaptureFallback.capture(
+            if: { isEligible },
+            primary: { isEligible = false; return nil as String? },
+            fallback: { fallbackCalls += 1; return "fallback" }
+        )
+        XCTAssertNil(image)
+        XCTAssertEqual(fallbackCalls, 0)
+    }
+}

--- a/src/macos/PermissionCalloutResolverSpecs.md
+++ b/src/macos/PermissionCalloutResolverSpecs.md
@@ -24,9 +24,8 @@ kernel deciding when the callout is worth showing and which feature(s) it names,
 - **The two inputs are independent dimensions.** The callout shows only at their intersection:
   permission missing **and** at least one feature depends on Screen Recording. The combinations where
   the permission is granted, or where `dependentFeatures` is `.none`, all hide it.
-- **`screenRecordingGranted` collapses three permission states into two.** Production passes
-  `ScreenRecordingPermission.status == .granted`, so both `.skipped` (user opted out) and
-  `.notGranted` (never granted) map to `false` → "permission missing". They behave identically.
+- **`screenRecordingGranted` hides temporary failures.** Production passes `false` only for
+  `.skipped` or a confirmed `.notGranted` state. A temporary probe failure does not show the callout.
 - **`dependentFeatures` is an OR of each flag across all shortcut slots.** Production computes it as
   `Preferences.screenRecordingDependentFeatures`, which OR-s the Thumbnails flag and the Preview flag
   independently over every shortcut (`0...maxShortcutCount`) using the *effective* per-shortcut

--- a/src/macos/PermissionCalloutResolverTests.swift
+++ b/src/macos/PermissionCalloutResolverTests.swift
@@ -11,8 +11,9 @@ import XCTest
 ///     / previews / both)?
 ///   - `shouldShowCallout` — given the permission state and the affected features, show?
 ///
-/// Production wires these to real state: `screenRecordingGranted` is `ScreenRecordingPermission.status
-/// == .granted` (so both `.skipped` and `.notGranted` map to `false`), and `dependentFeatures` is
+/// Production wires these to real state: `screenRecordingGranted` is false only for `.skipped` or a
+/// confirmed `.notGranted` state. A temporary probe failure stays true and does not show the callout.
+/// `dependentFeatures` is
 /// `Preferences.screenRecordingDependentFeatures`, which OR-s each feature flag over every shortcut
 /// slot — so a per-shortcut override that enables Thumbnails/Preview on any one slot flips it on.
 /// The shown copy reuses the existing "Thumbnails" translation; only the subject of the sentence varies.

--- a/src/macos/ScreenRecordingAuthorization.swift
+++ b/src/macos/ScreenRecordingAuthorization.swift
@@ -1,5 +1,34 @@
 import Foundation
 
+final class ScreenRecordingAuthorizationStore {
+    private let lock = NSLock()
+    private var model: ScreenRecordingAuthorizationModel
+    private var isSkipped = false
+
+    init(wasGranted: Bool) {
+        model = ScreenRecordingAuthorizationModel(wasGranted: wasGranted)
+    }
+
+    var snapshot: (model: ScreenRecordingAuthorizationModel, isSkipped: Bool) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (model, isSkipped)
+    }
+
+    func skip() {
+        lock.lock()
+        isSkipped = true
+        lock.unlock()
+    }
+
+    func receive(_ result: ScreenRecordingProbeResult) -> [ScreenRecordingAuthorizationEffect] {
+        lock.lock()
+        defer { lock.unlock() }
+        isSkipped = false
+        return model.receive(result)
+    }
+}
+
 enum ScreenRecordingProbeFailure: Equatable {
     case timeout
     case screenCaptureKit(domain: String, code: Int)

--- a/src/macos/ScreenRecordingAuthorization.swift
+++ b/src/macos/ScreenRecordingAuthorization.swift
@@ -67,25 +67,25 @@ struct ScreenRecordingAuthorizationModel {
 
     mutating func receive(_ result: ScreenRecordingProbeResult) -> [ScreenRecordingAuthorizationEffect] {
         switch result {
-            case .granted:
-                let mustPersist = !wasGranted
-                wasGranted = true
-                failedChecks = 0
-                state = .granted
-                return (mustPersist ? [.persistGrant] : []) + [.cancelConfirmations]
-            case .notGranted where !wasGranted && state == .unknown:
+        case .granted:
+            let mustPersist = !wasGranted
+            wasGranted = true
+            failedChecks = 0
+            state = .granted
+            return (mustPersist ? [.persistGrant] : []) + [.cancelConfirmations]
+        case .notGranted where !wasGranted && state == .unknown:
+            state = .needsUserReview
+            return [.openOnboarding]
+        case .notGranted, .temporarilyUnavailable:
+            failedChecks += 1
+            if failedChecks >= 3 {
                 state = .needsUserReview
-                return [.openOnboarding]
-            case .notGranted, .temporarilyUnavailable:
-                failedChecks += 1
-                if failedChecks >= 3 {
-                    state = .needsUserReview
-                    return [.showPassiveReview]
-                }
-                state = .temporarilyUnavailable
-                return failedChecks == 1
-                    ? [.scheduleConfirmation(after: 10), .scheduleConfirmation(after: 30)]
-                    : []
+                return [.showPassiveReview]
+            }
+            state = .temporarilyUnavailable
+            return failedChecks == 1
+                ? [.scheduleConfirmation(after: 10), .scheduleConfirmation(after: 30)]
+                : []
         }
     }
 }

--- a/src/macos/ScreenRecordingAuthorization.swift
+++ b/src/macos/ScreenRecordingAuthorization.swift
@@ -1,0 +1,62 @@
+import Foundation
+
+enum ScreenRecordingProbeFailure: Equatable {
+    case timeout
+    case screenCaptureKit(domain: String, code: Int)
+}
+
+enum ScreenRecordingProbeResult: Equatable {
+    case granted
+    case notGranted
+    case temporarilyUnavailable(ScreenRecordingProbeFailure)
+}
+
+enum ScreenRecordingAuthorizationState: Equatable {
+    case unknown
+    case granted
+    case temporarilyUnavailable
+    case needsUserReview
+}
+
+enum ScreenRecordingAuthorizationEffect: Equatable {
+    case persistGrant
+    case scheduleConfirmation(after: TimeInterval)
+    case cancelConfirmations
+    case openOnboarding
+    case showPassiveReview
+}
+
+struct ScreenRecordingAuthorizationModel {
+    private(set) var state: ScreenRecordingAuthorizationState
+    private(set) var wasGranted: Bool
+    private var failedChecks = 0
+
+    init(wasGranted: Bool) {
+        self.wasGranted = wasGranted
+        state = wasGranted ? .granted : .unknown
+    }
+
+    mutating func receive(_ result: ScreenRecordingProbeResult) -> [ScreenRecordingAuthorizationEffect] {
+        switch result {
+            case .granted:
+                let mustPersist = !wasGranted
+                wasGranted = true
+                failedChecks = 0
+                state = .granted
+                return (mustPersist ? [.persistGrant] : []) + [.cancelConfirmations]
+            case .notGranted where !wasGranted && state == .unknown:
+                state = .needsUserReview
+                return [.openOnboarding]
+            case .notGranted, .temporarilyUnavailable:
+                failedChecks += 1
+                if failedChecks >= 3 {
+                    state = .needsUserReview
+                    return [.showPassiveReview]
+                }
+                state = .temporarilyUnavailable
+                return failedChecks == 1
+                    ? [.scheduleConfirmation(after: 10), .scheduleConfirmation(after: 30)]
+                    : []
+        }
+    }
+}

--- a/src/macos/ScreenRecordingAuthorizationSpecs.md
+++ b/src/macos/ScreenRecordingAuthorizationSpecs.md
@@ -15,6 +15,8 @@ It separates a first-use denial from a timeout or a later failure.
 - Only a first-use denial requests the normal onboarding permission window.
 - A confirmed failure after a known grant requests only passive review UI.
 - ScreenCaptureKit error domain and code data stay in the probe result.
+- UI and capture workers read locked snapshots. The lock is never held across a system permission call.
+- Timer checks, capture-failure handling, and confirmation work run on the serial permission operation queue, not directly on its concurrent underlying queue.
 
 ## Test scenarios
 
@@ -22,3 +24,4 @@ It separates a first-use denial from a timeout or a later failure.
 - `testFirstUseDenialOpensOnboarding`
 - `testConfirmedLaterFailureUsesPassiveReview`
 - `testRecoveryCancelsConfirmationPeriod`
+- `testConcurrentGrantUpdatesKeepTrustedSnapshot`

--- a/src/macos/ScreenRecordingAuthorizationSpecs.md
+++ b/src/macos/ScreenRecordingAuthorizationSpecs.md
@@ -1,0 +1,24 @@
+# ScreenRecordingAuthorization — Specs
+
+## Summary
+
+The model keeps a valid Screen Recording grant trusted during a short macOS capture-service failure.
+It separates a first-use denial from a timeout or a later failure.
+
+## Behavior
+
+- A successful probe changes the state to `granted` and cancels confirmation checks.
+- A timeout after a known grant changes the state to `temporarilyUnavailable`.
+- The failed check at time 0 schedules non-prompting checks at 10 and 30 seconds.
+- A successful confirmation restores `granted` and cancels remaining checks.
+- Three failed checks across 30 seconds change the state to `needsUserReview`.
+- Only a first-use denial requests the normal onboarding permission window.
+- A confirmed failure after a known grant requests only passive review UI.
+- ScreenCaptureKit error domain and code data stay in the probe result.
+
+## Test scenarios
+
+- `testPermissionTimeoutAfterKnownGrantIsTemporary`
+- `testFirstUseDenialOpensOnboarding`
+- `testConfirmedLaterFailureUsesPassiveReview`
+- `testRecoveryCancelsConfirmationPeriod`

--- a/src/macos/ScreenRecordingAuthorizationTests.swift
+++ b/src/macos/ScreenRecordingAuthorizationTests.swift
@@ -47,7 +47,10 @@ final class ScreenRecordingAuthorizationTests: XCTestCase {
 
     func testRecoveryCancelsConfirmationPeriod() {
         var model = ScreenRecordingAuthorizationModel(wasGranted: true)
-        _ = model.receive(.temporarilyUnavailable(.screenCaptureKit(domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain", code: -3811)))
+        _ = model.receive(.temporarilyUnavailable(.screenCaptureKit(
+            domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain",
+            code: -3811
+        )))
 
         let effects = model.receive(.granted)
 

--- a/src/macos/ScreenRecordingAuthorizationTests.swift
+++ b/src/macos/ScreenRecordingAuthorizationTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+
+final class ScreenRecordingAuthorizationTests: XCTestCase {
+    func testPermissionTimeoutAfterKnownGrantIsTemporary() {
+        var model = ScreenRecordingAuthorizationModel(wasGranted: true)
+
+        let effects = model.receive(.temporarilyUnavailable(.timeout))
+
+        XCTAssertEqual(model.state, .temporarilyUnavailable)
+        XCTAssertEqual(effects, [.scheduleConfirmation(after: 10), .scheduleConfirmation(after: 30)])
+        XCTAssertFalse(effects.contains(.openOnboarding))
+    }
+
+    func testFirstUseDenialOpensOnboarding() {
+        var model = ScreenRecordingAuthorizationModel(wasGranted: false)
+
+        let effects = model.receive(.notGranted)
+
+        XCTAssertEqual(model.state, .needsUserReview)
+        XCTAssertEqual(effects, [.openOnboarding])
+    }
+
+    func testConfirmedLaterFailureUsesPassiveReview() {
+        var model = ScreenRecordingAuthorizationModel(wasGranted: true)
+
+        _ = model.receive(.notGranted)
+        _ = model.receive(.notGranted)
+        let effects = model.receive(.notGranted)
+
+        XCTAssertEqual(model.state, .needsUserReview)
+        XCTAssertEqual(effects, [.showPassiveReview])
+        XCTAssertFalse(effects.contains(.openOnboarding))
+    }
+
+    func testRecoveryCancelsConfirmationPeriod() {
+        var model = ScreenRecordingAuthorizationModel(wasGranted: true)
+        _ = model.receive(.temporarilyUnavailable(.screenCaptureKit(domain: "com.apple.ScreenCaptureKit.SCStreamErrorDomain", code: -3811)))
+
+        let effects = model.receive(.granted)
+
+        XCTAssertEqual(model.state, .granted)
+        XCTAssertEqual(effects, [.cancelConfirmations])
+        XCTAssertTrue(model.wasGranted)
+    }
+}

--- a/src/macos/ScreenRecordingAuthorizationTests.swift
+++ b/src/macos/ScreenRecordingAuthorizationTests.swift
@@ -1,6 +1,19 @@
 import XCTest
 
 final class ScreenRecordingAuthorizationTests: XCTestCase {
+    func testConcurrentGrantUpdatesKeepTrustedSnapshot() {
+        let store = ScreenRecordingAuthorizationStore(wasGranted: false)
+        DispatchQueue.concurrentPerform(iterations: 200) { _ in
+            _ = store.receive(.granted)
+            XCTAssertTrue(store.snapshot.model.wasGranted)
+            XCTAssertEqual(store.snapshot.model.state, .granted)
+        }
+        store.skip()
+        XCTAssertTrue(store.snapshot.isSkipped)
+        _ = store.receive(.granted)
+        XCTAssertFalse(store.snapshot.isSkipped)
+    }
+
     func testPermissionTimeoutAfterKnownGrantIsTemporary() {
         var model = ScreenRecordingAuthorizationModel(wasGranted: true)
 

--- a/src/macos/SystemPermissions.swift
+++ b/src/macos/SystemPermissions.swift
@@ -134,16 +134,19 @@ class AccessibilityPermission {
 }
 
 class ScreenRecordingPermission {
-    private static let authorization = ScreenRecordingAuthorizationStore(wasGranted: Preferences.screenRecordingPermissionWasGranted)
+    private static let authorization =
+        ScreenRecordingAuthorizationStore(wasGranted: Preferences.screenRecordingPermissionWasGranted)
     private static var confirmationWorkItems = [DispatchWorkItem]()
 
     static var status: PermissionStatus {
         let snapshot = authorization.snapshot
-        if snapshot.isSkipped { return .skipped }
+        if snapshot.isSkipped {
+            return .skipped
+        }
         switch snapshot.model.state {
-            case .unknown, .needsUserReview: return .notGranted
-            case .granted: return .granted
-            case .temporarilyUnavailable: return .temporarilyUnavailable
+        case .unknown, .needsUserReview: return .notGranted
+        case .granted: return .granted
+        case .temporarilyUnavailable: return .temporarilyUnavailable
         }
     }
 
@@ -201,20 +204,26 @@ class ScreenRecordingPermission {
         return .granted
     }
 
-    // This first-use probe can show the normal macOS permission prompt. No post-grant or background
-    // path calls it. Known grants use only CGPreflightScreenCaptureAccess above.
+    /// This first-use probe can show the normal macOS permission prompt. No post-grant or background
+    /// path calls it. Known grants use only CGPreflightScreenCaptureAccess above.
     private static func firstUseProbe() -> ScreenRecordingProbeResult {
         if #available(macOS 12.3, *) {
             return checkWithSCShareableContent()
         } else {
             let mainDisplayID = CGMainDisplayID()
             var lastFailure = checkWithCGDisplayStream(mainDisplayID)
-            if lastFailure == .granted { return .granted }
+            if lastFailure == .granted {
+                return .granted
+            }
             for screen in NSScreen.screens {
                 if let id = screen.number(), id != mainDisplayID {
                     let result = checkWithCGDisplayStream(id)
-                    if result == .granted { return .granted }
-                    if case .temporarilyUnavailable = result { lastFailure = result }
+                    if result == .granted {
+                        return .granted
+                    }
+                    if case .temporarilyUnavailable = result {
+                        lastFailure = result
+                    }
                 }
             }
             return lastFailure
@@ -225,23 +234,32 @@ class ScreenRecordingPermission {
     private static func checkWithSCShareableContent() -> ScreenRecordingProbeResult {
         return runWithTimeout { completion in
             ScreenCaptureCoordinator.shared.submit { captureCompletion in
-                SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
+                SCShareableContent.getExcludingDesktopWindows(true,
+                                                              onScreenWindowsOnly: false) { shareableContent, error in
                     captureCompletion()
                     if #available(macOS 14.0, *), let shareableContent, error == nil {
                         BackgroundWork.screenshotsQueue.addOperation {
-                            WindowCaptureScreenshots.cachedSCWindows.withLock { $0 = shareableContent.windows }
+                            WindowCaptureScreenshots.cachedSCWindows.withLock { $0 = shareableContent.windows
+                            }
                         }
                     }
                     if let error {
                         let nsError = error as NSError
-                        if nsError.domain == SCStreamErrorDomain && nsError.code == SCStreamError.Code.userDeclined.rawValue {
+                        if nsError.domain == SCStreamErrorDomain &&
+                            nsError.code == SCStreamError.Code.userDeclined.rawValue {
                             completion(.notGranted)
                         } else {
-                            completion(.temporarilyUnavailable(.screenCaptureKit(domain: nsError.domain, code: nsError.code)))
+                            completion(.temporarilyUnavailable(.screenCaptureKit(
+                                domain: nsError.domain,
+                                code: nsError.code
+                            )))
                         }
                     } else {
                         completion(shareableContent == nil
-                            ? .temporarilyUnavailable(.screenCaptureKit(domain: SCStreamErrorDomain, code: -1))
+                            ? .temporarilyUnavailable(.screenCaptureKit(
+                                domain: SCStreamErrorDomain,
+                                code: -1
+                            ))
                             : .granted)
                     }
                 }
@@ -263,7 +281,8 @@ class ScreenRecordingPermission {
         }
     }
 
-    private static func runWithTimeout(_ block: @escaping (@escaping (ScreenRecordingProbeResult) -> Void) -> Void) -> ScreenRecordingProbeResult {
+    private static func runWithTimeout(_ block: @escaping (@escaping (ScreenRecordingProbeResult) -> Void)
+        -> Void) -> ScreenRecordingProbeResult {
         let semaphore = DispatchSemaphore(value: 0)
         let lock = NSLock()
         var result: ScreenRecordingProbeResult?
@@ -297,16 +316,16 @@ class ScreenRecordingPermission {
     private static func apply(_ effects: [ScreenRecordingAuthorizationEffect]) {
         for effect in effects {
             switch effect {
-                case .persistGrant:
-                    Preferences.set("screenRecordingPermissionWasGranted", "true", false)
-                case let .scheduleConfirmation(after: delay):
-                    scheduleConfirmation(after: delay)
-                case .cancelConfirmations:
-                    cancelConfirmations()
-                case .openOnboarding:
-                    break
-                case .showPassiveReview:
-                    cancelConfirmations()
+            case .persistGrant:
+                Preferences.set("screenRecordingPermissionWasGranted", "true", false)
+            case let .scheduleConfirmation(after: delay):
+                scheduleConfirmation(after: delay)
+            case .cancelConfirmations:
+                cancelConfirmations()
+            case .openOnboarding:
+                break
+            case .showPassiveReview:
+                cancelConfirmations()
             }
         }
     }
@@ -329,7 +348,9 @@ class ScreenRecordingPermission {
     private static func refreshPermissionUi() {
         DispatchQueue.main.async {
             Menubar.refreshPermissionCallout()
-            if PermissionsWindow.shared != nil { PermissionsWindow.updatePermissionViews() }
+            if PermissionsWindow.shared != nil {
+                PermissionsWindow.updatePermissionViews()
+            }
         }
     }
 }

--- a/src/macos/SystemPermissions.swift
+++ b/src/macos/SystemPermissions.swift
@@ -21,7 +21,9 @@ class SystemPermissions {
 
     static func ensurePermissionsAreGranted() {
         timer = DispatchSource.makeTimerSource(queue: BackgroundWork.permissionsCheckOnTimerQueue.strongUnderlyingQueue)
-        timer.setEventHandler(handler: checkPermissionsOnTimer)
+        timer.setEventHandler {
+            BackgroundWork.permissionsCheckOnTimerQueue.addOperation { checkPermissionsOnTimer() }
+        }
         setImmediateTimer()
         timer.resume()
     }
@@ -132,16 +134,25 @@ class AccessibilityPermission {
 }
 
 class ScreenRecordingPermission {
-    static var status = PermissionStatus.notGranted
-    private static var authorization = ScreenRecordingAuthorizationModel(wasGranted: Preferences.screenRecordingPermissionWasGranted)
+    private static let authorization = ScreenRecordingAuthorizationStore(wasGranted: Preferences.screenRecordingPermissionWasGranted)
     private static var confirmationWorkItems = [DispatchWorkItem]()
 
+    static var status: PermissionStatus {
+        let snapshot = authorization.snapshot
+        if snapshot.isSkipped { return .skipped }
+        switch snapshot.model.state {
+            case .unknown, .needsUserReview: return .notGranted
+            case .granted: return .granted
+            case .temporarilyUnavailable: return .temporarilyUnavailable
+        }
+    }
+
     static var canContinueLaunch: Bool {
-        status != .notGranted || authorization.wasGranted
+        status != .notGranted || hasTrustedGrantHistory
     }
 
     static var hasTrustedGrantHistory: Bool {
-        authorization.wasGranted
+        authorization.snapshot.model.wasGranted
     }
 
     static var shouldShowPassiveReview: Bool {
@@ -157,9 +168,9 @@ class ScreenRecordingPermission {
                     receive(.granted)
                 } else {
                     cancelConfirmations()
-                    status = .skipped
+                    authorization.skip()
                 }
-            } else if authorization.wasGranted {
+            } else if hasTrustedGrantHistory {
                 receive(nonPromptingProbe())
             } else {
                 receive(firstUseProbe())
@@ -171,13 +182,13 @@ class ScreenRecordingPermission {
     }
 
     static func reportCaptureFailure(_ error: Error) {
-        guard #available(macOS 10.15, *), authorization.wasGranted else { return }
+        guard #available(macOS 10.15, *), hasTrustedGrantHistory else { return }
         let nsError = error as NSError
         Logger.error { "ScreenCaptureKit capture failed domain:\(nsError.domain) code:\(nsError.code)" }
         BackgroundWork.permissionsCheckOnTimerQueue.addOperation {
             guard confirmationWorkItems.isEmpty else { return }
-            // A successful preflight proves that the capture error is not a permission revocation.
-            // Keep the trusted state. Capture routing applies its own cooldown.
+            // A successful preflight is not evidence of revocation. Keep trusted state and
+            // let capture routing apply its cooldown; macOS can return a cached preflight result.
             guard !CGPreflightScreenCaptureAccess() else { return }
             receive(.temporarilyUnavailable(.screenCaptureKit(domain: nsError.domain, code: nsError.code)))
         }
@@ -279,12 +290,6 @@ class ScreenRecordingPermission {
             Logger.error { "Screen-recording permission probe is temporarily unavailable: \(failure)" }
         }
         let effects = authorization.receive(result)
-        switch authorization.state {
-            case .unknown: status = .temporarilyUnavailable
-            case .granted: status = .granted
-            case .temporarilyUnavailable: status = .temporarilyUnavailable
-            case .needsUserReview: status = .notGranted
-        }
         apply(effects)
         refreshPermissionUi()
     }
@@ -311,7 +316,9 @@ class ScreenRecordingPermission {
             receive(nonPromptingProbe())
         }
         confirmationWorkItems.append(workItem)
-        BackgroundWork.permissionsCheckOnTimerQueue.strongUnderlyingQueue.asyncAfter(deadline: .now() + delay, execute: workItem)
+        BackgroundWork.permissionsCheckOnTimerQueue.addOperationAfter(deadline: .now() + delay) {
+            workItem.perform()
+        }
     }
 
     private static func cancelConfirmations() {

--- a/src/macos/SystemPermissions.swift
+++ b/src/macos/SystemPermissions.swift
@@ -68,7 +68,7 @@ class SystemPermissions {
     }
 
     private static func checkPermissionsPreStartup() {
-        if AccessibilityPermission.status != .notGranted && ScreenRecordingPermission.status != .notGranted {
+        if AccessibilityPermission.status != .notGranted && ScreenRecordingPermission.canContinueLaunch {
             DispatchQueue.main.async {
                 preStartupPermissionsPassed = true
                 PermissionsWindow.shared?.close()
@@ -133,74 +133,110 @@ class AccessibilityPermission {
 
 class ScreenRecordingPermission {
     static var status = PermissionStatus.notGranted
+    private static var authorization = ScreenRecordingAuthorizationModel(wasGranted: Preferences.screenRecordingPermissionWasGranted)
+    private static var confirmationWorkItems = [DispatchWorkItem]()
+
+    static var canContinueLaunch: Bool {
+        status != .notGranted || authorization.wasGranted
+    }
+
+    static var hasTrustedGrantHistory: Bool {
+        authorization.wasGranted
+    }
+
+    static var shouldShowPassiveReview: Bool {
+        status == .notGranted || status == .skipped
+    }
 
     @discardableResult
     static func update() -> PermissionStatus {
-        status = detect()
+        guard confirmationWorkItems.isEmpty else { return status }
+        if #available(macOS 10.15, *) {
+            if Preferences.screenRecordingPermissionSkipped {
+                if CGPreflightScreenCaptureAccess() {
+                    receive(.granted)
+                } else {
+                    cancelConfirmations()
+                    status = .skipped
+                }
+            } else if authorization.wasGranted {
+                receive(nonPromptingProbe())
+            } else {
+                receive(firstUseProbe())
+            }
+        } else {
+            receive(.granted)
+        }
         return status
     }
 
-    private static func detect() -> PermissionStatus {
+    static func reportCaptureFailure(_ error: Error) {
+        guard #available(macOS 10.15, *), authorization.wasGranted else { return }
+        let nsError = error as NSError
+        Logger.error { "ScreenCaptureKit capture failed domain:\(nsError.domain) code:\(nsError.code)" }
+        BackgroundWork.permissionsCheckOnTimerQueue.addOperation {
+            guard confirmationWorkItems.isEmpty else { return }
+            // A successful preflight proves that the capture error is not a permission revocation.
+            // Keep the trusted state. Capture routing applies its own cooldown.
+            guard !CGPreflightScreenCaptureAccess() else { return }
+            receive(.temporarilyUnavailable(.screenCaptureKit(domain: nsError.domain, code: nsError.code)))
+        }
+    }
+
+    private static func nonPromptingProbe() -> ScreenRecordingProbeResult {
         if #available(macOS 10.15, *) {
-            // The user opted out of the prompt (#5548), so we must not call isGrantedOnSomeDisplay()
-            // here — it shows the system prompt when ungranted. But probing silently with the
-            // non-prompting preflight lets us still pick up a permission granted later in System
-            // Settings, instead of staying stuck on app-icons-only forever (#5739). The skip flag
-            // only downgrades .notGranted to .skipped to suppress nagging; it never masks a real grant.
-            // CGPreflightScreenCaptureAccess is frozen per-process (see isGrantedOnSomeDisplay below),
-            // so this reads the true state at launch but won't see a mid-session grant; that case
-            // recovers via the menubar "Grant permission" callout, which clears the flag and restarts.
-            guard !Preferences.screenRecordingPermissionSkipped else {
-                return CGPreflightScreenCaptureAccess() ? .granted : .skipped
-            }
-            return isGrantedOnSomeDisplay() ? .granted : .notGranted
+            return CGPreflightScreenCaptureAccess() ? .granted : .notGranted
         }
         return .granted
     }
 
-    // workaround: public API CGPreflightScreenCaptureAccess and private API SLSRequestScreenCaptureAccess exist, but
-    // their return value is not updated during the app lifetime
-    // note: shows the system prompt if there's no permission
-    private static func isGrantedOnSomeDisplay() -> Bool {
+    // This first-use probe can show the normal macOS permission prompt. No post-grant or background
+    // path calls it. Known grants use only CGPreflightScreenCaptureAccess above.
+    private static func firstUseProbe() -> ScreenRecordingProbeResult {
         if #available(macOS 12.3, *) {
             return checkWithSCShareableContent()
         } else {
             let mainDisplayID = CGMainDisplayID()
-            if checkWithCGDisplayStream(mainDisplayID) {
-                return true
-            }
-            // maybe the main screen can't produce a CGDisplayStream, but another screen can
-            // a positive on any screen must mean that the permission is granted; we try on the other screens
+            var lastFailure = checkWithCGDisplayStream(mainDisplayID)
+            if lastFailure == .granted { return .granted }
             for screen in NSScreen.screens {
                 if let id = screen.number(), id != mainDisplayID {
-                    if checkWithCGDisplayStream(id) {
-                        return true
-                    }
+                    let result = checkWithCGDisplayStream(id)
+                    if result == .granted { return .granted }
+                    if case .temporarilyUnavailable = result { lastFailure = result }
                 }
             }
-            return false
+            return lastFailure
         }
     }
 
     @available(macOS 12.3, *)
-    private static func checkWithSCShareableContent() -> Bool {
+    private static func checkWithSCShareableContent() -> ScreenRecordingProbeResult {
         return runWithTimeout { completion in
             SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
-                // this callback runs on a GCD queue, not on the thread that called getWithCompletionHandler
                 if #available(macOS 14.0, *), let shareableContent, error == nil {
                     BackgroundWork.screenshotsQueue.addOperation {
                         WindowCaptureScreenshots.cachedSCWindows.withLock { $0 = shareableContent.windows }
                     }
                 }
-                completion(error != nil ? false : (shareableContent != nil))
+                if let error {
+                    let nsError = error as NSError
+                    if nsError.domain == SCStreamErrorDomain && nsError.code == SCStreamError.Code.userDeclined.rawValue {
+                        completion(.notGranted)
+                    } else {
+                        completion(.temporarilyUnavailable(.screenCaptureKit(domain: nsError.domain, code: nsError.code)))
+                    }
+                } else {
+                    completion(shareableContent == nil
+                        ? .temporarilyUnavailable(.screenCaptureKit(domain: SCStreamErrorDomain, code: -1))
+                        : .granted)
+                }
             }
         }
     }
 
-    private static func checkWithCGDisplayStream(_ id: CGDirectDisplayID) -> Bool {
+    private static func checkWithCGDisplayStream(_ id: CGDirectDisplayID) -> ScreenRecordingProbeResult {
         return runWithTimeout { completion in
-            // this initializer can actually block for a while
-            // it's undocumented but has been proven by spindumps shared by AltTab users
             let displayStream = CGDisplayStream(
                 dispatchQueueDisplay: id,
                 outputWidth: 1,
@@ -209,24 +245,81 @@ class ScreenRecordingPermission {
                 properties: nil,
                 queue: .global()
             ) { _, _, _, _ in }
-            completion(displayStream != nil)
+            completion(displayStream == nil ? .notGranted : .granted)
         }
     }
 
-    private static func runWithTimeout(_ block: @escaping (@escaping (Bool) -> Void) -> Void) -> Bool {
+    private static func runWithTimeout(_ block: @escaping (@escaping (ScreenRecordingProbeResult) -> Void) -> Void) -> ScreenRecordingProbeResult {
         let semaphore = DispatchSemaphore(value: 0)
-        var result = false
+        let lock = NSLock()
+        var result: ScreenRecordingProbeResult?
         BackgroundWork.permissionsSystemCallsQueue.addOperation {
             block { r in
+                lock.lock()
                 result = r
+                lock.unlock()
                 semaphore.signal()
             }
         }
         let timeoutResult = semaphore.wait(timeout: .now() + 6)
         if timeoutResult == .timedOut {
             Logger.error { "Screen-recording permission call timed out after 6s" }
-            return false
+            return .temporarilyUnavailable(.timeout)
         }
-        return result
+        lock.lock()
+        defer { lock.unlock() }
+        return result ?? .temporarilyUnavailable(.timeout)
+    }
+
+    private static func receive(_ result: ScreenRecordingProbeResult) {
+        if case let .temporarilyUnavailable(failure) = result {
+            Logger.error { "Screen-recording permission probe is temporarily unavailable: \(failure)" }
+        }
+        let effects = authorization.receive(result)
+        switch authorization.state {
+            case .unknown: status = .temporarilyUnavailable
+            case .granted: status = .granted
+            case .temporarilyUnavailable: status = .temporarilyUnavailable
+            case .needsUserReview: status = .notGranted
+        }
+        apply(effects)
+        refreshPermissionUi()
+    }
+
+    private static func apply(_ effects: [ScreenRecordingAuthorizationEffect]) {
+        for effect in effects {
+            switch effect {
+                case .persistGrant:
+                    Preferences.set("screenRecordingPermissionWasGranted", "true", false)
+                case let .scheduleConfirmation(after: delay):
+                    scheduleConfirmation(after: delay)
+                case .cancelConfirmations:
+                    cancelConfirmations()
+                case .openOnboarding:
+                    break
+                case .showPassiveReview:
+                    cancelConfirmations()
+            }
+        }
+    }
+
+    private static func scheduleConfirmation(after delay: TimeInterval) {
+        let workItem = DispatchWorkItem {
+            receive(nonPromptingProbe())
+        }
+        confirmationWorkItems.append(workItem)
+        BackgroundWork.permissionsCheckOnTimerQueue.strongUnderlyingQueue.asyncAfter(deadline: .now() + delay, execute: workItem)
+    }
+
+    private static func cancelConfirmations() {
+        confirmationWorkItems.forEach { $0.cancel() }
+        confirmationWorkItems.removeAll()
+    }
+
+    private static func refreshPermissionUi() {
+        DispatchQueue.main.async {
+            Menubar.refreshPermissionCallout()
+            if PermissionsWindow.shared != nil { PermissionsWindow.updatePermissionViews() }
+        }
     }
 }

--- a/src/macos/SystemPermissions.swift
+++ b/src/macos/SystemPermissions.swift
@@ -213,23 +213,26 @@ class ScreenRecordingPermission {
     @available(macOS 12.3, *)
     private static func checkWithSCShareableContent() -> ScreenRecordingProbeResult {
         return runWithTimeout { completion in
-            SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
-                if #available(macOS 14.0, *), let shareableContent, error == nil {
-                    BackgroundWork.screenshotsQueue.addOperation {
-                        WindowCaptureScreenshots.cachedSCWindows.withLock { $0 = shareableContent.windows }
+            ScreenCaptureCoordinator.shared.submit { captureCompletion in
+                SCShareableContent.getExcludingDesktopWindows(true, onScreenWindowsOnly: false) { shareableContent, error in
+                    captureCompletion()
+                    if #available(macOS 14.0, *), let shareableContent, error == nil {
+                        BackgroundWork.screenshotsQueue.addOperation {
+                            WindowCaptureScreenshots.cachedSCWindows.withLock { $0 = shareableContent.windows }
+                        }
                     }
-                }
-                if let error {
-                    let nsError = error as NSError
-                    if nsError.domain == SCStreamErrorDomain && nsError.code == SCStreamError.Code.userDeclined.rawValue {
-                        completion(.notGranted)
+                    if let error {
+                        let nsError = error as NSError
+                        if nsError.domain == SCStreamErrorDomain && nsError.code == SCStreamError.Code.userDeclined.rawValue {
+                            completion(.notGranted)
+                        } else {
+                            completion(.temporarilyUnavailable(.screenCaptureKit(domain: nsError.domain, code: nsError.code)))
+                        }
                     } else {
-                        completion(.temporarilyUnavailable(.screenCaptureKit(domain: nsError.domain, code: nsError.code)))
+                        completion(shareableContent == nil
+                            ? .temporarilyUnavailable(.screenCaptureKit(domain: SCStreamErrorDomain, code: -1))
+                            : .granted)
                     }
-                } else {
-                    completion(shareableContent == nil
-                        ? .temporarilyUnavailable(.screenCaptureKit(domain: SCStreamErrorDomain, code: -1))
-                        : .granted)
                 }
             }
         }

--- a/src/macos/api-wrappers/SkyLight.framework.swift
+++ b/src/macos/api-wrappers/SkyLight.framework.swift
@@ -36,6 +36,16 @@ func CGSMainConnectionID() -> CGSConnectionID
 @_silgen_name("CGSHWCaptureWindowList")
 func CGSHWCaptureWindowList(_ cid: CGSConnectionID, _ windowList: UnsafeMutablePointer<CGWindowID>, _ windowCount: UInt32, _ options: CGSWindowCaptureOptions) -> Unmanaged<CFArray>
 
+/// Legacy WindowServer capture. The public SDK declaration was obsoleted in macOS 15,
+/// but the symbol remains available. We use it only if CGSHWCaptureWindowList returns no image.
+@_silgen_name("CGWindowListCreateImage")
+func CGWindowListCreateImageLegacy(
+    _ screenBounds: CGRect,
+    _ listOption: CGWindowListOption,
+    _ windowID: CGWindowID,
+    _ imageOption: CGWindowImageOption
+) -> Unmanaged<CGImage>?
+
 /// returns an array of displays (as NSDictionary) -> each having an array of spaces (as NSDictionary) at the "Spaces" key; each having a space ID (as UInt64) at the "id64" key
 /// * macOS 10.10+
 /// /!\ only returns correct values if the user has checked the checkbox in Preferences > Mission Control > "Displays have separate Spaces"

--- a/src/preferences/Preferences.swift
+++ b/src/preferences/Preferences.swift
@@ -44,6 +44,7 @@ class Preferences {
             "previewFocusedWindow": "false",
             "captureWindowsInBackground": "true",
             "screenRecordingPermissionSkipped": "false",
+            "screenRecordingPermissionWasGranted": "false",
             "trackpadHapticFeedbackEnabled": "true",
             "settingsWindowShownOnFirstLaunch": "false",
         ]
@@ -124,6 +125,7 @@ class Preferences {
     static var previewSelectedWindow: Bool { CachedUserDefaults.bool("previewFocusedWindow") }
     static var captureWindowsInBackground: Bool { CachedUserDefaults.bool("captureWindowsInBackground") }
     static var screenRecordingPermissionSkipped: Bool { CachedUserDefaults.bool("screenRecordingPermissionSkipped") }
+    static var screenRecordingPermissionWasGranted: Bool { CachedUserDefaults.bool("screenRecordingPermissionWasGranted") }
     static var settingsWindowShownOnFirstLaunch: Bool { CachedUserDefaults.bool("settingsWindowShownOnFirstLaunch") }
 
     // macro values

--- a/src/preferences/Preferences.swift
+++ b/src/preferences/Preferences.swift
@@ -125,7 +125,9 @@ class Preferences {
     static var previewSelectedWindow: Bool { CachedUserDefaults.bool("previewFocusedWindow") }
     static var captureWindowsInBackground: Bool { CachedUserDefaults.bool("captureWindowsInBackground") }
     static var screenRecordingPermissionSkipped: Bool { CachedUserDefaults.bool("screenRecordingPermissionSkipped") }
-    static var screenRecordingPermissionWasGranted: Bool { CachedUserDefaults.bool("screenRecordingPermissionWasGranted") }
+    static var screenRecordingPermissionWasGranted: Bool {
+        CachedUserDefaults.bool("screenRecordingPermissionWasGranted")
+    }
     static var settingsWindowShownOnFirstLaunch: Bool { CachedUserDefaults.bool("settingsWindowShownOnFirstLaunch") }
 
     // macro values

--- a/src/preferences/PreferencesMigrations.swift
+++ b/src/preferences/PreferencesMigrations.swift
@@ -18,12 +18,20 @@ class PreferencesMigrations {
         let preferencesKey = "preferencesVersion"
         let existingVersion = Self.defaults.string(forKey: preferencesKey)
         ProTransitionState.markFreshInstallIfUnknown(existingVersion == nil)
+        seedScreenRecordingGrantHistory(existingVersion: existingVersion)
         if let versionInPlist = existingVersion {
             if versionInPlist != "#VERSION#" && versionInPlist.compare(App.version, options: .numeric) != .orderedDescending {
                 updateToNewPreferences(versionInPlist)
             }
         }
         Self.defaults.set(App.version, forKey: preferencesKey)
+    }
+
+    static func seedScreenRecordingGrantHistory(existingVersion: String?) {
+        guard existingVersion != nil,
+              Self.defaults.object(forKey: "screenRecordingPermissionWasGranted") == nil,
+              Self.defaults.string(forKey: "screenRecordingPermissionSkipped") != "true" else { return }
+        Self.defaults.set("true", forKey: "screenRecordingPermissionWasGranted")
     }
 
     static func updateToNewPreferences(_ versionInPlist: String) {

--- a/src/preferences/PreferencesMigrationsTests.swift
+++ b/src/preferences/PreferencesMigrationsTests.swift
@@ -49,6 +49,26 @@ final class PreferencesMigrationsTests: XCTestCase {
         XCTAssertTrue(PreferencesMigrations.shouldRun("9.0.0", "10.0.0"))
     }
 
+    func testExistingOnboardedUserStartsWithGrantHistory() {
+        PreferencesMigrations.seedScreenRecordingGrantHistory(existingVersion: "11.5.0")
+
+        XCTAssertEqual(defaults.string(forKey: "screenRecordingPermissionWasGranted"), "true")
+    }
+
+    func testFreshInstallDoesNotStartWithGrantHistory() {
+        PreferencesMigrations.seedScreenRecordingGrantHistory(existingVersion: nil)
+
+        XCTAssertNil(defaults.object(forKey: "screenRecordingPermissionWasGranted"))
+    }
+
+    func testExistingUserWhoSkippedCaptureDoesNotStartWithGrantHistory() {
+        defaults.set("true", forKey: "screenRecordingPermissionSkipped")
+
+        PreferencesMigrations.seedScreenRecordingGrantHistory(existingVersion: "11.5.0")
+
+        XCTAssertNil(defaults.object(forKey: "screenRecordingPermissionWasGranted"))
+    }
+
     // MARK: - B. Grouping moved global -> per-shortcut
 
     func testGroupingCopiesGlobalShowAppsOrWindowsToPerShortcutKeysAndRemovesGlobal() {

--- a/src/secondary-windows/permission-window/PermissionView.swift
+++ b/src/secondary-windows/permission-window/PermissionView.swift
@@ -59,6 +59,9 @@ class PermissionView: StackView {
             case .skipped:
                 color = PermissionView.yellowColor
                 label = NSLocalizedString("Skipped", comment: "")
+            case .temporarilyUnavailable:
+                color = PermissionView.yellowColor
+                label = NSLocalizedString("Checking…", comment: "")
         }
         status.stringValue = "● " + label
         status.textColor = color.withAlphaComponent(1)
@@ -70,4 +73,5 @@ enum PermissionStatus {
     case granted
     case notGranted
     case skipped
+    case temporarilyUnavailable
 }

--- a/src/secondary-windows/permission-window/PermissionView.swift
+++ b/src/secondary-windows/permission-window/PermissionView.swift
@@ -59,9 +59,9 @@ class PermissionView: StackView {
             case .skipped:
                 color = PermissionView.yellowColor
                 label = NSLocalizedString("Skipped", comment: "")
-            case .temporarilyUnavailable:
-                color = PermissionView.yellowColor
-                label = NSLocalizedString("Checking…", comment: "")
+        case .temporarilyUnavailable:
+            color = PermissionView.yellowColor
+            label = NSLocalizedString("Checking…", comment: "")
         }
         status.stringValue = "● " + label
         status.textColor = color.withAlphaComponent(1)

--- a/src/switcher/SwitcherSession.swift
+++ b/src/switcher/SwitcherSession.swift
@@ -28,7 +28,10 @@ final class SwitcherSession {
     static var current: SwitcherSession? {
         didSet { activity.setActive(current != nil) }
     }
-    static var isActive: Bool { activity.isActive }
+
+    static var isActive: Bool {
+        activity.isActive
+    }
     /// The shortcut index of the currently-active session, or 0 when no session is active.
     /// Used by every per-shortcut effective preference read in `Appearance`, `TileView`, etc.
     static var activeShortcutIndex: Int { current?.shortcutIndex ?? 0 }

--- a/src/switcher/SwitcherSession.swift
+++ b/src/switcher/SwitcherSession.swift
@@ -1,5 +1,22 @@
 import Cocoa
 
+final class SwitcherSessionActivity {
+    private let lock = NSLock()
+    private var active = false
+
+    var isActive: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return active
+    }
+
+    func setActive(_ active: Bool) {
+        lock.lock()
+        self.active = active
+        lock.unlock()
+    }
+}
+
 /// Holds all state scoped to a single switcher invocation: from when the user
 /// first triggers the shortcut to when the panel is dismissed.
 ///
@@ -7,8 +24,11 @@ import Cocoa
 /// user. Lifetime is owned by `App.showUiOrCycleSelection` (creates) and
 /// `App.hideUi` (destroys).
 final class SwitcherSession {
-    static var current: SwitcherSession?
-    static var isActive: Bool { current != nil }
+    private static let activity = SwitcherSessionActivity()
+    static var current: SwitcherSession? {
+        didSet { activity.setActive(current != nil) }
+    }
+    static var isActive: Bool { activity.isActive }
     /// The shortcut index of the currently-active session, or 0 when no session is active.
     /// Used by every per-shortcut effective preference read in `Appearance`, `TileView`, etc.
     static var activeShortcutIndex: Int { current?.shortcutIndex ?? 0 }

--- a/src/switcher/state/WindowThumbnails.swift
+++ b/src/switcher/state/WindowThumbnails.swift
@@ -30,9 +30,10 @@ enum WindowThumbnails {
     /// its thumbnail while it's still frontmost lets that tile show a real screenshot instead. No-op while the
     /// switcher is open (the normal refresh captures then); throttled per wid; obeys the screenshot guards below.
     static func captureFocusedInBackground(_ window: Window) {
-        guard !SwitcherSession.isActive, let wid = window.cgWindowId, wid != CGWindowID(bitPattern: -1) else { return }
+        guard !SwitcherSession.isActive, Preferences.captureWindowsInBackground,
+              let wid = window.cgWindowId, wid != CGWindowID(bitPattern: -1) else { return }
         focusedCaptureThrottler.throttleOrProceed(key: "\(wid)") {
-            refreshAsync([window], .refreshUiAfterExternalEvent, force: true)
+            refreshAsync([window], .refreshUiAfterExternalEvent)
         }
     }
 
@@ -84,9 +85,8 @@ enum WindowThumbnails {
         DispatchQueue.main.asyncAfter(deadline: .now() + restoreAnimationDuration) { [weak window] in
             restoringWids.remove(wid)
             guard let window else { return }
-            // no `force`: this capture obeys the same conditions as the ones it replaces, so with the
-            // switcher closed and background captures off it is simply dropped — the next show captures
-            // every window anyway
+            // This capture obeys the background-capture setting. If it is dropped, the next show captures
+            // every window.
             refreshAsync([window], .refreshUiAfterExternalEvent)
         }
     }
@@ -138,8 +138,8 @@ enum WindowThumbnails {
             return true
         }
         partialFrameRetries[wid] = retries + 1
-        // no `force`: this re-capture obeys the same conditions the original one did, so a switcher that
-        // closed in the meantime (with background captures off) simply drops it
+        // This re-capture obeys the background-capture setting. A closed switcher drops it when background
+        // capture is disabled.
         DispatchQueue.main.asyncAfter(deadline: .now() + partialFrameRetryDelay) { [weak window] in
             guard let window else { return }
             refreshAsync([window], .refreshUiAfterExternalEvent)
@@ -151,13 +151,17 @@ enum WindowThumbnails {
     /// macOS 26+): full-resolution frames for the Preview panel are fetched separately and just-in-time
     /// by `fetchPreviewFrames` into the session's capped cache, so idle RAM stays small and a show
     /// doesn't burst N full-res captures at the system capture path (#5861).
-    static func refreshAsync(_ windows: [Window], _ source: RefreshCausedBy, windowRemoved: Bool = false, prioritizedIds: Set<CGWindowID>? = nil, force: Bool = false) {
+    static func refreshAsync(_ windows: [Window], _ source: RefreshCausedBy, windowRemoved: Bool = false, prioritizedIds: Set<CGWindowID>? = nil) {
         guard (!windows.isEmpty || windowRemoved) && ScreenRecordingPermission.status == .granted
                && !ScreenLockEvents.isScreenLocked
-               && Preferences.anyShortcutShowsWindowCaptures
-               // `force` = a targeted background capture of the frontmost window (captureFocusedInBackground),
-               // which must run even when the switcher is closed and background capture is off.
-               && (Preferences.captureWindowsInBackground || SwitcherSession.isActive || force) else { return }
+               && Preferences.anyShortcutShowsWindowCaptures else { return }
+        let backend = WindowCaptureRouting.backend(
+            macOSMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion,
+            kind: .thumbnail,
+            hasTrustedGrantHistory: ScreenRecordingPermission.hasTrustedGrantHistory,
+            switcherIsActive: SwitcherSession.isActive,
+            backgroundCaptureIsEnabled: Preferences.captureWindowsInBackground)
+        guard let backend else { return }
         var eligibleWindows = [Window]()
         for window in windows {
             if !window.isWindowlessApp, let cgWindowId = window.cgWindowId, cgWindowId != CGWindowID(bitPattern: -1),
@@ -168,14 +172,13 @@ enum WindowThumbnails {
             }
         }
         guard (!eligibleWindows.isEmpty || windowRemoved) else { return }
-        // ScreenCaptureKit's capture path is unreliable before macOS 26: macOS 14 crashes inside Apple's own
-        // teardown (-[SCStreamManager serverDidDisconnect], a top crash in 11.3.0) and macOS 15 hits the bugs
-        // in #5190 (https://github.com/lwouis/alt-tab-macos/issues/5190). Apple rewrote ScreenCaptureKit's
-        // internals for macOS 26, so we only use it there; everything older captures via CGSHWCaptureWindowList.
-        if #available(macOS 26.0, *) {
-            WindowCaptureScreenshots.oneTimeScreenshots(eligibleWindows, source, prioritizedIds: prioritizedIds)
-        } else {
-            WindowCaptureScreenshotsPrivateApi.oneTimeScreenshots(eligibleWindows, source, prioritizedIds: prioritizedIds)
+        switch backend {
+            case .screenCaptureKit:
+                if #available(macOS 14.0, *) {
+                    WindowCaptureScreenshots.oneTimeScreenshots(eligibleWindows, source, prioritizedIds: prioritizedIds)
+                }
+            case .windowServer:
+                WindowCaptureScreenshotsPrivateApi.oneTimeScreenshots(eligibleWindows, source, prioritizedIds: prioritizedIds)
         }
     }
 
@@ -188,6 +191,13 @@ enum WindowThumbnails {
         guard #available(macOS 26.0, *), let session = SwitcherSession.current,
               ScreenRecordingPermission.status == .granted, !ScreenLockEvents.isScreenLocked,
               Preferences.effectivePreviewSelectedWindow(session.shortcutIndex) else { return }
+        let backend = WindowCaptureRouting.backend(
+            macOSMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion,
+            kind: .focusedPreview,
+            hasTrustedGrantHistory: ScreenRecordingPermission.hasTrustedGrantHistory,
+            switcherIsActive: true,
+            backgroundCaptureIsEnabled: Preferences.captureWindowsInBackground)
+        guard backend == .screenCaptureKit else { return }
         let missingIds = Windows.selectedNeighborhoodIds().filter { !session.hasPreviewFrame($0) && !restoringWids.contains($0) }
         guard !missingIds.isEmpty else { return }
         let windowsToFetch = Windows.list.filter { $0.cgWindowId.map { missingIds.contains($0) } ?? false }

--- a/src/switcher/state/WindowThumbnails.swift
+++ b/src/switcher/state/WindowThumbnails.swift
@@ -151,16 +151,22 @@ enum WindowThumbnails {
     /// macOS 26+): full-resolution frames for the Preview panel are fetched separately and just-in-time
     /// by `fetchPreviewFrames` into the session's capped cache, so idle RAM stays small and a show
     /// doesn't burst N full-res captures at the system capture path (#5861).
-    static func refreshAsync(_ windows: [Window], _ source: RefreshCausedBy, windowRemoved: Bool = false, prioritizedIds: Set<CGWindowID>? = nil) {
+    static func refreshAsync(
+        _ windows: [Window],
+        _ source: RefreshCausedBy,
+        windowRemoved: Bool = false,
+        prioritizedIds: Set<CGWindowID>? = nil
+    ) {
         guard (!windows.isEmpty || windowRemoved) && ScreenRecordingPermission.status == .granted
                && !ScreenLockEvents.isScreenLocked
-               && Preferences.anyShortcutShowsWindowCaptures else { return }
+            && Preferences.anyShortcutShowsWindowCaptures else { return }
         let backend = WindowCaptureRouting.backend(
             macOSMajorVersion: ProcessInfo.processInfo.operatingSystemVersion.majorVersion,
             kind: .thumbnail,
             hasTrustedGrantHistory: ScreenRecordingPermission.hasTrustedGrantHistory,
             switcherIsActive: SwitcherSession.isActive,
-            backgroundCaptureIsEnabled: Preferences.captureWindowsInBackground)
+            backgroundCaptureIsEnabled: Preferences.captureWindowsInBackground
+        )
         guard let backend else { return }
         var eligibleWindows = [Window]()
         for window in windows {
@@ -173,12 +179,20 @@ enum WindowThumbnails {
         }
         guard (!eligibleWindows.isEmpty || windowRemoved) else { return }
         switch backend {
-            case .screenCaptureKit:
-                if #available(macOS 14.0, *) {
-                    WindowCaptureScreenshots.oneTimeScreenshots(eligibleWindows, source, prioritizedIds: prioritizedIds)
-                }
-            case .windowServer:
-                WindowCaptureScreenshotsPrivateApi.oneTimeScreenshots(eligibleWindows, source, prioritizedIds: prioritizedIds)
+        case .screenCaptureKit:
+            if #available(macOS 14.0, *) {
+                WindowCaptureScreenshots.oneTimeScreenshots(
+                    eligibleWindows,
+                    source,
+                    prioritizedIds: prioritizedIds
+                )
+            }
+        case .windowServer:
+            WindowCaptureScreenshotsPrivateApi.oneTimeScreenshots(
+                eligibleWindows,
+                source,
+                prioritizedIds: prioritizedIds
+            )
         }
     }
 
@@ -196,7 +210,8 @@ enum WindowThumbnails {
             kind: .focusedPreview,
             hasTrustedGrantHistory: ScreenRecordingPermission.hasTrustedGrantHistory,
             switcherIsActive: true,
-            backgroundCaptureIsEnabled: Preferences.captureWindowsInBackground)
+            backgroundCaptureIsEnabled: Preferences.captureWindowsInBackground
+        )
         guard backend == .screenCaptureKit else { return }
         let missingIds = Windows.selectedNeighborhoodIds().filter { !session.hasPreviewFrame($0) && !restoringWids.contains($0) }
         guard !missingIds.isEmpty else { return }


### PR DESCRIPTION
I've been running into repeated permission prompts from AltTab when my Mac is under load, with Screen Recording access already enabled. A capture timeout can send it back to the permission window even though the grant hasn't changed.

This keeps the last-known grant and uses non-prompting checks to confirm later failures. Accessibility checks stay separate. First-time denial still opens the normal permission window.

ScreenCaptureKit gets a shared limit of two operations. Queued requests check the switcher, preferences, lock state, and permission again when they're ready to run. The WindowServer path checks those conditions too, including before a fallback capture. That stops queued work from starting after the switcher closes when background capture is disabled.

UI state stays on main. Permission preflight and ScreenCaptureKit submission run on a worker queue, and focused previews go ahead of queued thumbnails. If a completion never arrives, its slot stays occupied and the user gets a restart action. Permission snapshots are locked, and confirmation work runs in order.

The Release tests also caught a stale switcher-visibility read that could leave previews missing. That's fixed here. On macOS 27 and later, thumbnails use the existing WindowServer backend after a known grant. Focused previews still use ScreenCaptureKit, with a cooldown after failures.

Related reports: [#5112](https://github.com/lwouis/alt-tab-macos/issues/5112) and [#5861](https://github.com/lwouis/alt-tab-macos/issues/5861). Both were closed when I checked them. They're useful context; I'm not claiming this resolves everything described there or replaces the existing fixes.

The backend change comes from logs on one macOS 27 beta host, where requests used executable-path identities while the bundle grants stayed allowed. I don't know how broadly that applies.

## Tests

- Debug build and full Debug scheme test action passed: 957 tests, no failures or skipped tests.
- Changed Swift lines passed SwiftFormat 0.63.0. Diff whitespace check passed.
- Tests cover confirmation, recovery, backend selection, request limits, lost completions, and thumbnail and focused-preview behavior.
- The latest Release candidate passed all 1,190 full-suite tests with zero failures. All 67 changed Swift ranges passed formatting. Regression tests first failed for main-thread submission, preview priority, dispatch ordering, timeout-stage ownership, and queued WindowServer capture after closure. P1 review has no unresolved P0/P1 finding. The final branch includes upstream `2f3c6773` (11.6.0); that last release commit changes no app source or build files.
- Live checks showed real thumbnails and the separate full-size focused preview. With eight CPU workers active, a fixture-only injected capture error entered the normal cooldown. The cached preview remained available. After the fixture content changed, a real 960-by-896 ScreenCaptureKit completion supplied the new thumbnail and full-size preview without an app restart.
- A thirty-second closed-switcher observation with background capture disabled produced no capture debug entry. The final native state confirmed that the switcher stayed closed.
- Three consecutive sixty-second, eight-worker load runs on the refreshed candidate each completed twenty observed switcher openings within fifty seconds. There were no late replies, app restarts, new permission alerts, or matching path-based TCC rows. Dayflow saved six new frames per run. All workers stopped. A separate preview check on this candidate produced 0 / 21,733 / 0 green pixels outside the tile panel before, during, and after the preview. A further 38-second closed-switcher check had no capture debug entry.

Testing was on Apple Silicon with macOS 27.0 build 26A5425a. Xcode signing was disabled, and the Sparkle helper script needed an ad-hoc identity override for temporary build output. The live Release candidate used my existing local signing identity. The normal app and changed settings were restored afterward. No release was distributed.

I haven't tested actual permission revocation, minimized and full-screen previews, sleep, wake, or display changes in the app yet. The 24-hour normal-use test and older macOS runtime tests are also open.

The earlier injected-error recovery checks had a permission dialog open already. Those show recovery; they can't establish whether another prompt would have appeared. The three final load runs started without a dialog. I've kept the failed attempts in the test report too, including a five-second state-read reply.

One earlier `--hide` request reached the main-thread hide routine immediately and took 2.703 seconds to prepare its reply. That missed the client's two-second deadline. The run remains failed, and there's no sample of the exact slow call. I'm not claiming a fix for that separate delay.

There's also an OS-side failure these changes can't prevent. During a later setup, Apple's permission service reported `Too many open files` while resolving both apps' signed code. Dayflow's preflight had passed about one second earlier, and the next system check still caused an Apple alert. The bundle grants stayed allowed, and no matching path row appeared.

This reduces repeated requests and preserves capture state. It can't make Apple's preflight and capture request atomic or guarantee that no Apple alert will ever appear. There are no TCC, signing configuration, updater, or release-version changes in the PR.

I'd especially appreciate your thoughts on the macOS 27 backend choice. That part is based on the behavior above, and I've kept it separate for review. Thanks!