### PR TITLE
fix: switching quickly could leave the previous window in front

### DIFF
--- a/alt-tab-macos.xcodeproj/project.pbxproj
+++ b/alt-tab-macos.xcodeproj/project.pbxproj
@@ -109,6 +109,9 @@
 		5E7AB00000000000000D2003 /* TabGroupResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7AB00000000000000D2001 /* TabGroupResolver.swift */; };
 		5E7AB00000000000000D2102 /* TabGroupResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E7AB00000000000000D2101 /* TabGroupResolverTests.swift */; };
 		5EC0DE00000000000000A102 /* RealWorldScenariosTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EC0DE00000000000000A101 /* RealWorldScenariosTests.swift */; };
+		5EF0C000000000000000F102 /* FocusIntentPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF0C000000000000000F101 /* FocusIntentPolicy.swift */; };
+		5EF0C000000000000000F103 /* FocusIntentPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF0C000000000000000F101 /* FocusIntentPolicy.swift */; };
+		5EF0C000000000000000F202 /* FocusIntentPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EF0C000000000000000F201 /* FocusIntentPolicyTests.swift */; };
 		5E2A571E000000000000A002 /* WindowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2A571E000000000000A001 /* WindowState.swift */; };
 		5E2A571E000000000000A003 /* WindowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E2A571E000000000000A001 /* WindowState.swift */; };
 		5EAA25AA000000000000A002 /* TrackedWindowState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5EAA25AA000000000000A001 /* TrackedWindowState.swift */; };
@@ -522,6 +525,8 @@
 		5E7AB00000000000000D2001 /* TabGroupResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabGroupResolver.swift; sourceTree = "<group>"; };
 		5E7AB00000000000000D2101 /* TabGroupResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabGroupResolverTests.swift; sourceTree = "<group>"; };
 		5EC0DE00000000000000A101 /* RealWorldScenariosTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RealWorldScenariosTests.swift; sourceTree = "<group>"; };
+		5EF0C000000000000000F101 /* FocusIntentPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusIntentPolicy.swift; sourceTree = "<group>"; };
+		5EF0C000000000000000F201 /* FocusIntentPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusIntentPolicyTests.swift; sourceTree = "<group>"; };
 		5E2A571E000000000000A001 /* WindowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowState.swift; sourceTree = "<group>"; };
 		5E2A571E000000000000A201 /* ApplicationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationState.swift; sourceTree = "<group>"; };
 		5EAA25AA000000000000A001 /* TrackedWindowState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackedWindowState.swift; sourceTree = "<group>"; };
@@ -1137,6 +1142,8 @@
 				5E7AB00000000000000D2001 /* TabGroupResolver.swift */,
 				5E7AB00000000000000D2101 /* TabGroupResolverTests.swift */,
 				5EC0DE00000000000000A101 /* RealWorldScenariosTests.swift */,
+				5EF0C000000000000000F101 /* FocusIntentPolicy.swift */,
+				5EF0C000000000000000F201 /* FocusIntentPolicyTests.swift */,
 				5E5EA12C0000000000000101 /* SearchModeResolverTests.swift */,
 				5E5EA12D0000000000000101 /* ShortcutModifierResolverTests.swift */,
 				5F5849A900000000000000A1 /* BruteForceWindowMatch.swift */,
@@ -2124,6 +2131,8 @@
 				5E7AB00000000000000D2003 /* TabGroupResolver.swift in Sources */,
 				5E7AB00000000000000D2102 /* TabGroupResolverTests.swift in Sources */,
 				5EC0DE00000000000000A102 /* RealWorldScenariosTests.swift in Sources */,
+				5EF0C000000000000000F103 /* FocusIntentPolicy.swift in Sources */,
+				5EF0C000000000000000F202 /* FocusIntentPolicyTests.swift in Sources */,
 				5E2A571E000000000000A003 /* WindowState.swift in Sources */,
 				5E2A571E000000000000A203 /* ApplicationState.swift in Sources */,
 				5EAA25AA000000000000A003 /* TrackedWindowState.swift in Sources */,
