### PR TITLE
feat: option to show only the windows under the cursor (closes #6013)

### DIFF
--- a/resources/l10n/Localizable.strings
+++ b/resources/l10n/Localizable.strings
@@ -917,6 +917,9 @@
 "Window title contains" = "Window title contains";
 
 /* No comment provided by engineer. */
+"Windows under the cursor" = "Windows under the cursor";
+
+/* No comment provided by engineer. */
 "You can’t undo this action." = "You can’t undo this action.";
 
 /* No comment provided by engineer. */

--- a/resources/l10n/en.lproj/Localizable.strings
+++ b/resources/l10n/en.lproj/Localizable.strings
@@ -304,6 +304,7 @@
 "window switches" = "window switches";
 "Window Title" = "Window Title";
 "Window title contains" = "Window title contains";
+"Windows under the cursor" = "Windows under the cursor";
 "You can’t undo this action." = "You can’t undo this action.";
 "You have 14 days to try all Pro features. After that, Pro features will step back and the core window switcher will keep working exactly as before.\n\nAltTab stays free and open-source. Pro is an optional one-time purchase that funds continued development." = "You have 14 days to try all Pro features. After that, Pro features will step back and the core window switcher will keep working exactly as before.\n\nAltTab stays free and open-source. Pro is an optional one-time purchase that funds continued development.";
 "You may need to disable some conflicting system gestures" = "You may need to disable some conflicting system gestures";

--- a/src/events/CliEvents.swift
+++ b/src/events/CliEvents.swift
@@ -155,12 +155,14 @@ class CliServer {
         let filters = WindowFilters.snapshot()
         let frontmostPid = Applications.frontmostPid
         let visibleSpaceIds = Spaces.visibleSpaces
+        let cursor = filters.appsToShow == .underCursor ? NSScreen.mouseLocationInQuartzCoordinates() : nil
         let windows = Windows.list.enumerated().map { (i, w) -> QaWindow in
             let wid = w.cgWindowId
             let shown = WindowFilterResolver.shouldShow(
                 w.state, w.application.state,
                 onlyFrontmostApp: filters.appsToShow == .active,
                 excludeFrontmostApp: filters.appsToShow == .nonActive,
+                onlyUnderCursor: filters.appsToShow == .underCursor,
                 hideHidden: filters.showHiddenWindows == .hide,
                 hideWindowless: filters.showWindowlessApps == .hide,
                 hideFullscreen: filters.showFullscreenWindows == .hide,
@@ -172,7 +174,8 @@ class CliServer {
                 frontmostPid: frontmostPid,
                 visibleSpaceIds: visibleSpaceIds,
                 exceptions: filters.exceptions,
-                isOnPreferredScreen: w.isOnScreen(NSScreen.preferred))
+                isOnPreferredScreen: w.isOnScreen(NSScreen.preferred),
+                isUnderCursor: cursor.map { w.contains($0) } ?? false)
             return QaWindow(
                 index: i,
                 wid: wid,

--- a/src/preferences/MacroPreferences.swift
+++ b/src/preferences/MacroPreferences.swift
@@ -153,12 +153,14 @@ enum AppsToShowPreference: CaseIterable, MacroPreference {
     case all
     case active
     case nonActive
+    case underCursor
 
     var localizedString: LocalizedString {
         switch self {
             case .all: return NSLocalizedString("All apps", comment: "")
             case .active: return NSLocalizedString("Active app", comment: "")
             case .nonActive: return NSLocalizedString("Non-active apps", comment: "")
+            case .underCursor: return NSLocalizedString("Windows under the cursor", comment: "")
         }
     }
 }

--- a/src/switcher/state/Screens.swift
+++ b/src/switcher/state/Screens.swift
@@ -64,6 +64,14 @@ extension NSScreen {
         return NSScreen.screens.first { NSMouseInRect(NSEvent.mouseLocation, $0.frame, false) }
     }
 
+    /// `NSEvent.mouseLocation` is in Cocoa coordinates (origin at the bottom-left of the main screen); window
+    /// frames from AX and the WindowServer are in Quartz coordinates (origin at its top-left), so the y axis is
+    /// flipped around the main screen's height, as in `Window.isOnScreen`.
+    static func mouseLocationInQuartzCoordinates() -> CGPoint {
+        let location = NSEvent.mouseLocation
+        return CGPoint(x: location.x, y: NSMaxY(NSScreen.screens[0].frame) - location.y)
+    }
+
     func ratio() -> CGFloat {
         return frame.width / frame.height
     }

--- a/src/switcher/state/Window.swift
+++ b/src/switcher/state/Window.swift
@@ -526,6 +526,14 @@ class Window {
         return true
     }
 
+    /// Whether the window's frame contains `point`, in Quartz coordinates (origin at the top-left of the main
+    /// screen, like `position`). A tabbed window borrows the visible tab's frame, as `isOnScreen` does.
+    func contains(_ point: CGPoint) -> Bool {
+        let referenceWindow = referenceWindowForTabbedWindow()
+        guard let topLeftCorner = referenceWindow?.position, let size = referenceWindow?.size else { return false }
+        return CGRect(origin: topLeftCorner, size: size).contains(point)
+    }
+
     func referenceWindowForTabbedWindow() -> Window? {
         // if the window is tabbed, we can't know its position/size before it's focused, so we use the currently
         // visible window-tab. Its data will match the tabbed window's

--- a/src/switcher/state/WindowFilterResolver.swift
+++ b/src/switcher/state/WindowFilterResolver.swift
@@ -5,7 +5,8 @@ import Foundation
 /// the app's `ApplicationState`, the dropdown booleans (defaulted to `false` so tests only spell out
 /// what they exercise), the runtime context (frontmost pid, visible spaces, exceptions), and a
 /// **lazy** `isOnPreferredScreen` — the one fact that's irreducibly OS-coupled (`Window.isOnScreen`
-/// touches `Spaces.screenSpacesMap` + multi-screen quartz math). Everything else is a pure
+/// touches `Spaces.screenSpacesMap` + multi-screen quartz math) — and a **lazy** `isUnderCursor` (the
+/// window's frame against the cursor, which `WindowState` doesn't carry). Everything else is a pure
 /// expression over the inputs, evaluated inline so `&&` short-circuits exactly like the original.
 enum WindowFilterResolver {
     /// True iff the window passes every active filter. Mirrors the original predicate term-for-term;
@@ -14,6 +15,7 @@ enum WindowFilterResolver {
     static func shouldShow(_ s: WindowState, _ app: ApplicationState,
                            onlyFrontmostApp: Bool = false,       // appsToShow == .active
                            excludeFrontmostApp: Bool = false,    // appsToShow == .nonActive
+                           onlyUnderCursor: Bool = false,        // appsToShow == .underCursor
                            hideHidden: Bool = false,             // showHiddenWindows == .hide
                            hideWindowless: Bool = false,         // showWindowlessApps == .hide
                            hideFullscreen: Bool = false,         // showFullscreenWindows == .hide
@@ -25,14 +27,15 @@ enum WindowFilterResolver {
                            frontmostPid: pid_t? = nil,
                            visibleSpaceIds: [UInt64] = [],       // CGSSpaceID === UInt64
                            exceptions: [ExceptionEntry] = [],
-                           isOnPreferredScreen: @autoclosure () -> Bool) -> Bool {
+                           isOnPreferredScreen: @autoclosure () -> Bool,
+                           isUnderCursor: @autoclosure () -> Bool = false) -> Bool {
         !s.isPhantom &&
             !ExceptionMatcher.hidesWindow(s, app, exceptions: exceptions,
                 activeAppOverride: onlyFrontmostApp && frontmostPid == app.pid) &&
             !(onlyFrontmostApp && !(frontmostPid == app.pid)) &&
             !(excludeFrontmostApp && frontmostPid == app.pid) &&
             !(hideHidden && app.isHidden) &&
-            ((!hideWindowless && s.isWindowlessApp) ||
+            ((!hideWindowless && !onlyUnderCursor && s.isWindowlessApp) ||
                 !s.isWindowlessApp &&
                 !(hideFullscreen && s.isFullscreen) &&
                 !(hideMinimized && s.isMinimized) &&
@@ -46,7 +49,16 @@ enum WindowFilterResolver {
                 !(onlyVisibleSpaces && !s.isHeldVisibleForTab && !inAnyVisibleSpace(s, visibleSpaceIds)) &&
                 !(onlyNonVisibleSpaces && (s.isHeldVisibleForTab || inAnyVisibleSpace(s, visibleSpaceIds))) &&
                 !(onlyPreferredScreen && !s.isHeldVisibleForTab && !isOnPreferredScreen()) &&
-                (separateTabs || !s.isTabbed))
+                (separateTabs || !s.isTabbed) &&
+                // A minimized window, a hidden app's window, or a window on another Space still has a stored
+                // frame that may contain the cursor, but nothing is drawn there: only what is actually under
+                // the pointer qualifies. Windowless placeholders are excluded above for the same reason.
+                !(onlyUnderCursor && (s.isMinimized || app.isHidden || !isOnVisibleSpace(s, visibleSpaceIds) || !isUnderCursor())))
+    }
+
+    /// A held tab counts as on the visible Space (see the Space gates above).
+    private static func isOnVisibleSpace(_ s: WindowState, _ visibleSpaceIds: [UInt64]) -> Bool {
+        s.isHeldVisibleForTab || inAnyVisibleSpace(s, visibleSpaceIds)
     }
 
     private static func inAnyVisibleSpace(_ s: WindowState, _ visibleSpaceIds: [UInt64]) -> Bool {

--- a/src/switcher/state/WindowFilterResolverSpecs.md
+++ b/src/switcher/state/WindowFilterResolverSpecs.md
@@ -23,7 +23,8 @@ The predicate, in order:
 
 1. **Phantom** windows are always excluded (unconditional, first).
 2. Windows matching a **hide-exception** (by bundle-id prefix + the exception's hide rule) are excluded.
-3. **App scope** (`appsToShow`): `.active` keeps only the frontmost app's windows; `.nonActive` excludes them.
+3. **App scope** (`appsToShow`): `.active` keeps only the frontmost app's windows; `.nonActive` excludes them;
+   `.underCursor` keeps only the windows whose frame contains the cursor (see 7).
 4. **Hidden apps** (⌘H): excluded when the "hide hidden" dropdown is set.
 5. **Windowless apps** (placeholder rows for apps with no open window): shown unless hidden — and they
    **bypass** the window-only filters below (space/screen/fullscreen/minimized/tab), since those only
@@ -31,6 +32,11 @@ The predicate, in order:
 6. For **real windows**: also exclude fullscreen / minimized (when set), windows not in a visible space
    (`.visible`) or in a visible space (`.nonVisible`), windows off the preferred screen
    (`.showingAltTab`), and non-frontmost native **tabs** (unless tabs are shown as separate windows).
+7. **Under the cursor** (`appsToShow == .underCursor`): only windows whose frame contains the cursor, read
+   once per show (`Windows.updatesBeforeShowing`) and passed as the lazy `isUnderCursor`. The frame must be
+   drawn there, so a minimized window, a hidden app's window, a window on a non-visible Space, and a
+   windowless placeholder are excluded even when their stored frame contains the point. A held tab counts as
+   on the visible Space, as for the Space gates. The other dropdowns still apply on top.
 
 Precedence matters: `isPhantom` wins over everything (even a would-be-shown windowless row).
 
@@ -91,3 +97,11 @@ Mirrors `WindowFilterResolverTests.swift` 1:1. Each test flips one knob from an 
 ### J. Combinations
 - **testAllFiltersOnAndWindowPassesEachShows** — every filter on, a window that satisfies all of them shows.
 - **testPhantomBeatsWindowlessShow** — `isPhantom` overrides the windowless "show" path.
+
+### K. Under the cursor (`appsToShow == .underCursor`)
+- **testOnlyUnderCursorHidesWindowNotUnderCursor** / **testOnlyUnderCursorShowsWindowUnderCursor** — the frame test decides.
+- **testOnlyUnderCursorHidesMinimizedWindowUnderCursor** / **testOnlyUnderCursorHidesHiddenAppWindowUnderCursor** /
+  **testOnlyUnderCursorHidesWindowOnNonVisibleSpace** — a frame that contains the point but isn't drawn there doesn't count.
+- **testOnlyUnderCursorHidesWindowlessApp** — a placeholder has no frame.
+- **testOnlyUnderCursorShowsHeldTabUnderCursor** — a held tab is on the visible Space.
+- **testOnlyUnderCursorStillHonoursOtherFilters** — the other dropdowns still apply.

--- a/src/switcher/state/WindowFilterResolverTests.swift
+++ b/src/switcher/state/WindowFilterResolverTests.swift
@@ -6,7 +6,7 @@ import XCTest
 /// knob, so every filter dimension is isolated.
 ///
 /// Groups: A always-excluded · B app scope · C hidden apps · D windowless · E fullscreen ·
-/// F minimized · G spaces · H screens · I tabs · J combinations.
+/// F minimized · G spaces · H screens · I tabs · J combinations · K under the cursor.
 final class WindowFilterResolverTests: XCTestCase {
 
     private func ws(isPhantom: Bool = false, isWindowlessApp: Bool = false, isFullscreen: Bool = false,
@@ -195,6 +195,63 @@ final class WindowFilterResolverTests: XCTestCase {
             onlyFrontmostApp: true, hideHidden: true, hideWindowless: true, hideFullscreen: true,
             hideMinimized: true, onlyVisibleSpaces: true, onlyPreferredScreen: true, separateTabs: false,
             frontmostPid: 100, visibleSpaceIds: [1], isOnPreferredScreen: true))
+    }
+
+    // MARK: - K. Under the cursor (appsToShow == .underCursor)
+
+    func testOnlyUnderCursorHidesWindowNotUnderCursor() {
+        XCTAssertFalse(WindowFilterResolver.shouldShow(ws(spaceIds: [1]), appState(),
+                                                       onlyUnderCursor: true, visibleSpaceIds: [1],
+                                                       isOnPreferredScreen: true, isUnderCursor: false))
+    }
+
+    func testOnlyUnderCursorShowsWindowUnderCursor() {
+        XCTAssertTrue(WindowFilterResolver.shouldShow(ws(spaceIds: [1]), appState(),
+                                                      onlyUnderCursor: true, visibleSpaceIds: [1],
+                                                      isOnPreferredScreen: true, isUnderCursor: true))
+    }
+
+    /// The frame under the cursor must be drawn there: a minimized window, a hidden app's window, or a window
+    /// on another Space keeps a stored frame that can contain the point, yet the user sees something else.
+    func testOnlyUnderCursorHidesMinimizedWindowUnderCursor() {
+        XCTAssertFalse(WindowFilterResolver.shouldShow(ws(isMinimized: true, spaceIds: [1]), appState(),
+                                                       onlyUnderCursor: true, visibleSpaceIds: [1],
+                                                       isOnPreferredScreen: true, isUnderCursor: true))
+    }
+
+    func testOnlyUnderCursorHidesHiddenAppWindowUnderCursor() {
+        XCTAssertFalse(WindowFilterResolver.shouldShow(ws(spaceIds: [1]), appState(appIsHidden: true),
+                                                       onlyUnderCursor: true, visibleSpaceIds: [1],
+                                                       isOnPreferredScreen: true, isUnderCursor: true))
+    }
+
+    func testOnlyUnderCursorHidesWindowOnNonVisibleSpace() {
+        XCTAssertFalse(WindowFilterResolver.shouldShow(ws(spaceIds: [2]), appState(),
+                                                       onlyUnderCursor: true, visibleSpaceIds: [1],
+                                                       isOnPreferredScreen: true, isUnderCursor: true))
+    }
+
+    /// A windowless placeholder has no frame, so it is never under the cursor.
+    func testOnlyUnderCursorHidesWindowlessApp() {
+        XCTAssertFalse(WindowFilterResolver.shouldShow(ws(isWindowlessApp: true), appState(),
+                                                       onlyUnderCursor: true, isOnPreferredScreen: true,
+                                                       isUnderCursor: true))
+    }
+
+    /// A held tab is Space-less but on the visible Space (same exemption as the Space gates), so it shows
+    /// when its frame is under the cursor.
+    func testOnlyUnderCursorShowsHeldTabUnderCursor() {
+        XCTAssertTrue(WindowFilterResolver.shouldShow(ws(isHeldVisibleForTab: true), appState(),
+                                                      onlyUnderCursor: true, visibleSpaceIds: [1],
+                                                      isOnPreferredScreen: true, isUnderCursor: true))
+    }
+
+    /// `isUnderCursor` is the frame test only; the other dropdowns still apply on top of it.
+    func testOnlyUnderCursorStillHonoursOtherFilters() {
+        XCTAssertFalse(WindowFilterResolver.shouldShow(ws(isFullscreen: true, spaceIds: [1]), appState(),
+                                                       onlyUnderCursor: true, hideFullscreen: true,
+                                                       visibleSpaceIds: [1],
+                                                       isOnPreferredScreen: true, isUnderCursor: true))
     }
 
     func testPhantomBeatsWindowlessShow() {

--- a/src/switcher/state/Windows.swift
+++ b/src/switcher/state/Windows.swift
@@ -112,11 +112,13 @@ class Windows {
         // computed-property access rebuilds the underlying array via N×`CachedUserDefaults.macroPref`
         // calls. Snapshot them once and pass into the per-window helper.
         let filters = WindowFilters.snapshot()
+        // Read the cursor once per show: the switcher lists what was under it when summoned, not where it moves to.
+        let cursor = filters.appsToShow == .underCursor ? NSScreen.mouseLocationInQuartzCoordinates() : nil
         // Tab grouping (incl. fullscreen siblings) and active→inactive state mirroring are reconciled
         // reactively on WindowServer events (TabGroup.reconcile), so the model is already grouped here —
         // doing it in this synchronous show path would reorder tiles mid-render (UI jump).
         for window in list {
-            refreshIfWindowShouldBeShownToTheUser(window, filters)
+            refreshIfWindowShouldBeShownToTheUser(window, filters, cursor)
         }
         refreshWhichWindowsToShowTheUser()
         sort()
@@ -147,7 +149,7 @@ class Windows {
         }
     }
 
-    private static func refreshIfWindowShouldBeShownToTheUser(_ window: Window, _ f: WindowFilters) {
+    private static func refreshIfWindowShouldBeShownToTheUser(_ window: Window, _ f: WindowFilters, _ cursor: CGPoint?) {
         // `isOnPreferredScreen` is the one irreducibly OS-coupled fact (touches `Spaces.screenSpacesMap` +
         // multi-screen quartz math); passed as `@autoclosure` so it's only evaluated if the cheaper
         // filters above don't already exclude the window.
@@ -155,6 +157,7 @@ class Windows {
             window.state, window.application.state,
             onlyFrontmostApp: f.appsToShow == .active,
             excludeFrontmostApp: f.appsToShow == .nonActive,
+            onlyUnderCursor: f.appsToShow == .underCursor,
             hideHidden: f.showHiddenWindows == .hide,
             hideWindowless: f.showWindowlessApps == .hide,
             hideFullscreen: f.showFullscreenWindows == .hide,
@@ -166,7 +169,8 @@ class Windows {
             frontmostPid: Applications.frontmostPid,
             visibleSpaceIds: Spaces.visibleSpaces,
             exceptions: f.exceptions,
-            isOnPreferredScreen: window.isOnScreen(NSScreen.preferred))
+            isOnPreferredScreen: window.isOnScreen(NSScreen.preferred),
+            isUnderCursor: cursor.map { window.contains($0) } ?? false)
     }
 
     /// selection + hover methods (all operate on `SwitcherSession.current`)


### PR DESCRIPTION
Closes #6013. Related: #6005 (same hit-test, scoped to the app under the cursor instead of the windows there).

## What

A new value in each shortcut's "Show windows from applications" dropdown: **Windows under the cursor**. When the shortcut is pressed, the switcher lists only the windows whose frame contains the pointer, from any app, so a stack of overlapping windows at one spot can be cycled without scanning the full list. The other dropdowns (Spaces, screens, minimized, hidden, fullscreen, tabs) still apply on top.

## How

- `AppsToShowPreference.underCursor` - appended, so persisted indexes of the existing cases are unchanged and no migration is needed. The settings dropdown and its search index pick it up through `allCases`.
- `WindowFilterResolver.shouldShow` gains `onlyUnderCursor` plus a lazy `isUnderCursor` autoclosure, following the `isOnPreferredScreen` pattern (the frame is not part of `WindowState`). A frame that contains the point but is not drawn there does not count: minimized windows, hidden apps' windows, windows on a non-visible Space, and windowless placeholders are excluded. A held tab counts as on the visible Space, as for the Space gates.
- `Window.contains(_:)` hit-tests the frame in Quartz coordinates, borrowing the visible tab's frame for tabbed windows as `isOnScreen` does. `NSScreen.mouseLocationInQuartzCoordinates()` flips `NSEvent.mouseLocation` the same way `isOnScreen` flips screen frames.
- The cursor is read once per show in `Windows.updatesBeforeShowing` (and in the CLI QA snapshot), not per window.
- Unit tests: group K in `WindowFilterResolverTests` (8 cases); `WindowFilterResolverSpecs.md` updated to match.
- `Localizable.strings` regenerated with `scripts/l10n/extract_l10n_strings.sh`; English copy added to `en.lproj`.

## Testing

- `ai/build.sh` (Debug) builds clean.
- `xcodebuild test -scheme Test` passes, including the new group K tests.
- Not yet exercised end to end on a live switcher from this branch: a Debug build here is not granted Accessibility / Screen Recording, so I could not drive the UI. Happy to add a capture if you want one before merging.
