### PR TITLE
fix: a window may disappear after leaving fullscreen

### DIFF
--- a/src/switcher/state/TestInteractionModel.swift
+++ b/src/switcher/state/TestInteractionModel.swift
@@ -8,6 +8,7 @@ enum TestUserAction: Equatable, CustomStringConvertible {
     case openTab(window: Int)                 // window: index into created order
     case switchTab(window: Int, tab: Int)
     case enterFullscreen(window: Int)
+    case exitFullscreen(window: Int)
     case switchToSpace(window: Int)           // move to the Space `window` lives on (its own, if fullscreen)
     case minimize(window: Int)
     case restoreFromDock(window: Int)         // click its tile in the Dock
@@ -18,6 +19,7 @@ enum TestUserAction: Equatable, CustomStringConvertible {
         case .openTab(let w): return "openTab(window: \(w))"
         case .switchTab(let w, let t): return "switchTab(window: \(w), tab: \(t))"
         case .enterFullscreen(let w): return "enterFullscreen(window: \(w))"
+        case .exitFullscreen(let w): return "exitFullscreen(window: \(w))"
         case .switchToSpace(let w): return "switchToSpace(window: \(w))"
         case .minimize(let w): return "minimize(window: \(w))"
         case .restoreFromDock(let w): return "restoreFromDock(window: \(w))"
@@ -47,6 +49,10 @@ struct TestInteractionModel {
         var position: CGPoint
         var isFullscreen: Bool
         var isMinimized: Bool = false
+        /// The frame fullscreen replaced, restored on the way out. macOS puts the window back exactly where
+        /// it was, which is what makes leaving fullscreen land it in its old size cluster again.
+        var windowedSize: CGSize?
+        var windowedPosition: CGPoint?
         var space: UInt64
         var tabs: [Tab]
         var activeTab: Int
@@ -306,6 +312,7 @@ struct TestInteractionModel {
         case .openTab(let w): return openTab(window: w)
         case .switchTab(let w, let t): return switchTab(window: w, toIndex: t)
         case .enterFullscreen(let w): return enterFullscreen(window: w)
+        case .exitFullscreen(let w): return exitFullscreen(window: w)
         case .switchToSpace(let w): return switchToSpace(window: w)
         case .minimize(let w): return minimize(window: w)
         case .restoreFromDock(let w): return restoreFromDock(window: w)
@@ -478,6 +485,8 @@ struct TestInteractionModel {
     private mutating func enterFullscreen(window: Int) -> ActionEvents {
         guard let wi = index(ofWindow: window) else { return ActionEvents() }
         let space = nextSpace; nextSpace += 1
+        world[wi].windowedSize = world[wi].size
+        world[wi].windowedPosition = world[wi].position
         world[wi].isFullscreen = true
         world[wi].space = space
         world[wi].size = CGSize(width: 1440, height: 900)
@@ -493,6 +502,52 @@ struct TestInteractionModel {
                    size: CGSize(width: 1440, height: 900), isFullscreen: true, isVisible: true)])),
                .input(.spaceMembershipChanged(wid: activeWid, spaceId: space, added: true, now: tick(), inSpaceTransition: false)),
                .input(.spaceMembershipChanged(wid: activeWid, spaceId: windowedSpace, added: false, now: tick(), inSpaceTransition: false))]
+        return e
+    }
+
+    /// **Leaving fullscreen**, which is NOT the enter events played backwards. Measured live (2026-09-08,
+    /// macOS 26, Chrome; the same shape twice in one session):
+    ///
+    ///     33.845  windowOrderedIn        the window is raised as the animation starts
+    ///     33.845  1326 space=764         it drops its fullscreen Space — and is now Space-LESS
+    ///     33.895  windowMovedOrResized   its frame is ALREADY back to the windowed one
+    ///     33.896  windowOrderedOut       it goes off screen for the length of the animation
+    ///     34.361  1325 space=1           ~516ms later it joins the windowed Space
+    ///     34.396  spaceCurrentChanged    and only then does the Space itself flip
+    ///
+    /// Two properties matter and neither has an analogue in `enterFullscreen`. The window spends half a
+    /// second Space-less, ordered out, wearing its WINDOWED frame — so it is back in the size cluster of
+    /// every other window of its app while holding no Space to tell them apart. And the WindowServer
+    /// snapshot that clears `isFullscreen` is a READ, landing whenever the query answers: until it does, the
+    /// window is a fullscreen-flagged member of a windowed cluster, which is what waives tab grouping's
+    /// confirmation gate.
+    ///
+    /// The rejoin is `settlingWindow` (it straddles the next action) for the same reason `switchToSpace`'s
+    /// is: that gap is the whole point of modelling this at all.
+    private mutating func exitFullscreen(window: Int) -> ActionEvents {
+        guard let wi = index(ofWindow: window), world[wi].isFullscreen else { return ActionEvents() }
+        let fullscreenSpace = world[wi].space
+        world[wi].isFullscreen = false
+        world[wi].space = windowedSpace
+        world[wi].size = world[wi].windowedSize ?? CGSize(width: 900, height: 600)
+        world[wi].position = world[wi].windowedPosition ?? .zero
+        world[wi].tabs[world[wi].activeTab].size = world[wi].size
+        world[wi].tabs[world[wi].activeTab].position = world[wi].position
+        currentVisibleSpace = windowedSpace
+        transitioningIdentities.insert(world[wi].identity)
+        let activeWid = world[wi].activeWid
+        var e = ActionEvents()
+        e.ordered = [.setSpaces(visible: [windowedSpace], current: windowedSpace, index: (windowedSpace, 1))]
+            + appSteps(world[wi].pid)
+            + [.input(.windowFocused(wid: activeWid, now: tick())),
+               .input(.windowOrderedIn(wid: activeWid, now: tick(), inSpaceTransition: false)),
+               .input(.spaceMembershipChanged(wid: activeWid, spaceId: fullscreenSpace, added: false,
+                   now: tick(), inSpaceTransition: false)),
+               .input(.windowMovedOrResized(wid: activeWid, inSpaceTransition: false)),
+               .input(.windowOrderedOut(wid: activeWid, inSpaceTransition: false))]
+        e.readUnits = [[.input(.windowServerStateRead([WsWindowSnapshot(wid: activeWid,
+            position: world[wi].position, size: world[wi].size, isFullscreen: false, isVisible: true)]))]]
+        e.settlingWindow = world[wi].identity
         return e
     }
 

--- a/src/switcher/state/TestReducerRunner.swift
+++ b/src/switcher/state/TestReducerRunner.swift
@@ -373,9 +373,15 @@ final class TestReducerRunner {
 
     /// A Space-less, ungrouped, unheld window is hidden (phantom) — the strays the recordings kept finding
     /// shown (rec15's ghost flood arrived visible; rec20's orphan stood as a stray tile).
+    ///
+    /// ORDERED-IN windows are exempt, because `PhantomWindowDetector.syncVerdict` says so before it ever
+    /// reaches Space-lessness: "a window the WindowServer is still showing on screen is not a phantom".
+    /// Demanding otherwise here states a rule the app deliberately does not have, and the state is reachable
+    /// — a window LEAVING fullscreen is ordered back in while CGS has not yet listed it on the windowed
+    /// Space (`exitFullscreen`). A real stray is ordered OUT, which is what the recordings above caught.
     private func checkSpacelessUngroupedHidden(_ context: String) {
         for w in state.windows {
-            guard let wid = w.wid, w.spaceIds.isEmpty, !w.isWindowlessApp, !w.isMinimized,
+            guard let wid = w.wid, w.spaceIds.isEmpty, !w.isWindowlessApp, !w.isMinimized, !w.isOrderedIn,
                   state.apps[w.pid]?.state.isHidden != true,
                   state.groups.groupId(of: wid) == nil, !state.held.contains(wid) else { continue }
             if !state.isPhantom(w) {

--- a/src/switcher/state/TestReducerRunnerSpecs.md
+++ b/src/switcher/state/TestReducerRunnerSpecs.md
@@ -84,7 +84,11 @@ facts via `modelWindow(...)` wherever a capture exists.
 4. **A real on-Space window is never claimed** — tabbed ⇒ Space empty/borrowed/held; exempt while a
    creation is in flight (the sanctioned atomic claim) or the wid is a pending drag-out's outgoing
    representative (its genuine Space outlives the swap by a few ms — observed in rec19).
-5. **Space-less ungrouped unheld windows are hidden** (rec15/rec20 strays).
+5. **Space-less ungrouped unheld windows are hidden** (rec15/rec20 strays) — unless the WindowServer has
+   them ORDERED IN, which `PhantomWindowDetector.syncVerdict` already treats as decisive before it reaches
+   Space-lessness ("a window the WindowServer is still showing on screen is not a phantom"). That state is
+   reachable: a window LEAVING fullscreen is ordered back in while CGS has not yet listed it on the windowed
+   Space. A real stray is ordered OUT, which is what the recordings caught.
 6. **The representative is the most recently focused presentable member** (rec18/rec19 — focus is
    authoritative, read order is not evidence).
 

--- a/src/switcher/state/TestScenarioGenerator.swift
+++ b/src/switcher/state/TestScenarioGenerator.swift
@@ -148,6 +148,13 @@ struct TestScenarioGenerator {
                 guard canReach(w) else { return false }
                 guard w < windowCount else { break }
                 fullscreen.insert(w); onSpaceOf = w
+            // Leaving fullscreen is only reachable from inside that window's own Space, and it puts you back
+            // on the windowed one. Not generated (see `scenario`), but the hand-written scenarios use it and
+            // the shrinker walks them.
+            case .exitFullscreen(let w):
+                guard canReach(w) else { return false }
+                guard w < windowCount, fullscreen.contains(w) else { break }
+                fullscreen.remove(w); onSpaceOf = nil
             case .switchToSpace(let w):
                 guard canReach(w) else { return false }
                 guard w < windowCount else { break }

--- a/src/switcher/state/TestScenarioSimulatorSpecs.md
+++ b/src/switcher/state/TestScenarioSimulatorSpecs.md
@@ -437,8 +437,16 @@ responsible for and pointed the fix at the wrong rule. `shrink` now rejects any 
   the open lead it was built for — an occasional tile vanish-then-reappear after switching a tab in a
   NON-fullscreen window — is NOT reproduced by it. Either the shape is different, or the model still cannot
   express it. Do not close that lead on the strength of this axis being green.
-- Gestures not modeled: minimize/unminimize, drag-tab-out, window close + 804-lag timing, Space-move via
-  Mission Control, multi-monitor, hidden apps.
+- Gestures not modeled: drag-tab-out, window close + 804-lag timing, Space-move via Mission Control,
+  multi-monitor, hidden apps. (minimize/unminimize and leaving fullscreen are modelled.)
+- **A tab frozen at the fullscreen frame after its window leaves fullscreen.** `exitFullscreen` restores the
+  ACTIVE tab's frame; a background tab gets no geometry event, so it keeps the fullscreen size — which is
+  screen-sized, i.e. the size cluster of every fullscreen window on the machine. The frame invariant
+  (`checkNoGroupSpansDistinctFrames`) exempts a group with a genuinely-fullscreen MEMBER, not one whose
+  member is merely frozen at that frame, so a tabbed window's exit trips it. Seen by adding the action to the
+  generator's pool (which reshuffles every seed, so that change is not committed): shrunk to
+  `[newWindow, openTab, switchTab, enterFullscreen, switchTab, exitFullscreen, show]`. Unread: it is either
+  that exemption gap or a real staleness, and it is NOT the reporter's shape (Chrome, no tabs).
 - Non-Finder tabbing (Terminal/Safari mint wids differently).
 - Non-Finder tab lifecycles beyond the two modelled switch behaviours (Safari/Terminal differ again).
 
@@ -466,6 +474,22 @@ over the interleaving axes (ordering / handover order / late read), so one entry
   switching must not accumulate tiles or fail to settle; the per-step convergence check is what sees it.
 - **testFullscreenTabbedWindowCoexistsWithWindowedWindows** — the fullscreen group and ordinary windows of
   the same app do not bleed into each other.
+
+### B2. Leaving fullscreen (`exitFullscreen`)
+
+The inverse of `enterFullscreen`, and NOT its events played backwards. Measured live (2026-09-08, macOS 26,
+Chrome, twice in one session): the window is raised, drops its fullscreen Space, has its windowed frame back
+within 50ms, is ordered OUT for the animation, and rejoins the windowed Space ~516ms later — so it spends
+half a second Space-less, ordered out, and wearing the size cluster of every other window of its app, while
+the WindowServer snapshot that clears `isFullscreen` is still a read in flight. Modelled with the rejoin as a
+`settlingWindow` straddle, exactly like `switchToSpace`, because that gap is the point.
+
+- **testLeavingFullscreenKeepsBothWindowsOfTheApp** — two same-sized windows, one goes fullscreen and comes
+  back: two tiles throughout. The reporter's shape.
+- **testLeavingFullscreenNextToATabbedWindowKeepsBothTiles** — the same exit next to a window that really has
+  tabs, so the fold has an established group to swallow the returning window into.
+- **testRepeatedFullscreenRoundTripsKeepBothWindows** — four round trips: a fold that only survives one of
+  them still hides the window for good, since nothing re-splits an established group.
 
 ### C. Real bugs the model found and we fixed (each pinned, each fuzzed)
 - **testSupersededIncomingTabDoesNotBecomeRepresentative** — switching TO a tab arms its focus promotion;

--- a/src/switcher/state/TestScenarioSimulatorTests.swift
+++ b/src/switcher/state/TestScenarioSimulatorTests.swift
@@ -40,6 +40,35 @@ final class TestScenarioSimulatorTests: XCTestCase {
                        .enterFullscreen(window: 0), .show])
     }
 
+    /// **: leaving fullscreen with a second window of the same app open.** Both windows are the model's
+    /// default 900x600, which is the reporter's setup (two Chrome windows at one size) and the ordinary one —
+    /// windows of an app are the same size far more often than not. On the way out the fullscreen window is
+    /// Space-less, ordered out and already wearing that shared size for ~500ms, so every fact geometry keys
+    /// on says "background tab of the other window"; folding it there marks it `isTabbed` and nothing ever
+    /// re-splits an established group, so the tile does not come back.
+    func testLeavingFullscreenKeepsBothWindowsOfTheApp() {
+        assertCorrect([.newWindow(pid: 1), .newWindow(pid: 1), .enterFullscreen(window: 0), .show,
+                       .exitFullscreen(window: 0), .show])
+    }
+
+    /// The same exit with the OTHER window carrying tabs — the fold has a real group to swallow it into.
+    func testLeavingFullscreenNextToATabbedWindowKeepsBothTiles() {
+        assertCorrect([.newWindow(pid: 1), .newWindow(pid: 1), .openTab(window: 1),
+                       .enterFullscreen(window: 0), .show, .exitFullscreen(window: 0), .show])
+    }
+
+    /// Enter and leave repeatedly: a fold that only survives one round trip still hides the window for good.
+    func testRepeatedFullscreenRoundTripsKeepBothWindows() {
+        var s: TestScenario = [.newWindow(pid: 1), .newWindow(pid: 1), .show]
+        for _ in 0..<4 { s += [.enterFullscreen(window: 0), .show, .exitFullscreen(window: 0), .show] }
+        assertCorrect(s)
+    }
+
+    func testProbeSwitchAwayFromStandaloneFullscreen() {
+        assertCorrect([.newWindow(pid: 1), .newWindow(pid: 1), .enterFullscreen(window: 0), .show,
+                       .switchToSpace(window: 1), .show])
+    }
+
     // MARK: - the churn class (many switches — rec24f)
 
     func testManyWindowedTabSwitchesStayOneTile() {

--- a/src/switcher/state/WindowEventReducer.swift
+++ b/src/switcher/state/WindowEventReducer.swift
@@ -611,6 +611,34 @@ enum WindowEventReducer {
         if let i = state.windowIndex(wid) {
             state.windows[i].lastLeftSpaceId = added ? nil : spaceId
         }
+        // **A fullscreen window's Space is its own** — that is the invariant every Space-based tab decision
+        // rests on (`TabGroupResolver`). So a window still FLAGGED fullscreen that joins a Space another
+        // window is genuinely settled on has demonstrably left fullscreen, whatever its last WindowServer
+        // snapshot said: the flag is derived from the Space's type mask (`WsWindowState.isFullscreen`) and
+        // the query that refreshes it is a READ, landing whenever it answers. Leaving it standing is what
+        // made a window that just left fullscreen foldable: same app, same size, ordered out, and carrying
+        // the flag that waives tab grouping's confirmation gate, so geometry claimed it as a background tab
+        // of a same-sized neighbour and its tile never came back
+        // (`testLeavingFullscreenIsNotFoldedIntoASameSizedSibling`). Only a GENUINELY settled neighbour counts
+        // — a borrowed or held Space is our own annotation, not CGS evidence, and entering fullscreen joins a
+        // Space that is by construction empty, so that direction is untouched.
+        if added, let i = state.windowIndex(wid), state.windows[i].isFullscreen,
+           state.windows.contains(where: { other in
+               other.wid != wid && other.spaceIds == [spaceId] && !other.spaceIsBorrowed
+                   && !(other.wid.map { state.held.contains($0) } ?? false)
+                   // ...and it must belong to ANOTHER APP, which is what proves the Space is shared rather
+                   // than ours: no window of another app can be a tab of this one. Same-app neighbours prove
+                   // nothing — a fullscreen tab SWITCH has the incoming tab joining the Space its outgoing
+                   // sibling still holds, and clearing the flag there tears the group apart
+                   // (`testManyFullscreenTabSwitchesStayOneTile`). Size cannot stand in for it either: a
+                   // fullscreen window's background tabs are frozen at the pre-fullscreen size, so they
+                   // legitimately differ from their own active tab.
+                   && other.pid != window.pid
+           }) {
+            effects.append(.log("leftFullscreen #\(wid) (joined shared space=\(spaceId))"))
+            state.windows[i].isFullscreen = false
+            state.windows[i].isFullscreenMirrored = false
+        }
         // Hold a backgrounding tab visible through the new-tab discovery gap (the kernel decides; see
         // `shouldHoldVisibleThroughDiscovery`). The derived `isPhantom` keeps a held wid non-phantom, so
         // it shows its last thumbnail until the incoming tab's claim folds it in — a clean one-tile swap.

--- a/src/switcher/state/WindowEventReducerSpaceSpecs.md
+++ b/src/switcher/state/WindowEventReducerSpaceSpecs.md
@@ -87,6 +87,32 @@ reports a non-zero `spaceTypeMask` for one it places, and passes the contradicti
 - **testAPlacedWindowStillTakesItsNewSpace** — a real answer always beats the keep, so a window that genuinely
   changed Space is not frozen at its old one.
 
+### D2. Leaving fullscreen
+
+A window's `isFullscreen` is not a property of the window — it is derived from the **type mask of the Space it
+sits on** (`WsWindowState.isFullscreen`, bit `0x20`), and it is refreshed by a WindowServer query, which is a
+READ that lands whenever it answers. Leaving fullscreen therefore has a window of time in which the flag is
+stale: measured live (2026-09-08, macOS 26, Chrome), the window drops its fullscreen Space, is ordered out,
+snaps back to its windowed frame within 50ms, and only rejoins the windowed Space ~516ms later.
+
+For that half second the window is same-app, same-size, Space-less or freshly rejoined, ordered out — and
+still flagged fullscreen. Every one of those facts also describes a background TAB of another window of the
+app, and the flag is what waives tab grouping's confirmation gate (`TabGroupResolver.geometryGroups` keeps a
+cluster with a fullscreen member whole, and folds every member of a single settled Space into one window).
+So geometry claims the returning window as a tab of a same-sized neighbour, `isTabbed` drops its tile, and
+nothing re-splits an established group: the window is unreachable for the rest of the session.
+
+The Space membership event settles it, because **a fullscreen Space holds exactly one window and its tabs** —
+the invariant every Space-based tab decision already rests on. A window joining a Space that another APP's
+window genuinely sits on is therefore not on a fullscreen Space, whatever its last snapshot said. Another
+app's window is the proof that carries: a same-app neighbour proves nothing (a fullscreen tab switch has the
+incoming tab joining the Space its outgoing sibling still holds), and neither does size (a fullscreen window's
+background tabs stay frozen at the pre-fullscreen size, so they legitimately differ from their own active).
+
+- **testLeavingFullscreenIsNotFoldedIntoASameSizedSibling** — the live sequence, with a second window of the
+  app at the same size and a third window of another app on the windowed Space: the returning window is not
+  claimed as a tab and joins no group.
+
 ### E. A transition that never commits, and transitions that overlap
 
 Both shapes became reachable when the QA harness learned to synthesize a dock swipe. A commanded

--- a/src/switcher/state/WindowEventReducerSpaceTests.swift
+++ b/src/switcher/state/WindowEventReducerSpaceTests.swift
@@ -75,6 +75,47 @@ final class WindowEventReducerSpaceTests: XCTestCase {
                        + "would re-read the topology twice for nothing")
     }
 
+    // MARK: - B2. Leaving fullscreen
+
+    /// **Leaving fullscreen must not hand the window to a same-sized sibling.** Live trace (2026-09-08,
+    /// Chrome, two windows at one frame): the window drops its fullscreen Space, joins the windowed one, and
+    /// a Spaces re-query lands in the tail of the animation still naming NO Space for it — CGS lags the
+    /// rejoin. The 1326 recorded `lastLeftSpaceId`, but the 1325 that followed cleared it, so by the time the
+    /// re-query empties `spaceIds` again the one fact that says "this window came off its OWN Space" is gone.
+    /// What is left is same-app, same-size, Space-less, ordered-out and still flagged fullscreen: every fact
+    /// a background tab of the other window has, and the fullscreen clause waives the confirmation gate the
+    /// windowed path would have required. Geometry folds it in, `isTabbed` hides its tile, and nothing
+    /// re-splits an established group — the window is unreachable for the rest of the session.
+    func testLeavingFullscreenIsNotFoldedIntoASameSizedSibling() {
+        var s = state()
+        // a third window, of another app, sitting on the windowed Space — what makes that Space demonstrably
+        // SHARED, and so proves the returning window is not on a fullscreen Space any more
+        var other = window(5003, spaceId: 1, order: 2)
+        other.pid = 4712
+        other.size = CGSize(width: 700, height: 500)
+        other.isOrderedIn = true
+        s.windows.append(other)
+        s.apps[4712] = TrackedApp(
+            state: ApplicationState(pid: 4712, bundleIdentifier: "com.apple.Safari",
+                                    localizedName: "Safari", isHidden: false),
+            isActive: false)
+        s.windows[1].spaceIds = [764]
+        s.windows[1].spaceIndexes = [2]
+        s.windows[1].isFullscreen = true
+        s.windows[0].isOrderedIn = true
+        s.spaceIndexById[764] = 2
+        _ = WindowEventReducer.reduce(&s, .spaceMembershipChanged(wid: Self.widB, spaceId: 764, added: false,
+            now: 1, inSpaceTransition: false))
+        _ = WindowEventReducer.reduce(&s, .spaceMembershipChanged(wid: Self.widB, spaceId: 1, added: true,
+            now: 2, inSpaceTransition: false))
+        _ = WindowEventReducer.reduce(&s, .spacesSynced(windowToSpaces: [Self.widA: [1], Self.widB: []],
+            queried: [Self.widA, Self.widB], answered: [Self.widA, Self.widB],
+            placedByWindowServer: [], topologyChanged: false))
+        XCTAssertFalse(s.isTabbed(s.windows[1]),
+                       "a window coming out of fullscreen is not a tab of the window it happens to match in size")
+        XCTAssertNil(s.groups.groupId(of: Self.widB), "members=\(s.groups.membersByGroup) tabbedA=\(s.isTabbed(s.windows[0])) tabbedB=\(s.isTabbed(s.windows[1])) spA=\(s.windows[0].spaceIds) spB=\(s.windows[1].spaceIds)")
+    }
+
     // MARK: - C. The Spaces answer applies only to the windows it was asked about
 
     /// The pass captures its wid list on main, queries off-main, and lands later. A window discovered in that


### PR DESCRIPTION
### The bug

With a second window of the same app open at the same size, a window returning from fullscreen could be claimed as one of its tabs. Its tile then went away for good: nothing splits an established tab group again, so the window stayed unreachable from the switcher for the rest of the session.

### Root cause

A window's fullscreen flag is derived from the type mask of the Space it sits on, and it is refreshed by a WindowServer query that lands whenever it answers. While the flag is still set, the returning window looks exactly like a background tab of its neighbour — same app, same size, ordered out, no Space of its own — and that flag is what waives tab grouping's confirmation gate.

### The fix

A fullscreen Space holds exactly one window and its tabs, so a window joining a Space that another app's window genuinely sits on has left fullscreen, whatever its last snapshot said.

Two things that look like they would work, but don't:

- same-app neighbours prove nothing there — a fullscreen tab switch has the incoming tab joining the Space its outgoing sibling still holds
- size cannot stand in for it either, since a fullscreen window's background tabs stay frozen at the pre-fullscreen size

### Test coverage

The interaction model could enter fullscreen but never leave it, so every race in that transition was unreachable by the model-based suite.

Leaving is not the enter events played backwards. Measured live on macOS 26: the window drops its fullscreen Space, has its windowed frame back within 50ms, is ordered out for the length of the animation, and only rejoins the windowed Space ~516ms later. For that half second it is Space-less, ordered out, and back in the size cluster of every other window of its app, while the WindowServer snapshot that clears its fullscreen flag is still a read in flight. The rejoin is modelled as a straddling settle, like a Space switch, because that gap is the whole point.

Three scenarios pin it, each fuzzed over the interleaving axes.

The stray-window check needed the exemption the app's own phantom rule already states: a window the WindowServer shows ordered in is not a phantom, whatever its Space membership says, and a window coming back from fullscreen is briefly exactly that.

Full suite on this branch: 1164 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016AEWsxpS7HdkdguCdzQ3nT