@@ -2209,6 +2218,7 @@
 				5E7C0F70000000000000E002 /* ExceptionMatcher.swift in Sources */,
 				5E0DE2A0000000000000D002 /* WindowOrderResolver.swift in Sources */,
 				5E7AB00000000000000D2002 /* TabGroupResolver.swift in Sources */,
+				5EF0C000000000000000F102 /* FocusIntentPolicy.swift in Sources */,
 				5E2A571E000000000000A002 /* WindowState.swift in Sources */,
 				5E2A571E000000000000A202 /* ApplicationState.swift in Sources */,
 				5EAA25AA000000000000A002 /* TrackedWindowState.swift in Sources */,

--- a/src/switcher/state/FocusIntentPolicy.swift
+++ b/src/switcher/state/FocusIntentPolicy.swift
@@ -1,0 +1,103 @@
+import Foundation
+import CoreGraphics
+
+/// Names one focus request. Monotonic, so a later request is always the newer intent.
+struct FocusGeneration: RawRepresentable, Hashable, Comparable {
+    let rawValue: UInt64
+    static func < (lhs: Self, rhs: Self) -> Bool { lhs.rawValue < rhs.rawValue }
+}
+
+/// **Which of several in-flight focus operations may still touch the screen.**
+///
+/// `Window.focus()` puts the whole activate-key-raise sequence on the shared 4-wide
+/// `accessibilityCommandsQueue` and returns without waiting, so two quick alt-tabs are two concurrent
+/// operations that start in order and finish in any order. Only `_SLPSSetFrontProcessWithOptions` sets the
+/// front process; `makeKeyWindow` and `kAXRaiseAction` only move the z-order. When the older operation's
+/// z-order call lands after the newer one's front-switch, the menu bar names the new app while the old app's
+/// window sits on top.
+///
+/// Checking here before each step stops an operation blocked in the 1s AX messaging timeout from spending its
+/// #5586 retry budget on a target the user has left. But a z-order call is a post to another process and
+/// cannot be recalled, so a bail alone still leaves the screen wrong for an operation that already acted —
+/// hence the repair, which re-asserts the current intent. This is that rule as a pure function; `FocusIntents`
+/// holds it behind a lock and `Window.focus()` does the actual calls.
+struct FocusIntentPolicy {
+    /// The process-wide AX messaging timeout (`AXUIElement.globalMessagingTimeoutInSeconds`), which is the
+    /// longest a stale operation can plausibly have been blocked. Past it, the front the user is looking at is
+    /// more likely one they chose than one AltTab owes them.
+    static let repairHorizon: TimeInterval = 1
+
+    struct Intent: Equatable {
+        let generation: FocusGeneration
+        let wid: CGWindowID
+        let pid: pid_t
+        let at: TimeInterval
+    }
+
+    private var nextGeneration = UInt64(1)
+    private(set) var current: Intent?
+    /// When each live operation last moved the z-order. Absent means it bailed before touching anything.
+    private var reorderedAt = [FocusGeneration: TimeInterval]()
+    /// When `current` was last re-asserted, so a second stale operation whose touch predates it owes nothing.
+    private var repairedAt: TimeInterval?
+
+    /// A focus was asked for. It supersedes whatever was pending.
+    mutating func request(wid: CGWindowID, pid: pid_t, now: TimeInterval) -> FocusGeneration {
+        let generation = FocusGeneration(rawValue: nextGeneration)
+        nextGeneration += 1
+        current = Intent(generation: generation, wid: wid, pid: pid, at: now)
+        repairedAt = nil
+        return generation
+    }
+
+    /// May the operation stamped `generation` run its next step?
+    func mayProceed(_ generation: FocusGeneration) -> Bool {
+        current?.generation == generation
+    }
+
+    /// The operation stamped `generation` moved the target in the z-order, by fronting it, making it key, or
+    /// raising it. Only such an operation can owe a repair.
+    mutating func noteReordered(_ generation: FocusGeneration, now: TimeInterval) {
+        reorderedAt[generation] = now
+    }
+
+    /// The operation stamped `generation` is done. Returns the intent to re-assert, or nil.
+    mutating func finish(_ generation: FocusGeneration, now: TimeInterval) -> Intent? {
+        guard let touchedAt = reorderedAt.removeValue(forKey: generation) else { return nil }
+        guard let current, current.generation != generation else { return nil }
+        guard now - current.at <= Self.repairHorizon else { return nil }
+        guard touchedAt > (repairedAt ?? -.greatestFiniteMagnitude) else { return nil }
+        repairedAt = now
+        return current
+    }
+}
+
+/// The lock-holding shell around `FocusIntentPolicy`, since focus operations run on several queue workers at
+/// once. It branches on nothing: every decision is the policy's.
+class FocusIntents {
+    static let shared = FocusIntents()
+    private let lock = NSLock()
+    private var policy = FocusIntentPolicy()
+
+    private func withPolicy<T>(_ body: (inout FocusIntentPolicy) -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body(&policy)
+    }
+
+    func request(wid: CGWindowID, pid: pid_t) -> FocusGeneration {
+        withPolicy { $0.request(wid: wid, pid: pid, now: ProcessInfo.processInfo.systemUptime) }
+    }
+
+    func mayProceed(_ generation: FocusGeneration) -> Bool {
+        withPolicy { $0.mayProceed(generation) }
+    }
+
+    func noteReordered(_ generation: FocusGeneration) {
+        withPolicy { $0.noteReordered(generation, now: ProcessInfo.processInfo.systemUptime) }
+    }
+
+    func finish(_ generation: FocusGeneration) -> FocusIntentPolicy.Intent? {
+        withPolicy { $0.finish(generation, now: ProcessInfo.processInfo.systemUptime) }
+    }
+}

--- a/src/switcher/state/FocusIntentPolicySpecs.md
+++ b/src/switcher/state/FocusIntentPolicySpecs.md
@@ -1,0 +1,62 @@
+# Focus intent — Specs
+
+The rule that decides which of several in-flight focus operations may still touch the screen, and what a
+superseded one owes when it already did. Pure: requests and step reports in, a verdict and an optional
+repair out. `Window.focus()` owns the queue and the private APIs, and calls this.
+
+## Why it exists
+
+Focusing a window across apps takes two kinds of call, and only one of them fronts the process:
+
+- `_SLPSSetFrontProcessWithOptions` sets the front process — the menu bar — *and* raises the target window
+- `makeKeyWindow` and `kAXRaiseAction` only move a window in the global z-order
+
+`Window.focus()` runs all of them in one operation on the shared 4-wide `accessibilityCommandsQueue`, and
+returns without waiting. Two alt-tabs in quick succession are therefore two operations running concurrently:
+they start in order and finish in any order. `raiseWindow` is a raw `AXUIElementPerformAction` against a
+foreign app, bounded only by the process-wide 1s messaging timeout, and the stale-element retry behind it
+(#5586) costs up to 1.25s more — so an operation can stay in flight for seconds against a re-switch the user
+performs in ~200ms.
+
+When the older operation's z-order call lands after the newer one's front-switch, the menu bar names the new
+app while the old app's window sits on top. That split is only reachable because the two kinds of call can
+interleave; nothing else in `focus()` moves them apart.
+
+## The rule
+
+- a request supersedes every earlier one, and only the newest may act — an operation checks before each step,
+  so one blocked in the AX timeout stops at the next boundary instead of spending its retry budget
+- a superseded operation that already moved the z-order owes a **repair**: the current intent is re-asserted
+  so the newest switch, not the stale one, is what the user ends up looking at. The z-order call is a post to
+  another process, which cannot be recalled, so bailing alone leaves the screen wrong
+- an operation that bailed before touching anything owes nothing, so a bail never costs a redundant re-front
+- a repair is refused once the current intent is older than `repairHorizon`, so a very late operation cannot
+  yank a front the user has since chosen themselves
+- one repair per intent, not one per stale operation: a repair issued after a stale operation's last z-order
+  touch already covers it
+- a repair runs under the intent it repairs and allocates no generation, so it cannot supersede that intent
+  or provoke a further repair
+
+Fronting is what `_SLPSSetFrontProcessWithOptions` does, so a superseded operation that got that far must
+still run the cross-Space origin repair (#4507). That step is gated on having fronted, never on being
+current — bailing out of it would leak the clobber it exists to undo.
+
+## Test scenarios
+
+- **testANewerRequestSupersedesTheOlderOne** — the fast alt-tab, in one line: two requests, and only the
+  second may act.
+- **testTheNewestRequestAlwaysProceeds** — after any number of requests only the last proceeds, so a backlog
+  collapses rather than replaying.
+- **testASupersededOpThatAlreadyReorderedAsksForARepair** — the case a bail alone misses: the older
+  operation's raise already landed, so the newest intent has to be re-asserted.
+- **testASupersededOpThatNeverReorderedAsksForNoRepair** — it stopped before touching the screen, so there is
+  nothing to undo and AltTab does not re-front for free.
+- **testTheCurrentOpAsksForNoRepair** — the ordinary single switch emits nothing.
+- **testARepairIsRefusedOnceTheIntentIsStale** — past `repairHorizon` the user has moved on, and a repair
+  would take the front away from them.
+- **testTwoStaleOpsProduceOneRepair** — the first repair already re-asserted the intent both of them
+  clobbered.
+- **testARepairDoesNotCascade** — an operation reports its outcome once, so the re-assert cannot start
+  another round.
+- **testARepeatedFocusOfTheSameWindowStillSupersedes** — the generation is per request, not per window; the
+  older operation bails even when both name the same target.

--- a/src/switcher/state/FocusIntentPolicyTests.swift
+++ b/src/switcher/state/FocusIntentPolicyTests.swift
@@ -1,0 +1,100 @@
+import XCTest
+
+/// Pins the supersede-and-repair rule that keeps a slow focus operation from raising its window after a
+/// faster one already switched. See FocusIntentPolicySpecs.md.
+final class FocusIntentPolicyTests: XCTestCase {
+    private let safari: pid_t = 500
+    private let terminal: pid_t = 600
+
+    /// The fast alt-tab, in one line. Both operations are in flight; only the newest may act.
+    func testANewerRequestSupersedesTheOlderOne() {
+        var policy = FocusIntentPolicy()
+        let first = policy.request(wid: 1, pid: safari, now: 0)
+        let second = policy.request(wid: 2, pid: terminal, now: 0.2)
+        XCTAssertFalse(policy.mayProceed(first), "a superseded operation was still allowed to touch the screen")
+        XCTAssertTrue(policy.mayProceed(second))
+    }
+
+    /// A backlog collapses to its last member rather than replaying every switch the user passed through.
+    func testTheNewestRequestAlwaysProceeds() {
+        var policy = FocusIntentPolicy()
+        let generations = (0..<5).map { policy.request(wid: CGWindowID($0), pid: safari, now: Double($0) * 0.2) }
+        for generation in generations.dropLast() {
+            XCTAssertFalse(policy.mayProceed(generation))
+        }
+        XCTAssertTrue(policy.mayProceed(generations.last!))
+    }
+
+    /// **The case a bail alone misses.** Safari's raise was posted before Terminal was ever requested, and a
+    /// posted event cannot be recalled: it lands late and puts Safari back on top of Terminal. The stale
+    /// operation has to re-assert the current intent on its way out.
+    func testASupersededOpThatAlreadyReorderedAsksForARepair() {
+        var policy = FocusIntentPolicy()
+        let first = policy.request(wid: 1, pid: safari, now: 0)
+        policy.noteReordered(first, now: 0.01)
+        let second = policy.request(wid: 2, pid: terminal, now: 0.2)
+        let repair = policy.finish(first, now: 0.5)
+        XCTAssertEqual(repair?.generation, second, "the stale raise landed and nothing re-asserted the switch")
+        XCTAssertEqual(repair?.wid, 2)
+        XCTAssertEqual(repair?.pid, terminal)
+    }
+
+    /// It stopped at a checkpoint before fronting or raising anything, so the screen is already right and a
+    /// repair would be a redundant re-front.
+    func testASupersededOpThatNeverReorderedAsksForNoRepair() {
+        var policy = FocusIntentPolicy()
+        let first = policy.request(wid: 1, pid: safari, now: 0)
+        _ = policy.request(wid: 2, pid: terminal, now: 0.2)
+        XCTAssertNil(policy.finish(first, now: 0.5))
+    }
+
+    /// The ordinary single switch: nobody overtook it, so it owes nothing.
+    func testTheCurrentOpAsksForNoRepair() {
+        var policy = FocusIntentPolicy()
+        let only = policy.request(wid: 1, pid: safari, now: 0)
+        policy.noteReordered(only, now: 0.01)
+        XCTAssertNil(policy.finish(only, now: 0.02))
+    }
+
+    /// Past the horizon the user has had a second to click somewhere themselves. Re-asserting then would take
+    /// the front away from them, which is worse than the stale raise it repairs.
+    func testARepairIsRefusedOnceTheIntentIsStale() {
+        var policy = FocusIntentPolicy()
+        let first = policy.request(wid: 1, pid: safari, now: 0)
+        policy.noteReordered(first, now: 0.01)
+        _ = policy.request(wid: 2, pid: terminal, now: 0.2)
+        XCTAssertNil(policy.finish(first, now: 0.2 + FocusIntentPolicy.repairHorizon + 0.01))
+    }
+
+    /// Both stale operations clobbered the same intent, and the first repair already re-asserted it.
+    func testTwoStaleOpsProduceOneRepair() {
+        var policy = FocusIntentPolicy()
+        let first = policy.request(wid: 1, pid: safari, now: 0)
+        policy.noteReordered(first, now: 0.01)
+        let second = policy.request(wid: 2, pid: terminal, now: 0.1)
+        policy.noteReordered(second, now: 0.11)
+        _ = policy.request(wid: 3, pid: safari, now: 0.2)
+        XCTAssertNotNil(policy.finish(first, now: 0.5))
+        XCTAssertNil(policy.finish(second, now: 0.6), "the intent was re-asserted twice for one clobber")
+    }
+
+    /// An operation reports its outcome once, so the re-assert cannot start another round of repairs.
+    func testARepairDoesNotCascade() {
+        var policy = FocusIntentPolicy()
+        let first = policy.request(wid: 1, pid: safari, now: 0)
+        policy.noteReordered(first, now: 0.01)
+        _ = policy.request(wid: 2, pid: terminal, now: 0.2)
+        XCTAssertNotNil(policy.finish(first, now: 0.5))
+        XCTAssertNil(policy.finish(first, now: 0.6))
+    }
+
+    /// The generation is per request, not per window: holding the shortcut through a window and back still
+    /// leaves the older operation superseded.
+    func testARepeatedFocusOfTheSameWindowStillSupersedes() {
+        var policy = FocusIntentPolicy()
+        let first = policy.request(wid: 1, pid: safari, now: 0)
+        let second = policy.request(wid: 1, pid: safari, now: 0.2)
+        XCTAssertFalse(policy.mayProceed(first))
+        XCTAssertTrue(policy.mayProceed(second))
+    }
+}

--- a/src/switcher/state/Window.swift
+++ b/src/switcher/state/Window.swift
@@ -396,54 +396,93 @@ class Window {
             let targetMaybeCrossSpace = !self.spaceIds.isEmpty && !self.spaceIds.contains(originSpaceId)
             let originFrontPid = targetMaybeCrossSpace
                 ? NSWorkspace.shared.frontmostApplication?.processIdentifier : nil
+            let generation = FocusIntents.shared.request(wid: cgWindowId!, pid: application.pid)
             BackgroundWork.accessibilityCommandsQueue.addOperation { [weak self] in
-                guard let self else { return }
-                if self.isMinimized, let element = self.axUiElement {
-                    try? element.setAttribute(kAXMinimizedAttribute, false)
-                }
-                // Focusing another app's window reliably takes the steps below. The public APIs alone don't
-                // move key focus across apps (macOS 14 downgraded NSRunningApplication.activate to an advisory
-                // "request").
-                //   1. _SLPSSetFrontProcessWithOptions fronts the process + the target window (passing the wid
-                //      raises only that window, not all the app's windows). For a cross-Space target it also
-                //      makes macOS switch to a Space showing it. The global front clobbers the front process of
-                //      other Spaces where the app has windows (they pop on Space entry, #4507); step 4 repairs
-                //      the origin Space for a cross-Space focus.
-                //   2. makeKeyWindow: make it key, via a synthetic mouse-down/up aimed just outside the window,
-                //      so it becomes key without clicking its content (a top-left click would hit fullscreen UI, #5381).
-                //   3. raiseWindow (kAXRaiseAction): raise it within the app's own window stack. If our cached
-                //      element went stale (the app silently rebuilt the window's a11y node, #5586), this returns
-                //      .invalidUIElement and no-ops, so re-resolve the live element by wid, retry, and heal the
-                //      cache; _SLPS/makeKeyWindow above use the wid/psn directly so they're unaffected.
-                //   4. cross-Space only: restore the origin Space's front process (see snapshot above).
-                var psn = ProcessSerialNumber()
-                GetProcessForPID(self.application.pid, &psn)
-                _SLPSSetFrontProcessWithOptions(&psn, self.cgWindowId!, SLPSMode.userGenerated.rawValue)
-                makeKeyWindow(&psn, self.cgWindowId!)
-                // Step 3 is the only AX-dependent step: 1 and 2 use the wid and psn directly, so a window
-                // with no element still gets fronted and made key — which is the whole point of keeping a
-                // hung app's window trackable.
-                if self.axUiElement?.raiseWindow() != .success, let fresh = self.refreshedAxElement() {
-                    fresh.raiseWindow()
-                    DispatchQueue.main.async { [weak self] in
-                        guard let self, self.axUiElement != fresh else { return }
-                        self.rebindAxElement(fresh)
-                        Windows.promoteVerified(self.cgWindowId ?? 0)
-                    }
-                }
-                // step 4 (#4507): undo step 1's clobber of the origin Space. The front-switch made that Space
-                // remember our app as its front; restore the app that was there before (snapshotted above) so
-                // returning shows it, not our window. Cross-Space only (originFrontPid is nil otherwise), and
-                // skipped when the origin's front was already this app.
-                if let originFrontPid, originFrontPid != self.application.pid {
-                    var originPsn = ProcessSerialNumber()
-                    GetProcessForPID(originFrontPid, &originPsn)
-                    SLSSpaceSetFrontPSN(CGS_CONNECTION, originSpaceId, originPsn)
-                }
-                DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
-                    WindowThumbnails.previewSelectedIfNeeded()
-                }
+                self?.applyFocus(generation, originSpaceId, originFrontPid)
             }
+        }
+    }
+
+    /// Focusing another app's window reliably takes the steps below. The public APIs alone don't move key
+    /// focus across apps (macOS 14 downgraded NSRunningApplication.activate to an advisory "request").
+    ///   1. _SLPSSetFrontProcessWithOptions fronts the process + the target window (passing the wid raises
+    ///      only that window, not all the app's windows). For a cross-Space target it also makes macOS switch
+    ///      to a Space showing it. The global front clobbers the front process of other Spaces where the app
+    ///      has windows (they pop on Space entry, #4507); step 4 repairs the origin Space for a cross-Space
+    ///      focus.
+    ///   2. makeKeyWindow: make it key, via a synthetic mouse-down/up aimed just outside the window, so it
+    ///      becomes key without clicking its content (a top-left click would hit fullscreen UI, #5381).
+    ///   3. raiseWindow (kAXRaiseAction): raise it within the app's own window stack. If our cached element
+    ///      went stale (the app silently rebuilt the window's a11y node, #5586), this returns
+    ///      .invalidUIElement and no-ops, so re-resolve the live element by wid, retry, and heal the cache;
+    ///      _SLPS/makeKeyWindow above use the wid/psn directly so they're unaffected.
+    ///   4. cross-Space only: restore the origin Space's front process (snapshotted by the caller).
+    ///
+    /// This queue runs 4 operations at once, and steps 0 and 3 each block for up to the 1s AX messaging
+    /// timeout, so a second alt-tab starts a second operation while this one is still inside a step. Each step
+    /// is therefore skipped once a newer focus exists, and a superseded operation that already moved the
+    /// z-order re-asserts the newer intent on its way out — see FocusIntentPolicySpecs.md.
+    private func applyFocus(_ generation: FocusGeneration, _ originSpaceId: CGSSpaceID, _ originFrontPid: pid_t?) {
+        guard FocusIntents.shared.mayProceed(generation) else { return }
+        if self.isMinimized, let element = axUiElement {
+            try? element.setAttribute(kAXMinimizedAttribute, false)
+        }
+        guard FocusIntents.shared.mayProceed(generation) else { return }
+        var psn = ProcessSerialNumber()
+        GetProcessForPID(application.pid, &psn)
+        _SLPSSetFrontProcessWithOptions(&psn, cgWindowId!, SLPSMode.userGenerated.rawValue)
+        FocusIntents.shared.noteReordered(generation)
+        makeKeyAndRaise(generation, &psn)
+        restoreOriginSpaceFront(originSpaceId, originFrontPid)
+        repairIfSuperseded(generation)
+        guard FocusIntents.shared.mayProceed(generation) else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(50)) {
+            WindowThumbnails.previewSelectedIfNeeded()
+        }
+    }
+
+    /// Steps 2 and 3. Step 3 is the only AX-dependent step: 1 and 2 use the wid and psn directly, so a window
+    /// with no element still gets fronted and made key — which is the whole point of keeping a hung app's
+    /// window trackable. The guard before the #5586 re-resolve is the one that pays: it follows a call that
+    /// may have blocked for the full 1s timeout, and the re-resolve itself costs up to 1.25s more.
+    private func makeKeyAndRaise(_ generation: FocusGeneration, _ psn: inout ProcessSerialNumber) {
+        guard FocusIntents.shared.mayProceed(generation) else { return }
+        makeKeyWindow(&psn, cgWindowId!)
+        guard FocusIntents.shared.mayProceed(generation) else { return }
+        guard axUiElement?.raiseWindow() != .success else { return }
+        guard FocusIntents.shared.mayProceed(generation), let fresh = refreshedAxElement() else { return }
+        fresh.raiseWindow()
+        DispatchQueue.main.async { [weak self] in
+            guard let self, self.axUiElement != fresh else { return }
+            self.rebindAxElement(fresh)
+            Windows.promoteVerified(self.cgWindowId ?? 0)
+        }
+    }
+
+    /// Step 4 (#4507): undo step 1's clobber of the origin Space. The front-switch made that Space remember
+    /// our app as its front; restore the app that was there before so returning shows it, not our window.
+    /// Cross-Space only (originFrontPid is nil otherwise), and skipped when the origin's front was already
+    /// this app. Owed by whoever ran step 1, so it is never skipped for being superseded.
+    private func restoreOriginSpaceFront(_ originSpaceId: CGSSpaceID, _ originFrontPid: pid_t?) {
+        guard let originFrontPid, originFrontPid != application.pid else { return }
+        var originPsn = ProcessSerialNumber()
+        GetProcessForPID(originFrontPid, &originPsn)
+        SLSSpaceSetFrontPSN(CGS_CONNECTION, originSpaceId, originPsn)
+    }
+
+    /// A z-order call is a post to another process, so it can land after a newer focus already switched and
+    /// leave the menu bar naming the new app while the old window sits on top. Re-assert the newer intent.
+    /// Steps 1 and 2 only: step 3 would need that window's AX element, and `Windows` is main-thread state,
+    /// while the wid and psn are enough to front it and make it key again. Re-name the target too, so the
+    /// activation this provokes is attributed to it rather than to a racy read (#5596).
+    private func repairIfSuperseded(_ generation: FocusGeneration) {
+        guard let intent = FocusIntents.shared.finish(generation) else { return }
+        var psn = ProcessSerialNumber()
+        GetProcessForPID(intent.pid, &psn)
+        _SLPSSetFrontProcessWithOptions(&psn, intent.wid, SLPSMode.userGenerated.rawValue)
+        makeKeyWindow(&psn, intent.wid)
+        DispatchQueue.main.async {
+            WindowServerEvents.noteAltTabInitiatedFocus(intent.wid, intent.pid)
         }
     }
 


### PR DESCRIPTION
### The bug

Alt-tabbing quickly between two apps sometimes switches the app but not the window: the menu bar names the target app, while the window the user came from stays on top. Slow switching is unaffected.

### Root cause

Focusing a window across apps takes two kinds of call, and only one of them fronts the process:

- `_SLPSSetFrontProcessWithOptions` sets the front process — the menu bar — *and* raises the target window
- `makeKeyWindow` and `kAXRaiseAction` only move a window in the global z-order

`Window.focus()` ran all of them in one operation on the shared 4-wide `accessibilityCommandsQueue` and returned without waiting, so two quick switches were two concurrent operations: they start in order and finish in any order.

The blocking budget makes the overlap easy to hit. `raiseWindow()` is a raw `AXUIElementPerformAction` against a foreign app, bounded only by the process-wide 1s AX messaging timeout, and the stale-element retry behind it (#5586) costs up to 1.25s more — against a re-switch a user performs in ~200ms.

When the older operation's z-order call landed after the newer one's front-switch, the result was exactly the reported split: menu bar on the new app, old app's window in front.

### The fix

A monotonic focus intent. Each request supersedes the earlier ones, and the operation checks before every step, so one blocked in the AX timeout stops at the next boundary instead of spending its retry budget on a target the user has left.

A z-order call is a post to another process and cannot be recalled, so bailing alone still leaves the screen wrong for an operation that already acted. Such an operation therefore re-asserts the current intent on its way out. The re-assert is bounded to a second, happens once per request, and cannot cascade.

The cross-Space origin repair (#4507) is owed by whoever ran the front-switch, so it stays gated on having done that step and never on being superseded — bailing out of it would leak the clobber it exists to undo.

### Notes on existing behaviour

- #5586 stale-element re-resolve and the element-cache heal are preserved for the current operation
- #5381 synthetic click position is untouched; the guard only decides *whether* `makeKeyWindow` runs
- #5596 attribution is re-issued on the repair path, so the activation it provokes names the right window

### Testing

New triad `FocusIntentPolicy.swift` / `FocusIntentPolicySpecs.md` / `FocusIntentPolicyTests.swift` — a pure kernel with no AX or queue involvement, covering supersession, the repair a plain guard would miss, the repair horizon, one-repair-per-intent, and no cascade.

Full suite on this branch: 1168 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AEWsxpS7HdkdguCdzQ3nT
